### PR TITLE
docs: reconcile @since tags (24.10)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanValidationBinder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanValidationBinder.java
@@ -67,6 +67,7 @@ public class BeanValidationBinder<BEAN> extends Binder<BEAN> {
      *            the bean type to use, not {@code null}
      * @param scanNestedDefinitions
      *            if {@code true}, scan for nested property definitions as well
+     * @since 2.2
      */
     public BeanValidationBinder(Class<BEAN> beanType,
             boolean scanNestedDefinitions) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -221,6 +221,7 @@ public class Binder<BEAN> implements Serializable {
          * @param asRequiredEnabled
          *            {@code false} if asRequired validator should be disabled,
          *            {@code true} otherwise (default)
+         * @since 2.2
          */
         public void setAsRequiredEnabled(boolean asRequiredEnabled);
 
@@ -232,6 +233,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * @return {@code false} if asRequired validator is disabled
          *         {@code true} otherwise (default)
+         * @since 2.2
          */
         public boolean isAsRequiredEnabled();
 
@@ -241,6 +243,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * @param validatorsDisabled
          *            A boolean value.
+         * @since 4.0
          */
         public void setValidatorsDisabled(boolean validatorsDisabled);
 
@@ -248,6 +251,7 @@ public class Binder<BEAN> implements Serializable {
          * Returns if validators are currently disabled or not.
          *
          * @return A boolean value.
+         * @since 4.0
          */
         public boolean isValidatorsDisabled();
 
@@ -264,6 +268,7 @@ public class Binder<BEAN> implements Serializable {
          *            to reset (fall back to Binder-level setting)
          * @see Binder#setDefaultValidatorsEnabled(boolean) for faster way to
          *      toggle default validators for all bound fields.
+         * @since 24.4
          */
         void setDefaultValidatorEnabled(Boolean defaultValidatorEnabled);
 
@@ -273,6 +278,7 @@ public class Binder<BEAN> implements Serializable {
          * @return {@literal true} if default validator is enabled for this
          *         binding, {@literal false} if it is disabled, {@literal null}
          *         if falls back to Binder-level setting
+         * @since 24.4
          */
         Boolean isDefaultValidatorEnabled();
 
@@ -293,6 +299,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * @param convertBackToPresentation
          *            A boolean value
+         * @since 6.0.4
          */
         void setConvertBackToPresentation(boolean convertBackToPresentation);
 
@@ -301,6 +308,7 @@ public class Binder<BEAN> implements Serializable {
          * the field when a converter is used in binding.
          *
          * @return A boolean value
+         * @since 6.0.4
          */
         boolean isConvertBackToPresentation();
 
@@ -313,6 +321,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * @return {@literal true} if the field the binding uses has uncommitted
          *         changes, otherwise {@literal false}.
+         * @since 24.3
          */
         boolean hasChanges();
 
@@ -325,6 +334,7 @@ public class Binder<BEAN> implements Serializable {
          * </p>
          *
          * @return the predicate to use for equality comparison
+         * @since 24.5
          */
         SerializableBiPredicate<TARGET, TARGET> getEqualityPredicate();
     }
@@ -440,6 +450,7 @@ public class Binder<BEAN> implements Serializable {
          * @return the newly created binding
          * @throws IllegalStateException
          *             if {@code bind} has already been called on this binding
+         * @since 9.0
          */
         Binding<BEAN, TARGET> bindReadOnly(ValueProvider<BEAN, TARGET> getter);
 
@@ -521,6 +532,7 @@ public class Binder<BEAN> implements Serializable {
          *             {@link PropertySet}
          *
          * @see BindingBuilder#bind(ValueProvider, Setter)
+         * @since 9.0
          */
         Binding<BEAN, TARGET> bindReadOnly(String propertyName);
 
@@ -872,6 +884,7 @@ public class Binder<BEAN> implements Serializable {
          * @return this binding, for chaining
          * @see Binder#setDefaultValidatorsEnabled(boolean) for faster way to
          *      toggle default validators for all bound fields.
+         * @since 24.4
          */
         BindingBuilder<BEAN, TARGET> withDefaultValidator(
                 boolean defaultValidatorEnabled);
@@ -972,6 +985,7 @@ public class Binder<BEAN> implements Serializable {
          * @param equalityPredicate
          *            the predicate to use for equality comparison
          * @return this {@code BindingBuilder}, for method chaining
+         * @since 24.5
          */
         public default BindingBuilder<BEAN, TARGET> withEqualityPredicate(
                 SerializableBiPredicate<TARGET, TARGET> equalityPredicate) {
@@ -2218,6 +2232,7 @@ public class Binder<BEAN> implements Serializable {
      *            the function to get the value of the property to the field,
      *            not null
      * @return the newly created binding
+     * @since 9.0
      */
     public <FIELDVALUE> Binding<BEAN, FIELDVALUE> bindReadOnly(
             HasValue<?, FIELDVALUE> field,
@@ -2306,6 +2321,7 @@ public class Binder<BEAN> implements Serializable {
      *             {@link PropertySet}
      *
      * @see #bind(HasValue, ValueProvider, Setter)
+     * @since 9.0
      */
     public <FIELDVALUE> Binding<BEAN, FIELDVALUE> bindReadOnly(
             HasValue<?, FIELDVALUE> field, String propertyName) {
@@ -2434,6 +2450,7 @@ public class Binder<BEAN> implements Serializable {
      *            clear bound fields
      * @throws IllegalArgumentException
      *             if the given object's type is not a record
+     * @since 24.5.3
      */
     public void readRecord(BEAN record) {
         if (!isRecord) {
@@ -2456,6 +2473,7 @@ public class Binder<BEAN> implements Serializable {
      * @see #readBean(Object)
      * @see #writeBean(Object)
      * @see #writeBeanIfValid(Object)
+     * @since 23.1
      */
     public void refreshFields() {
         readBean(bean);
@@ -2516,6 +2534,7 @@ public class Binder<BEAN> implements Serializable {
      * @throws IllegalArgumentException
      *             if bindingsToWrite contains bindings not belonging to this
      *             Binder
+     * @since 24.4
      */
     public void writeBean(BEAN bean,
             Collection<Binding<BEAN, ?>> bindingsToWrite)
@@ -2556,6 +2575,7 @@ public class Binder<BEAN> implements Serializable {
      *            {@code null}
      * @throws ValidationException
      *             if some of the bound field values fail to validate
+     * @since 24.4
      */
     public void writeChangedBindingsToBean(BEAN bean)
             throws ValidationException {
@@ -2568,6 +2588,7 @@ public class Binder<BEAN> implements Serializable {
      * @see #hasChanges()
      *
      * @return Immutable set of bindings.
+     * @since 24.4
      */
     public Set<Binding<BEAN, ?>> getChangedBindings() {
         return Collections.unmodifiableSet(changedBindings);
@@ -2585,6 +2606,7 @@ public class Binder<BEAN> implements Serializable {
      * @param bean
      *            the object to which to write the field values, not
      *            {@code null}
+     * @since 2.2
      */
     public void writeBeanAsDraft(BEAN bean) {
         doWriteDraft(bean, new ArrayList<>(bindings), false);
@@ -2605,6 +2627,7 @@ public class Binder<BEAN> implements Serializable {
      *            {@code null}
      * @param forced
      *            disable all Validators during write
+     * @since 4.0
      */
     public void writeBeanAsDraft(BEAN bean, boolean forced) {
         doWriteDraft(bean, new ArrayList<>(bindings), forced);
@@ -2657,6 +2680,7 @@ public class Binder<BEAN> implements Serializable {
      *             Binder's model type is bean
      * @throws IllegalArgumentException
      *             if record instantiation fails for any reason
+     * @since 24.5
      */
     public BEAN writeRecord() throws ValidationException {
         if (!isRecord) {
@@ -3114,6 +3138,7 @@ public class Binder<BEAN> implements Serializable {
      * @param defaultValidatorsEnabled
      *            {@literal true} to enable default validators of bound fields,
      *            {@literal false} to disable them
+     * @since 24.4
      */
     public void setDefaultValidatorsEnabled(boolean defaultValidatorsEnabled) {
         this.defaultValidatorsEnabled = defaultValidatorsEnabled;
@@ -3125,6 +3150,7 @@ public class Binder<BEAN> implements Serializable {
      *
      * @return {@literal true} if default validators of bound fields are
      *         enabled, {@literal false} if they are disabled
+     * @since 24.4
      */
     public boolean isDefaultValidatorsEnabled() {
         return defaultValidatorsEnabled;
@@ -3222,6 +3248,7 @@ public class Binder<BEAN> implements Serializable {
      * @see #handleError(HasValue, ValidationResult)
      * @see #clearError(HasValue)
      * @see DefaultBinderValidationErrorHandler
+     * @since 8.0
      */
     public BinderValidationErrorHandler getValidationErrorHandler() {
         return errorHandler;
@@ -3244,6 +3271,7 @@ public class Binder<BEAN> implements Serializable {
      *             for <code>null</code> status handler
      * @see #handleError(HasValue, ValidationResult)
      * @see #clearError(HasValue)
+     * @since 8.0
      */
     public void setValidationErrorHandler(
             BinderValidationErrorHandler handler) {
@@ -3513,6 +3541,7 @@ public class Binder<BEAN> implements Serializable {
      * @param binding
      *            Binding to be checked
      * @return true if field has been changed.
+     * @since 24.3
      */
     public boolean hasChanges(Binding<BEAN, ?> binding) {
         return hasChanges() && changedBindings.contains(binding);
@@ -3827,6 +3856,7 @@ public class Binder<BEAN> implements Serializable {
      * composing with the default one.
      *
      * @return an instance of {@link ConverterFactory}, never {@literal null}.
+     * @since 23.1
      */
     protected ConverterFactory getConverterFactory() {
         return DefaultConverterFactory.INSTANCE;
@@ -4042,6 +4072,7 @@ public class Binder<BEAN> implements Serializable {
      *
      * @param validatorsDisabled
      *            Boolean value.
+     * @since 4.0
      */
     public void setValidatorsDisabled(boolean validatorsDisabled) {
         this.validatorsDisabled = validatorsDisabled;
@@ -4052,6 +4083,7 @@ public class Binder<BEAN> implements Serializable {
      * enabled for this Binder.
      *
      * @return Boolean value
+     * @since 4.0
      */
     public boolean isValidatorsDisabled() {
         return validatorsDisabled;
@@ -4064,6 +4096,7 @@ public class Binder<BEAN> implements Serializable {
      *
      * @param fieldsValidationStatusChangeListenerEnabled
      *            Boolean value.
+     * @since 23.1.4
      */
     public void setFieldsValidationStatusChangeListenerEnabled(
             boolean fieldsValidationStatusChangeListenerEnabled) {
@@ -4076,6 +4109,7 @@ public class Binder<BEAN> implements Serializable {
      * {@code validate} upon receiving them.
      *
      * @return Boolean value
+     * @since 23.1.4
      */
     public boolean isFieldsValidationStatusChangeListenerEnabled() {
         return fieldsValidationStatusChangeListenerEnabled;
@@ -4092,6 +4126,7 @@ public class Binder<BEAN> implements Serializable {
      *
      * @param changeDetectionEnabled
      *            Boolean value
+     * @since 24.5
      */
     public void setChangeDetectionEnabled(boolean changeDetectionEnabled) {
         this.changeDetectionEnabled = changeDetectionEnabled;
@@ -4107,6 +4142,7 @@ public class Binder<BEAN> implements Serializable {
      * {@link BindingBuilder#withEqualityPredicate(SerializableBiPredicate)}.
      *
      * @return Boolean value
+     * @since 24.5
      */
     public boolean isChangeDetectionEnabled() {
         return changeDetectionEnabled;
@@ -4131,6 +4167,7 @@ public class Binder<BEAN> implements Serializable {
      *
      * @param handler
      *            the exception handler, not {@code null}
+     * @since 9.0
      */
     public void setBindingExceptionHandler(BindingExceptionHandler handler) {
         exceptionHandler = Objects.requireNonNull(handler);
@@ -4144,6 +4181,7 @@ public class Binder<BEAN> implements Serializable {
      * implementation is returned.
      *
      * @return the exception handler, not {@code null}
+     * @since 9.0
      */
     public BindingExceptionHandler getBindingExceptionHandler() {
         return exceptionHandler;

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationErrorHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationErrorHandler.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.HasValue;
  * @see DefaultBinderValidationErrorHandler
  * @see Binder#setValidationErrorHandler(BinderValidationErrorHandler)
  * @author Vaadin Ltd
- * @since
+ * @since 8.0
  *
  */
 public interface BinderValidationErrorHandler extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingException.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingException.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.data.binder.Binder.Binding;
  * validator, converter, etc. behavior.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  *
  * @see BindingExceptionHandler
  */

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingExceptionHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingExceptionHandler.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.data.binder.Binder.Binding;
  * {@link HasValue} object is the source of the exception).
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  *
  * @see BindingException
  */

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBinderValidationErrorHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBinderValidationErrorHandler.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.dom.ThemeList;
  *
  *
  * @author Vaadin Ltd
- * @since
+ * @since 8.0
  *
  */
 public class DefaultBinderValidationErrorHandler

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBindingExceptionHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBindingExceptionHandler.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
  * exception is not produced if the element has no any attribute or property.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  *
  */
 public class DefaultBindingExceptionHandler implements BindingExceptionHandler {

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemComponents.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemComponents.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.component.HasElement;
  * {@link #prependComponents(Object, Component...)}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 4.0
  *
  * @param <T>
  *            the type of the displayed items

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/HasValidator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/HasValidator.java
@@ -114,7 +114,7 @@ public interface HasValidator<V> extends Serializable {
      *
      * @see com.vaadin.flow.data.binder.Binder.BindingBuilderImpl#bind(ValueProvider,
      *      Setter)
-     * @since 23.2
+     * @since 23.1.2
      *
      * @return Registration of the added listener.
      */

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/PropertyDefinition.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/PropertyDefinition.java
@@ -53,6 +53,7 @@ public interface PropertyDefinition<T, V> extends Serializable {
      *
      * @return {@code true} if the type of this property references a generic
      *         type, {@code false} otherwise
+     * @since 24.1.1
      */
     boolean isGenericType();
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/ValidationStatusChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/ValidationStatusChangeEvent.java
@@ -17,7 +17,7 @@ import java.io.Serializable;
  * {@link ValidationStatusChangeListener#validationStatusChanged(ValidationStatusChangeEvent)}
  * invoked.
  *
- * @since 23.2
+ * @since 23.1.2
  *
  * @param <V>
  *            the value type

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/ValidationStatusChangeListener.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/ValidationStatusChangeListener.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.function.ValueProvider;
  * subscribe for each other's validation statuses and enable/disable or clear
  * values, etc. respectively.
  *
- * @since 23.2
+ * @since 23.1.2
  *
  * @see HasValidator
  * @see com.vaadin.flow.data.binder.Binder.BindingBuilderImpl#bind(ValueProvider,

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/ValueContext.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/ValueContext.java
@@ -35,6 +35,7 @@ public class ValueContext implements Serializable {
      *
      * @param binder
      *            the Binder using the value context
+     * @since 24.5
      */
     public ValueContext(Binder<?> binder) {
         this.binder = binder;
@@ -50,6 +51,7 @@ public class ValueContext implements Serializable {
      *            the Binder using the value context
      * @param locale
      *            The locale used with conversion. Can be null.
+     * @since 24.5
      */
     public ValueContext(Binder binder, Locale locale) {
         this.binder = binder;
@@ -67,6 +69,7 @@ public class ValueContext implements Serializable {
      *            The component related to current value. Can be null. If the
      *            component implements {@link HasValue}, it will be returned by
      *            {@link #getHasValue()} as well.
+     * @since 24.5
      */
     public ValueContext(Binder binder, Component component) {
         this.binder = binder;
@@ -88,6 +91,7 @@ public class ValueContext implements Serializable {
      *            The component related to current value. Can be null.
      * @param hasValue
      *            The value source related to current value. Can be null.
+     * @since 24.5
      */
     public ValueContext(Binder binder, Component component,
             HasValue<?, ?> hasValue) {
@@ -109,6 +113,7 @@ public class ValueContext implements Serializable {
      * @param hasValue
      *            The value source related to current value. Can be
      *            {@code null}.
+     * @since 24.5
      */
     public ValueContext(Binder binder, Component component,
             HasValue<?, ?> hasValue, Locale locale) {
@@ -256,6 +261,7 @@ public class ValueContext implements Serializable {
      * context.
      *
      * @return the optional of {@code Binder}
+     * @since 24.5
      */
     public Optional<Binder<?>> getBinder() {
         return Optional.ofNullable(binder);

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/BigDecimalToFloatConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/BigDecimalToFloatConverter.java
@@ -15,6 +15,8 @@ import java.math.BigDecimal;
 
 /**
  * A converter that converts from {@link BigDecimal} to {@link Float} and back.
+ *
+ * @since 24.5
  */
 public class BigDecimalToFloatConverter
         implements Converter<BigDecimal, Float> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/BigDecimalToLongConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/BigDecimalToLongConverter.java
@@ -15,6 +15,8 @@ import java.math.BigDecimal;
 
 /**
  * A converter that converts from {@link BigDecimal} to {@link Long} and back.
+ *
+ * @since 24.5
  */
 public class BigDecimalToLongConverter implements Converter<BigDecimal, Long> {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/ConverterFactory.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/ConverterFactory.java
@@ -16,7 +16,7 @@ import java.util.Optional;
  * model and a presentation type.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 23.1
  */
 public interface ConverterFactory extends Serializable {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/DefaultConverterFactory.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/DefaultConverterFactory.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.internal.ReflectTools;
  * converters defined in {@code com.vaadin.flow.data.converters} package.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 23.1
  */
 public enum DefaultConverterFactory implements ConverterFactory {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/FloatToBigDecimalConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/FloatToBigDecimalConverter.java
@@ -15,6 +15,8 @@ import java.math.BigDecimal;
 
 /**
  * A converter that converts from {@link Float} to {@link BigDecimal} and back.
+ *
+ * @since 24.5
  */
 public class FloatToBigDecimalConverter
         implements Converter<Float, BigDecimal> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/IntegerToLongConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/IntegerToLongConverter.java
@@ -13,6 +13,8 @@ import com.vaadin.flow.data.binder.ValueContext;
 
 /**
  * A converter that converts from {@link Integer} to {@link Long} and back.
+ *
+ * @since 24.5
  */
 public class IntegerToLongConverter implements Converter<Integer, Long> {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/LocalDateTimeToInstantConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/LocalDateTimeToInstantConverter.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.data.binder.ValueContext;
  * A converter that converts between <code>LocalDateTime</code> and
  * <code>Instant</code>.
  *
+ * @since 24.1
  */
 public class LocalDateTimeToInstantConverter
         implements Converter<LocalDateTime, Instant> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/LongToBigDecimalConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/LongToBigDecimalConverter.java
@@ -15,6 +15,8 @@ import java.math.BigDecimal;
 
 /**
  * A converter that converts from {@link Long} to {@link BigDecimal} and back.
+ *
+ * @since 24.5
  */
 public class LongToBigDecimalConverter implements Converter<Long, BigDecimal> {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToUuidConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToUuidConverter.java
@@ -27,6 +27,7 @@ import java.util.UUID;
  * </p>
  *
  * @author Vaadin Ltd
+ * @since 2.1
  */
 public class StringToUuidConverter implements Converter<String, UUID> {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractComponentDataGenerator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractComponentDataGenerator.java
@@ -94,6 +94,7 @@ public abstract class AbstractComponentDataGenerator<T>
      *            the updated item
      * @return the component that should represent the updated item, not
      *         <code>null</code>
+     * @since 1.2
      */
     protected Component updateComponent(Component currentComponent, T item) {
         return createComponent(item);

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.shared.Registration;
  *
  * @param <T>
  *            data type
+ * @since 4.0
  */
 public abstract class AbstractDataView<T> implements DataView<T> {
 
@@ -119,6 +120,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
      *            data provider to be verified
      * @throws IllegalStateException
      *             if data provider type is incompatible with data view type
+     * @since 24.4
      */
     protected final void verifyDataProviderType(
             DataProvider<T, ?> dataProvider) {
@@ -197,6 +199,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
      * @param listener
      *            identifier provider change listener to register
      * @return registration for removing the listener
+     * @since 23.2
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Registration addIdentifierProviderChangeListener(
@@ -224,6 +227,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
      * @param stream
      *            the stream to get index from
      * @return the index of the item in the stream, or -1 if not found
+     * @since 24.4
      */
     protected int getItemIndex(T item, Stream<T> stream) {
         Objects.requireNonNull(item, NULL_ITEM_ERROR_MESSAGE);

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.function.SerializableConsumer;
  *
  * @param <T>
  *            the type of data
+ * @since 4.0
  */
 public abstract class AbstractLazyDataView<T> extends AbstractDataView<T>
         implements LazyDataView<T> {
@@ -85,6 +86,7 @@ public abstract class AbstractLazyDataView<T> extends AbstractDataView<T>
      * @throws UnsupportedOperationException
      *             if the item index provider is not set with
      *             {@link #setItemIndexProvider(ItemIndexProvider)}
+     * @since 24.4
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -152,6 +154,7 @@ public abstract class AbstractLazyDataView<T> extends AbstractDataView<T>
      * Gets the item index provider for this data view's component.
      *
      * @return the item index provider. May be null.
+     * @since 24.4
      */
     @SuppressWarnings("unchecked")
     protected ItemIndexProvider<T, ?> getItemIndexProvider() {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.function.ValueProvider;
  *
  * @param <T>
  *            data type
+ * @since 4.0
  */
 public abstract class AbstractListDataView<T> extends AbstractDataView<T>
         implements ListDataView<T, AbstractListDataView<T>> {
@@ -53,6 +54,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
      * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the component filtering
      *            or sorting changes, not <code>null</code>
+     * @since 5.0
      */
     public AbstractListDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/BeanDataGenerator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/BeanDataGenerator.java
@@ -29,7 +29,7 @@ import elemental.json.JsonValue;
  * {@code [[item.value]]} in the template.
  *
  * @author Vaadin Ltd.
- * @since 1.2
+ * @since 1.1
  *
  * @param <T>
  *            the type of the bean to be serialized to the client

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
@@ -64,6 +64,7 @@ public class DataChangeEvent<T> extends EventObject {
          * @param refreshChildren
          *            whether, in hierarchical providers, subelements should be
          *            refreshed as well
+         * @since 2.1
          */
         public DataRefreshEvent(DataProvider<T, ?> source, T item,
                 boolean refreshChildren) {
@@ -88,6 +89,7 @@ public class DataChangeEvent<T> extends EventObject {
          *
          * @return whether, in hierarchical providers, subelements should be
          *         refreshed as well
+         * @since 2.1
          */
         public boolean isRefreshChildren() {
             return refreshChildren;
@@ -131,6 +133,7 @@ public class DataChangeEvent<T> extends EventObject {
      *
      * @throws IllegalStateException
      *             if the method is called outside of the event listener.
+     * @since 9.0
      */
     public void unregisterListener() throws IllegalStateException {
         if (unregisterListenerCommand == null) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -142,6 +142,7 @@ public class DataCommunicator<T> implements Serializable {
      *            item type
      *
      * @see AbstractDataView#AbstractDataView(SerializableSupplier, Component)
+     * @since 5.0
      */
     public static final class EmptyDataProvider<T1>
             extends ListDataProvider<T1> {
@@ -160,6 +161,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @param <F>
      *            filter's type
+     * @since 5.0
      */
     public static final class Filter<F> implements Serializable {
 
@@ -299,6 +301,7 @@ public class DataCommunicator<T> implements Serializable {
      *            if {@code fetchEnabled} is {@code true} then the data provider
      *            will be called to fetch the items and/or to get the items
      *            count until it's set to {@code false}
+     * @since 5.0
      */
     public DataCommunicator(DataGenerator<T> dataGenerator,
             ArrayUpdater arrayUpdater,
@@ -338,6 +341,7 @@ public class DataCommunicator<T> implements Serializable {
      *            the start of the viewport range
      * @param length
      *            the end of the viewport range
+     * @since 24.9
      */
     public void setViewportRange(int start, int length) {
         setRequestedRange(start, length);
@@ -354,6 +358,7 @@ public class DataCommunicator<T> implements Serializable {
      * @return
      * @deprecated since 24.9 and will be removed in Vaadin 26. Use
      *             {@link #computeViewportRange(int, int)} instead.
+     * @since 24.3.3
      */
     protected final Range computeRequestedRange(int start, int length) {
         final int maximumAllowedItems = getMaximumAllowedItems();
@@ -375,6 +380,7 @@ public class DataCommunicator<T> implements Serializable {
      *            the start of the viewport range
      * @param length
      *            the end of the viewport range
+     * @since 24.9
      */
     protected final Range computeViewportRange(int start, int length) {
         return computeRequestedRange(start, length);
@@ -391,6 +397,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @param executor
      *            The Executor used for async updates.
+     * @since 23.0
      */
     public void enablePushUpdates(Executor executor) {
         if (this.executor != null && future != null) {
@@ -481,6 +488,7 @@ public class DataCommunicator<T> implements Serializable {
      *            the filter type
      *
      * @return a consumer that accepts a new filter value to use
+     * @since 5.0
      */
     public <F> SerializableConsumer<Filter<F>> setDataProvider(
             DataProvider<T, F> dataProvider, F initialFilter,
@@ -554,6 +562,7 @@ public class DataCommunicator<T> implements Serializable {
      * fetched from the DataProvider if client data has not been sent.
      *
      * @return count of available items
+     * @since 4.0
      */
     public int getItemCount() {
         if (isDefinedSize()
@@ -576,6 +585,7 @@ public class DataCommunicator<T> implements Serializable {
      * @param item
      *            the item to check, not {@code null}
      * @return {@code true} if item is active, {@code false} if not
+     * @since 4.0
      */
     public boolean isItemActive(T item) {
         return getKeyMapper().has(item);
@@ -594,6 +604,7 @@ public class DataCommunicator<T> implements Serializable {
      * @throws IndexOutOfBoundsException
      *             requested index is outside of the filtered and sorted data
      *             set
+     * @since 4.0
      */
     @SuppressWarnings("unchecked")
     public T getItem(int index) {
@@ -647,6 +658,7 @@ public class DataCommunicator<T> implements Serializable {
      * @param limit
      *            fetched item count
      * @return {@link Query} for component state
+     * @since 4.0
      */
     public Query buildQuery(int offset, int limit) {
         return new Query(offset, limit, getBackEndSorting(),
@@ -659,6 +671,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @param pageSize
      *            the page size to set
+     * @since 4.0
      */
     public void setPageSize(int pageSize) {
         if (pageSize < 1) {
@@ -672,6 +685,7 @@ public class DataCommunicator<T> implements Serializable {
      * Returns the page size set to fetch items.
      *
      * @return the page size
+     * @since 4.0
      */
     public int getPageSize() {
         return pageSize;
@@ -683,6 +697,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @param countCallback
      *            the size callback to use
+     * @since 4.0
      */
     public void setCountCallback(
             CallbackDataProvider.CountCallback<T, ?> countCallback) {
@@ -713,6 +728,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @param itemCountEstimate
      *            the item count estimate to be used
+     * @since 4.0
      */
     public void setItemCountEstimate(int itemCountEstimate) {
         if (itemCountEstimate < 1) {
@@ -733,6 +749,7 @@ public class DataCommunicator<T> implements Serializable {
      * Gets the item count estimate used.
      *
      * @return the item count estimate used
+     * @since 4.0
      */
     public int getItemCountEstimate() {
         if (itemCountEstimate < 1) {
@@ -750,6 +767,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @param itemCountEstimateIncrease
      *            the item count estimate step to use
+     * @since 4.0
      */
     public void setItemCountEstimateIncrease(int itemCountEstimateIncrease) {
         if (itemCountEstimateIncrease < 1) {
@@ -765,6 +783,7 @@ public class DataCommunicator<T> implements Serializable {
      * Gets the item count estimate increase used.
      *
      * @return the item count estimate increase
+     * @since 4.0
      */
     public int getItemCountEstimateIncrease() {
         if (itemCountEstimateIncrease == -1) {
@@ -788,6 +807,7 @@ public class DataCommunicator<T> implements Serializable {
      * @param definedSize
      *            {@code true} for defined size, {@code false} for undefined
      *            size
+     * @since 4.0
      */
     public void setDefinedSize(boolean definedSize) {
         if (this.definedSize != definedSize) {
@@ -813,6 +833,7 @@ public class DataCommunicator<T> implements Serializable {
      * Returns whether defined or undefined size is used.
      *
      * @return {@code true} for defined size, {@code false} for undefined size
+     * @since 4.0
      */
     public boolean isDefinedSize() {
         return definedSize;
@@ -836,6 +857,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @param keyMapper
      *            the keyMapper
+     * @since 1.1
      */
     protected void setKeyMapper(DataKeyMapper<T> keyMapper) {
         this.keyMapper = keyMapper;
@@ -894,6 +916,7 @@ public class DataCommunicator<T> implements Serializable {
      *         queries
      *
      * @see #setPagingEnabled(boolean)
+     * @since 4.0
      */
     public boolean isPagingEnabled() {
         return pagingEnabled;
@@ -905,6 +928,7 @@ public class DataCommunicator<T> implements Serializable {
      * @param pagingEnabled
      *            {@code true} for paged queries, {@code false} for offset/limit
      *            queries
+     * @since 4.0
      */
     public void setPagingEnabled(boolean pagingEnabled) {
         this.pagingEnabled = pagingEnabled;
@@ -917,6 +941,7 @@ public class DataCommunicator<T> implements Serializable {
      *
      * @return {@code true} if the calls to data provider are enabled,
      *         {@code false} otherwise
+     * @since 5.0
      */
     public boolean isFetchEnabled() {
         return fetchEnabled;
@@ -936,6 +961,7 @@ public class DataCommunicator<T> implements Serializable {
      *            if {@code true} then the calls to data provider are enabled,
      *            otherwise the data provider won't be called to fetch the
      *            items.
+     * @since 5.0
      */
     public void setFetchEnabled(boolean fetchEnabled) {
         this.fetchEnabled = fetchEnabled;

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -115,6 +115,7 @@ public interface DataProvider<T, F> extends Serializable {
      *            the item to refresh
      * @param refreshChildren
      *            whether or not to refresh child items
+     * @since 2.1
      */
     default void refreshItem(T item, boolean refreshChildren) {
         refreshItem(item);

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.shared.Registration;
  *
  * @param <T>
  *            data type
- * @since
+ * @since 4.0
  */
 public interface DataView<T> extends Serializable {
 
@@ -45,6 +45,7 @@ public interface DataView<T> extends Serializable {
      * @param item
      *            item to get index for
      * @return index of the item or empty optional if the item is not found
+     * @since 24.4
      */
     Optional<Integer> getItemIndex(T item);
 
@@ -94,6 +95,8 @@ public interface DataView<T> extends Serializable {
 
     /**
      * Notifies the component that all the items should be refreshed.
+     *
+     * @since 5.0.2
      */
     void refreshAll();
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataViewUtils.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataViewUtils.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.function.SerializablePredicate;
  * simplify the filtering and sorting handling, but not limited to it.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 5.0
  */
 public final class DataViewUtils {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasDataView.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
  *            filter type
  * @param <V>
  *            DataView type
- * @since
+ * @since 4.0
  */
 public interface HasDataView<T, F, V extends DataView<T>> extends Serializable {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
@@ -21,7 +21,7 @@ import java.util.Collection;
  *            filter type
  * @param <V>
  *            DataView type
- * @since
+ * @since 4.0
  */
 public interface HasLazyDataView<T, F, V extends LazyDataView<T>>
         extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasListDataView.java
@@ -20,7 +20,7 @@ import java.util.Collection;
  *            item type
  * @param <V>
  *            DataView type
- * @since
+ * @since 4.0
  */
 public interface HasListDataView<T, V extends ListDataView<T, ?>>
         extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProvider.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.function.ValueProvider;
  *
  * @param <T>
  *            the type of the item
- * @since
+ * @since 4.0
  */
 @FunctionalInterface
 public interface IdentifierProvider<T> extends ValueProvider<T, Object> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProviderChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProviderChangeEvent.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.ComponentEvent;
  *            the type of item used by the identifier provider
  * @param <C>
  *            the event source type
+ * @since 23.2
  */
 public class IdentifierProviderChangeEvent<T, C extends Component>
         extends ComponentEvent<C> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.component.ComponentEvent;
  *
  * @param <T>
  *            the event source type
- * @since
+ * @since 4.0
  */
 public class ItemCountChangeEvent<T extends Component>
         extends ComponentEvent<T> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeListener.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeListener.java
@@ -30,7 +30,7 @@ import java.io.Serializable;
  * }
  * </pre>
  *
- * @since
+ * @since 4.0
  */
 @FunctionalInterface
 public interface ItemCountChangeListener extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
@@ -13,7 +13,7 @@ package com.vaadin.flow.data.provider;
  *
  * @param <T>
  *            data type
- * @since
+ * @since 4.0
  */
 public interface LazyDataView<T> extends DataView<T> {
 
@@ -106,6 +106,7 @@ public interface LazyDataView<T> extends DataView<T> {
      *
      * @param itemIndexProvider
      *            the item index provider to use
+     * @since 24.4
      */
     void setItemIndexProvider(ItemIndexProvider<T, ?> itemIndexProvider);
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.function.ValueProvider;
  *            data type
  * @param <V>
  *            ListDataView type
- * @since
+ * @since 4.0
  */
 public interface ListDataView<T, V extends ListDataView<T, ?>>
         extends DataView<T> {
@@ -292,6 +292,7 @@ public interface ListDataView<T, V extends ListDataView<T, ?>>
      * @see #addItems(Collection)
      * @see #addItemsBefore(Collection, Object)
      * @see #addItemsAfter(Collection, Object)
+     * @since 24.9
      */
     V setItems(Collection<T> items);
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
@@ -119,6 +119,7 @@ public class Query<T, F> implements Serializable {
      * until it is. Updates the page size value if it has been raised.
      *
      * @return the zero-based page index
+     * @since 4.0
      */
     public int getPage() {
         int pageSize = getPageSize();
@@ -154,6 +155,7 @@ public class Query<T, F> implements Serializable {
      * item.
      *
      * @return the page size used for data access
+     * @since 4.0
      */
     public int getPageSize() {
         if (pageSize != null) {
@@ -225,6 +227,7 @@ public class Query<T, F> implements Serializable {
      * {@code getOffset() + getLimit()} where the end is exclusive.
      *
      * @return the requested range end
+     * @since 4.0
      */
     public int getRequestedRangeEnd() {
         return getOffset() + getLimit();

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/SortDirection.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/SortDirection.java
@@ -40,6 +40,7 @@ public enum SortDirection {
      *
      * @return The shortened representation of the sort direction, either "asc"
      *         or "desc"
+     * @since 24.9
      */
     public String getShortName() {
         return ASCENDING.equals(this) ? "asc" : "desc";

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/AbstractBackEndHierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/AbstractBackEndHierarchicalDataProvider.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.data.provider.SortOrder;
  *            data type
  * @param <F>
  *            filter type
- * @since 1.2
+ * @since 1.1
  */
 public abstract class AbstractBackEndHierarchicalDataProvider<T, F>
         extends AbstractHierarchicalDataProvider<T, F>

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/AbstractHierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/AbstractHierarchicalDataProvider.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.function.SerializableFunction;
  *            data type
  * @param <F>
  *            filter type
- * @since 1.2
+ * @since 1.1
  */
 public abstract class AbstractHierarchicalDataProvider<T, F> extends
         AbstractDataProvider<T, F> implements HierarchicalDataProvider<T, F> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/BackEndHierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/BackEndHierarchicalDataProvider.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.data.provider.BackEndDataProvider;
  *            data provider data type
  * @param <F>
  *            data provider filter type
- * @since 1.2
+ * @since 1.1
  */
 public interface BackEndHierarchicalDataProvider<T, F>
         extends HierarchicalDataProvider<T, F>, BackEndDataProvider<T, F> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProvider.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.function.ValueProvider;
  *
  * @param <T>
  *            the item data type
- * @since 1.2
+ * @since 1.1
  */
 public interface HasHierarchicalDataProvider<T> extends Serializable {
 
@@ -152,6 +152,7 @@ public interface HasHierarchicalDataProvider<T> extends Serializable {
      *
      * @param hierarchicalDataProvider
      *            the hierarchical data provider to use, not {@code null}
+     * @since 4.0
      */
     void setDataProvider(
             HierarchicalDataProvider<T, ?> hierarchicalDataProvider);

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
@@ -36,7 +36,7 @@ import elemental.json.JsonValue;
  *
  * @param <T>
  *            the target bean type
- * @since 1.2
+ * @since 1.1
  * @deprecated since 24.9 and will be removed in Vaadin 25.
  */
 @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalConfigurableFilterDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalConfigurableFilterDataProvider.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
  * that will be applied to all queries.
  *
  * @author Vaadin Ltd
- * @since 1.0
+ * @since 1.3
  *
  * @param <T>
  *            the data provider item type

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -51,7 +51,7 @@ import elemental.json.JsonValue;
  * @param <T>
  *            the bean type
  * @author Vaadin Ltd
- * @since 1.2
+ * @since 1.1
  */
 public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
@@ -601,6 +601,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
      *             HierarchicalDataCommunicator will be <a href=
      *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
      *             to handle hierarchy management entirely on the server side.
+     * @since 23.2.8
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)
@@ -629,6 +630,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
      *             HierarchicalDataCommunicator will be <a href=
      *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
      *             to handle hierarchy management entirely on the server side.
+     * @since 24.5
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)
@@ -684,6 +686,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     /**
      * Estimates are not supported in HierarchicalDataCommunicator
+     *
+     * @since 24.5
      */
     @Override
     public void setItemCountEstimate(int itemCountEstimate) {
@@ -693,6 +697,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     /**
      * Estimates are not supported in HierarchicalDataCommunicator
+     *
+     * @since 24.5
      */
     @Override
     public int getItemCountEstimate() {
@@ -702,6 +708,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     /**
      * Estimates are not supported in HierarchicalDataCommunicator
+     *
+     * @since 24.5
      */
     @Override
     public void setItemCountEstimateIncrease(int itemCountEstimateIncrease) {
@@ -711,6 +719,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     /**
      * Estimates are not supported in HierarchicalDataCommunicator
+     *
+     * @since 24.5
      */
     @Override
     public int getItemCountEstimateIncrease() {
@@ -720,6 +730,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     /**
      * Estimates are not supported in HierarchicalDataCommunicator
+     *
+     * @since 24.5
      */
     @Override
     public void setDefinedSize(boolean definedSize) {
@@ -730,6 +742,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
     /**
      * Estimates are not supported in HierarchicalDataCommunicator. Therefore
      * this method will always return {@literal true}
+     *
+     * @since 24.5
      */
     @Override
     public boolean isDefinedSize() {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataProvider.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.function.SerializableFunction;
  *            data type
  * @param <F>
  *            filter type
- * @since 1.2
+ * @since 1.1
  */
 public interface HierarchicalDataProvider<T, F> extends DataProvider<T, F> {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalQuery.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalQuery.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.data.provider.QuerySortOrder;
  *            bean type
  * @param <F>
  *            filter type
- * @since 1.2
+ * @since 1.1
  */
 public class HierarchicalQuery<T, F> extends Query<T, F> {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
@@ -43,7 +43,7 @@ import com.vaadin.flow.internal.Range;
  *            the data type
  * @param <F>
  *            the filter type
- * @since 1.2
+ * @since 1.1
  * @deprecated since 24.9 and will be removed in Vaadin 25 where
  *             HierarchicalDataCommunicator will be <a href=
  *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
@@ -634,6 +634,7 @@ public class HierarchyMapper<T, F> implements Serializable {
      *
      * @return an unmodifiable {@code Collection<T>} containing the expanded
      *         items.
+     * @since 5.0
      */
     public Collection<T> getExpandedItems() {
         return Collections.unmodifiableCollection(expandedItems.values());

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.function.ValueProvider;
  * Typically used as a backing data source for {@link TreeDataProvider}.
  *
  * @author Vaadin Ltd
- * @since 1.2
+ * @since 1.1
  *
  * @param <T>
  *            data type

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.function.SerializablePredicate;
  * data. Uses an instance of {@link TreeData} as its source of data.
  *
  * @author Vaadin Ltd
- * @since 1.2
+ * @since 1.1
  *
  * @param <T>
  *            data type

--- a/flow-data/src/main/java/com/vaadin/flow/data/selection/MultiSelect.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/selection/MultiSelect.java
@@ -89,6 +89,7 @@ public interface MultiSelect<C extends Component, T> extends
      *
      * @param items
      *            to add to selection, not {@code null}
+     * @since 1.2
      */
     default void select(Iterable<T> items) {
         Objects.requireNonNull(items);
@@ -115,6 +116,7 @@ public interface MultiSelect<C extends Component, T> extends
      *
      * @param items
      *            to remove from selection, not {@code null}
+     * @since 1.2
      */
     default void deselect(Iterable<T> items) {
         Objects.requireNonNull(items);

--- a/flow-data/src/main/java/com/vaadin/flow/data/validator/EmailValidator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/validator/EmailValidator.java
@@ -52,6 +52,7 @@ public class EmailValidator extends RegexpValidator {
      * @param allowEmpty
      *            if {@code true} then an empty string passes the validation,
      *            otherwise the validation fails
+     * @since 4.0
      */
     public EmailValidator(String errorMessage, boolean allowEmpty) {
         super(errorMessage, PATTERN, true);

--- a/flow-data/src/main/java/com/vaadin/flow/data/value/HasValueChangeMode.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/value/HasValueChangeMode.java
@@ -31,6 +31,8 @@ public interface HasValueChangeMode extends Serializable {
 
     /**
      * Default value change timeout for textual inputs in milliseconds.
+     *
+     * @since 2.0
      */
     int DEFAULT_CHANGE_TIMEOUT = 400;
 
@@ -65,6 +67,7 @@ public interface HasValueChangeMode extends Serializable {
      * @throws UnsupportedOperationException
      *             if neither {@link ValueChangeMode#LAZY}, nor
      *             {@link ValueChangeMode#TIMEOUT} is supported
+     * @since 2.0
      */
     default void setValueChangeTimeout(int valueChangeTimeout) {
         throw new UnsupportedOperationException();
@@ -80,6 +83,7 @@ public interface HasValueChangeMode extends Serializable {
      * @throws UnsupportedOperationException
      *             if neither {@link ValueChangeMode#LAZY}, nor
      *             {@link ValueChangeMode#TIMEOUT} is supported
+     * @since 2.0
      */
     default int getValueChangeTimeout() {
         throw new UnsupportedOperationException();

--- a/flow-data/src/main/java/com/vaadin/flow/data/value/ValueChangeMode.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/value/ValueChangeMode.java
@@ -32,12 +32,16 @@ public enum ValueChangeMode {
      * <p>
      * The recommended default timeout for input fields is
      * {@link HasValueChangeMode#DEFAULT_CHANGE_TIMEOUT}.
+     *
+     * @since 2.0
      */
     LAZY,
 
     /**
      * Syncs the value at defined intervals as long as the value changes from
      * one event to the next.
+     *
+     * @since 2.0
      */
     TIMEOUT,
 
@@ -114,6 +118,7 @@ public enum ValueChangeMode {
      *            {@link #EAGER}
      * @param registration
      *            The registration of the DOM event listener that synchronizes.
+     * @since 2.0
      */
     public static void applyChangeTimeout(ValueChangeMode mode, int timeout,
             DomListenerRegistration registration) {

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
@@ -313,6 +313,7 @@ public interface DragSource<T extends Component> extends HasElement {
      *      MDN web docs</a> for more information.
      * @param dragImage
      *            the image to be used as drag image or null to remove it
+     * @since 24.6
      */
     default void setDragImage(Component dragImage) {
         setDragImage(dragImage, 0, 0);
@@ -338,6 +339,7 @@ public interface DragSource<T extends Component> extends HasElement {
      *            the x-offset of the drag image
      * @param offsetY
      *            the y-offset of the drag image
+     * @since 24.6
      */
     default void setDragImage(Component dragImage, int offsetX, int offsetY) {
         if (dragImage != null && !dragImage.isVisible()) {
@@ -398,6 +400,7 @@ public interface DragSource<T extends Component> extends HasElement {
      * next drag start event in the browser.
      *
      * @return Server side drag image if set, otherwise {@literal null}.
+     * @since 24.6
      */
     default Component getDragImage() {
         return (Component) ComponentUtil.getData(getDragSourceComponent(),

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/internal/DndUtil.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/internal/DndUtil.java
@@ -46,6 +46,8 @@ public class DndUtil {
     /**
      * Key for storing server side drag image for a
      * {@link com.vaadin.flow.component.dnd.DragSource}.
+     *
+     * @since 24.6
      */
     public static final String DRAG_SOURCE_IMAGE = "drag-source-image";
 
@@ -89,6 +91,7 @@ public class DndUtil {
      *            the drag source to update active status on
      * @param <T>
      *            the type of the drag source component
+     * @since 2.1
      */
     public static <T extends Component> void updateDragSourceActivation(
             DragSource<T> dragSource) {
@@ -108,6 +111,7 @@ public class DndUtil {
      *            the drop target to update active status on
      * @param <T>
      *            the type of the drop target component
+     * @since 2.1
      */
     public static <T extends Component> void updateDropTargetActivation(
             DropTarget<T> dropTarget) {
@@ -137,6 +141,8 @@ public class DndUtil {
 
     /**
      * Reports DnD feature usage from mixin interfaces.
+     *
+     * @since 2.1
      */
     public static void reportUsage() {
         UsageStatistics.markAsUsed("flow/generic-dnd", null);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -81,6 +81,7 @@ public class Anchor extends HtmlContainer
      *            the text content to set
      * @param target
      *            the target window, tab or frame
+     * @since 8.0
      */
     public Anchor(String href, String text, AnchorTarget target) {
         setHref(href);
@@ -125,6 +126,7 @@ public class Anchor extends HtmlContainer
      *            the callback that handles data download, not null
      * @param text
      *            the text content to set
+     * @since 24.8
      */
     public Anchor(DownloadHandler downloadHandler, String text) {
         AttachmentType att = downloadHandler instanceof AbstractDownloadHandler
@@ -156,6 +158,7 @@ public class Anchor extends HtmlContainer
      *            {@code null} will set type to {@link AttachmentType#DOWNLOAD}
      * @param text
      *            the text content to set
+     * @since 24.8
      */
     public Anchor(DownloadHandler downloadHandler,
             AttachmentType attachmentType, String text) {
@@ -176,6 +179,7 @@ public class Anchor extends HtmlContainer
      *            the href to set
      * @param components
      *            the components to add
+     * @since 1.3
      */
     public Anchor(String href, Component... components) {
         setHref(href);
@@ -210,6 +214,7 @@ public class Anchor extends HtmlContainer
      *
      * @see Anchor#setHref(String)
      *
+     * @since 1.2
      */
     public void removeHref() {
         getElement().removeAttribute("href");
@@ -241,6 +246,7 @@ public class Anchor extends HtmlContainer
      *
      * @param downloadHandler
      *            the callback that handles data download, not null
+     * @since 24.8
      */
     public void setHref(DownloadHandler downloadHandler) {
         setHref(downloadHandler, getLinkMode(downloadHandler));
@@ -274,6 +280,7 @@ public class Anchor extends HtmlContainer
      *            set the correct attribute for anchor according to given mode,
      *            {@code null} will set the type to
      *            {@link AttachmentType#DOWNLOAD}
+     * @since 24.8
      */
     public void setHref(DownloadHandler downloadHandler,
             AttachmentType attachmentType) {
@@ -296,6 +303,7 @@ public class Anchor extends HtmlContainer
      * @param download
      *            {@code true} to add the 'download' attribute and {@code false}
      *            to remove it
+     * @since 24.8
      */
     public void setDownload(boolean download) {
         if (download) {
@@ -309,6 +317,7 @@ public class Anchor extends HtmlContainer
      * Check if the anchor target will be downloaded for a click.
      *
      * @return {@code true} if download is set for this anchor
+     * @since 24.8
      */
     public boolean isDownload() {
         return getElement().hasAttribute("download");
@@ -323,6 +332,7 @@ public class Anchor extends HtmlContainer
      * @param ignore
      *            true if this link should not be intercepted by the single-page
      *            web application routing mechanism in Vaadin.
+     * @since 24.3
      */
     public void setRouterIgnore(boolean ignore) {
         getElement().setAttribute(ROUTER_IGNORE_ATTRIBUTE, ignore);
@@ -331,6 +341,7 @@ public class Anchor extends HtmlContainer
     /**
      * @return true if this anchor should be ignored by the Vaadin router and
      *         behave normally.
+     * @since 24.3
      */
     public boolean isRouterIgnore() {
         return getElement().hasAttribute(ROUTER_IGNORE_ATTRIBUTE);
@@ -428,6 +439,7 @@ public class Anchor extends HtmlContainer
      *
      * @param target
      *            the target value, not null
+     * @since 8.0
      */
     public void setTarget(AnchorTargetValue target) {
         Objects.requireNonNull(target, "target cannot be null.");
@@ -442,6 +454,7 @@ public class Anchor extends HtmlContainer
      *
      * @return the target window value , or {@link AnchorTarget#DEFAULT} if no
      *         target has been set
+     * @since 8.0
      */
     public AnchorTargetValue getTargetValue() {
         Optional<String> target = getTarget();

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTarget.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTarget.java
@@ -13,7 +13,7 @@ package com.vaadin.flow.component.html;
  * <code>&lt;a&gt;</code> element.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 8.0
  */
 public enum AnchorTarget implements AnchorTargetValue {
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTargetValue.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTargetValue.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
  * element.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 8.0
  *
  * @see AnchorTarget
  *

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AttachmentType.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AttachmentType.java
@@ -14,6 +14,8 @@ package com.vaadin.flow.component.html;
  * </p>
  * {@link #DOWNLOAD} will set the download attribute to Anchor, where as
  * {@link #INLINE} will remove it.
+ *
+ * @since 24.8
  */
 public enum AttachmentType {
     DOWNLOAD, INLINE

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Code.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Code.java
@@ -16,7 +16,7 @@ import com.vaadin.flow.component.Tag;
  * Component representing a <code>&lt;code&gt;</code> element.
  *
  * @author Vaadin Ltd
- * @since 25.0
+ * @since 24.9
  */
 @Tag(Tag.CODE)
 public class Code extends HtmlContainer {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/DescriptionList.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/DescriptionList.java
@@ -30,7 +30,6 @@ public class DescriptionList extends HtmlContainer
      * Component representing a <code>&lt;dt&gt;</code> element.
      *
      * @author Vaadin Ltd
-     * @since 1.0
      */
     @Tag(Tag.DT)
     public static class Term extends HtmlContainer
@@ -69,7 +68,6 @@ public class DescriptionList extends HtmlContainer
      * Component representing a <code>&lt;dd&gt;</code> element.
      *
      * @author Vaadin Ltd
-     * @since 1.0
      */
     @Tag(Tag.DD)
     public static class Description extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Div.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Div.java
@@ -46,6 +46,7 @@ public class Div extends HtmlContainer
      *
      * @param text
      *            the text
+     * @since 24.3
      */
     public Div(String text) {
         setText(text);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -18,6 +18,8 @@ import com.vaadin.flow.component.*;
  * Represents an HTML <code>&lt;fieldset&gt;</code> element. This component is
  * used to group several UI components within a form, enhancing form
  * accessibility and organization.
+ *
+ * @since 24.5
  */
 @Tag("fieldset")
 public class FieldSet extends HtmlContainer implements HasAriaLabel {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.server.StreamResourceRegistry;
  * Component representing a <code>&lt;object&gt;</code> element.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  *
  */
 @Tag(Tag.OBJECT)
@@ -149,6 +149,7 @@ public class HtmlObject extends HtmlContainer implements
      *            the callback for providing resource data, not null
      * @param type
      *            a type attribute value
+     * @since 24.8
      */
     public HtmlObject(DownloadHandler data, String type) {
         setData(data);
@@ -175,6 +176,7 @@ public class HtmlObject extends HtmlContainer implements
      *            a type attribute value
      * @param params
      *            parameter components
+     * @since 24.8
      */
     public HtmlObject(DownloadHandler data, String type, Param... params) {
         setData(data);
@@ -201,6 +203,7 @@ public class HtmlObject extends HtmlContainer implements
      *            component
      * @param params
      *            parameter components
+     * @since 24.8
      */
     public HtmlObject(DownloadHandler data, Param... params) {
         setData(data);
@@ -224,6 +227,7 @@ public class HtmlObject extends HtmlContainer implements
      * @param data
      *            a handler that defines the data to be set to this object
      *            component
+     * @since 24.8
      */
     public HtmlObject(DownloadHandler data) {
         setData(data);
@@ -314,6 +318,7 @@ public class HtmlObject extends HtmlContainer implements
      *
      * @param data
      *            a "data" attribute value, not {@code null}
+     * @since 24.8
      */
     public void setData(DownloadHandler data) {
         if (data instanceof AbstractDownloadHandler<?> handler) {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -142,6 +142,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * @param downloadHandler
      *            the download handler callback that provides a resource from
      *            server, not null
+     * @since 24.8
      */
     public IFrame(DownloadHandler downloadHandler) {
         setSrc(downloadHandler);
@@ -168,6 +169,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * @param src
      *            the resource value, not null
      * @deprecated use {@link #setSrc(DownloadHandler)} instead
+     * @since 24.7
      */
     @Deprecated(since = "24.8", forRemoval = true)
     public void setSrc(AbstractStreamResource src) {
@@ -193,6 +195,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *
      * @param downloadHandler
      *            the download handler resource, not null
+     * @since 24.8
      */
     public void setSrc(DownloadHandler downloadHandler) {
         if (downloadHandler instanceof AbstractDownloadHandler<?> handler) {
@@ -337,6 +340,8 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
 
     /**
      * Reloads the IFrame.
+     *
+     * @since 3.0
      */
     public void reload() {
         getElement().executeJs("this.src = this.src");

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -103,6 +103,7 @@ public class Image extends HtmlContainer
      *
      * @see #setSrc(DownloadHandler)
      * @see #setAlt(String)
+     * @since 24.8
      */
     public Image(DownloadHandler downloadHandler, String alt) {
         setSrc(downloadHandler);
@@ -157,6 +158,7 @@ public class Image extends HtmlContainer
      *
      * @param downloadHandler
      *            the download handler resource, not null
+     * @since 24.8
      */
     public void setSrc(DownloadHandler downloadHandler) {
         if (downloadHandler instanceof AbstractDownloadHandler<?> handler) {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Input.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Input.java
@@ -55,6 +55,7 @@ public class Input extends AbstractSinglePropertyField<Input, String>
      * @param valueChangeMode
      *            initial value change mode, or <code>null</code> to disable the
      *            value synchronization
+     * @since 2.0
      */
     public Input(ValueChangeMode valueChangeMode) {
         super("value", "", false);
@@ -115,6 +116,8 @@ public class Input extends AbstractSinglePropertyField<Input, String>
      * {@inheritDoc}
      * <p>
      * The default value is {@link HasValueChangeMode#DEFAULT_CHANGE_TIMEOUT}.
+     *
+     * @since 2.0
      */
     @Override
     public int getValueChangeTimeout() {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.shared.Registration;
  * Component representing a <code>&lt;details&gt;</code> element.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  */
 @Tag(Tag.DETAILS)
 public class NativeDetails extends HtmlComponent

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Component representing a <code>&lt;table&gt;</code> element.
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.TABLE)
 public class NativeTable extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableBody.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableBody.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Component representing a <code>&lt;tbody&gt;</code> element.
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.TBODY)
 public class NativeTableBody extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableCaption.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableCaption.java
@@ -16,7 +16,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Represents the table caption element ({@code <caption>}).
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.CAPTION)
 public class NativeTableCaption extends HtmlContainer {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableCell.java
@@ -16,7 +16,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Component representing a <code>&lt;td&gt;</code> element.
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.TD)
 public class NativeTableCell extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableFooter.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableFooter.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Component representing a <code>&lt;tfoot&gt;</code> element.
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.TFOOT)
 public class NativeTableFooter extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeader.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeader.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Component representing a <code>&lt;thead&gt;</code> element.
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.THEAD)
 public class NativeTableHeader extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeaderCell.java
@@ -16,7 +16,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Component representing a <code>&lt;th&gt;</code> element.
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.TH)
 public class NativeTableHeaderCell extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.component.Tag;
 /**
  * Component representing a <code>&lt;tr&gt;</code> element.
  *
- * @since 24.4
+ * @since 24.5
  */
 @Tag(Tag.TR)
 public class NativeTableRow extends HtmlContainer

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Param.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Param.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.component.Tag;
  * @see HtmlObject
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  *
  */
 @Tag(Tag.PARAM)

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Pre.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Pre.java
@@ -17,6 +17,7 @@ import com.vaadin.flow.component.Tag;
  * Component representing a <code>&lt;pre&gt;</code> element.
  *
  * @author Vaadin Ltd
+ * @since 2.1
  */
 @Tag(Tag.PRE)
 public class Pre extends HtmlContainer implements ClickNotifier<Pre> {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
@@ -28,6 +28,8 @@ import java.util.Objects;
  * </p>
  * Note: Slider doesn't support the read-only mode and will disable itself
  * instead.
+ *
+ * @since 24.3
  */
 @Tag(Tag.INPUT)
 public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/AbstractTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/AbstractTemplate.java
@@ -123,6 +123,7 @@ public abstract class AbstractTemplate<M extends TemplateModel>
      * @param type
      *            Class to check support for
      * @return True if supported by this PolymerTemplate
+     * @since 2.0
      */
     public boolean isSupportedClass(Class<?> type) {
         List<ModelType> modelTypes = ModelDescriptor.get(getModelType())
@@ -164,6 +165,7 @@ public abstract class AbstractTemplate<M extends TemplateModel>
      * @param type
      *            Type to get the ModelType for
      * @return ModelType for given Type
+     * @since 2.0
      */
     public ModelType getModelType(Type type) {
         List<ModelType> modelTypes = ModelDescriptor.get(getModelType())

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
@@ -33,6 +33,7 @@ public class IdMapper
      *
      * @param template
      *            a template instance
+     * @since 4.0
      */
     public IdMapper(Component template) {
         super(template);

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 5.0
  * @deprecated {@code InjectableLitElementInitializer} should be used for Lit
  *             templates since polymer support is deprecated, we recommend you
  *             to use {@code LitTemplate} instead. Read more details from

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -71,6 +71,8 @@ public class NpmTemplateParser implements TemplateParser {
      * The default constructor. Protected in order to prevent direct
      * instantiation, but not private in order to allow mocking/overrides for
      * testing purposes.
+     *
+     * @since 2.2
      */
     protected NpmTemplateParser() {
     }
@@ -175,6 +177,7 @@ public class NpmTemplateParser implements TemplateParser {
      *            {@code @vaadin/vaadin-button.js}.
      * @return the .js source which declares given custom element, or null if no
      *         such source can be found.
+     * @since 6.0
      */
     protected String getSourcesFromTemplate(VaadinService service, String tag,
             String url) {

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
@@ -44,7 +44,7 @@ import elemental.json.JsonArray;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since 1.0
+ * @since 2.0
  * @deprecated Use {@code LitTemplateDataAnalyzer} for {@code LitTemplate}
  *             components. Polymer template support is deprecated - we recommend
  *             you to use {@code LitTemplate} instead. Read more details from
@@ -75,7 +75,6 @@ public class TemplateDataAnalyzer {
      * Three argument consumer.
      *
      * @author Vaadin Ltd
-     * @since 1.0
      *
      */
     @FunctionalInterface
@@ -103,6 +102,8 @@ public class TemplateDataAnalyzer {
      * Immutable parser data which may be stored in cache.
      *
      * Use {@link ParserData} instead.
+     *
+     * @since 5.0
      */
     @Deprecated
     public static class PolymerParserData extends ParserData {

--- a/flow-react/src/main/java/com/vaadin/flow/component/react/ReactAdapterComponent.java
+++ b/flow-react/src/main/java/com/vaadin/flow/component/react/ReactAdapterComponent.java
@@ -168,6 +168,7 @@ public abstract class ReactAdapterComponent extends Component {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.8
      */
     protected static <T> T readFromJson(JsonNode jsonValue,
             Class<T> typeClass) {
@@ -202,6 +203,7 @@ public abstract class ReactAdapterComponent extends Component {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.8
      */
     protected static <T> T readFromJson(JsonNode jsonValue,
             TypeReference<T> typeReference) {
@@ -227,6 +229,7 @@ public abstract class ReactAdapterComponent extends Component {
      * @param object
      *            Java object to convert
      * @return converted JSON value
+     * @since 24.8
      */
     protected static BaseJsonNode writeToJson(Object object) {
         return JacksonUtils.writeValue(object);
@@ -239,6 +242,7 @@ public abstract class ReactAdapterComponent extends Component {
      * @param name
      *            the name attribute for the container element
      * @return Element for the Flow container under ReactAdapter element
+     * @since 24.5
      */
     protected Element getContentElement(String name) {
         if (contentMap == null) {

--- a/flow-react/src/main/java/com/vaadin/flow/component/react/ReactRouterOutlet.java
+++ b/flow-react/src/main/java/com/vaadin/flow/component/react/ReactRouterOutlet.java
@@ -14,6 +14,8 @@ import com.vaadin.flow.component.dependency.JsModule;
 /**
  * Component used to create a React {@code Outlet} element for binding a Hilla
  * React view inside a Flow view.
+ *
+ * @since 24.5
  */
 @Tag("react-router-outlet")
 @JsModule("./ReactRouterOutletElement.tsx")

--- a/flow-server/src/main/java/com/vaadin/experimental/DisabledFeatureException.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/DisabledFeatureException.java
@@ -18,6 +18,8 @@ package com.vaadin.experimental;
  * functionality.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.8
  */
 public class DisabledFeatureException extends RuntimeException {
 

--- a/flow-server/src/main/java/com/vaadin/experimental/Feature.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/Feature.java
@@ -15,6 +15,8 @@ import com.vaadin.flow.internal.UsageStatistics;
 
 /**
  * Information about a feature available behind a flag.
+ *
+ * @since 9.0
  */
 public final class Feature implements Serializable {
 
@@ -39,6 +41,7 @@ public final class Feature implements Serializable {
      * @param componentClassName
      *            If the feature is a component, the qualified name of the class
      *            otherwise null
+     * @since 23.0
      */
     public Feature(String title, String id, String moreInfoLink,
             boolean requiresServerRestart, String componentClassName) {

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -37,6 +37,8 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
  * Enabled feature flags are stored in
  * <code>vaadin-featureflags.properties</code> inside the resources folder
  * (<code>src/main/resources</code>).
+ *
+ * @since 9.0
  */
 public class FeatureFlags implements Serializable {
 
@@ -44,6 +46,7 @@ public class FeatureFlags implements Serializable {
 
     /**
      * @deprecated Use {@link #SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL} instead.
+     * @since 23.2
      */
     @Deprecated
     public static final String SYSTEM_PROPERTY_PREFIX = "vaadin.";
@@ -199,6 +202,8 @@ public class FeatureFlags implements Serializable {
     /**
      * Read the feature flag properties files and updates the enable property of
      * each feature object.
+     *
+     * @since 23.0
      */
     public void loadProperties() {
         final ResourceProvider resourceProvider = lookup

--- a/flow-server/src/main/java/com/vaadin/experimental/UnknownFeatureException.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/UnknownFeatureException.java
@@ -12,6 +12,8 @@ package com.vaadin.experimental;
  * Exception thrown for when a FeatureFlag that doesn't exist is checked.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 9.0
  */
 public class UnknownFeatureException extends RuntimeException {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractField.java
@@ -62,7 +62,6 @@ public abstract class AbstractField<C extends AbstractField<C, T>, T>
      * Value change event fired by components.
      *
      * @author Vaadin Ltd
-     * @since 1.0
      * @param <C>
      *            the source component type
      * @param <V>

--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
@@ -302,6 +302,7 @@ public abstract class AbstractSinglePropertyField<C extends AbstractField<C, T>,
      * @return the registration of the DOM event listener that synchronizes the
      *         property value, or <code>null</code> if property synchronization
      *         is disabled
+     * @since 2.0
      */
     protected DomListenerRegistration getSynchronizationRegistration() {
         return synchronizationRegistration;

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -51,6 +51,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * @param listener
      *            the listener to add, not <code>null</code>
      * @return a handle that can be used for removing the listener
+     * @since 24.1
      */
     default Registration addDoubleClickListener(
             ComponentEventListener<ClickEvent<T>> listener) {
@@ -73,6 +74,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * @param listener
      *            the listener to add, not <code>null</code>
      * @return a handle that can be used for removing the listener
+     * @since 24.1
      */
     default Registration addSingleClickListener(
             ComponentEventListener<ClickEvent<T>> listener) {
@@ -119,6 +121,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      *            with the {@code key} for the shortcut to trigger
      * @return {@link ShortcutRegistration} for configuring the shortcut and
      *         removing
+     * @since 1.3
      */
     default ShortcutRegistration addClickShortcut(Key key,
             KeyModifier... keyModifiers) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -382,6 +382,7 @@ public abstract class Component
      *            the component event type
      * @return A collection with all registered listeners for a given event
      *         type. Empty if no listeners are found.
+     * @since 23.2
      */
     protected Collection<?> getListeners(
             Class<? extends ComponentEvent> eventType) {
@@ -485,6 +486,7 @@ public abstract class Component
      * current request which also detaches the UI and its components.
      *
      * @return true if the component is attached to an active UI.
+     * @since 5.0
      */
     public boolean isAttached() {
         return getElement().getNode().isAttached();
@@ -651,6 +653,7 @@ public abstract class Component
      *            parameters used in translation string
      * @return translation for key if found (implementation should not return
      *         null)
+     * @since 23.2
      */
     public String getTranslation(Object key, Object... params) {
         final Optional<I18NProvider> i18NProvider = LocaleUtil
@@ -699,6 +702,7 @@ public abstract class Component
      * @return translation for key if found
      * @deprecated Use {@link #getTranslation(Locale, String, Object...)}
      *             instead
+     * @since 23.2
      */
     @Deprecated
     public String getTranslation(Object key, Locale locale, Object... params) {
@@ -719,6 +723,7 @@ public abstract class Component
      * @param params
      *            parameters used in translation string
      * @return translation for key if found
+     * @since 9.0
      */
     public String getTranslation(Locale locale, String key, Object... params) {
         return LocaleUtil.getI18NProvider()
@@ -740,6 +745,7 @@ public abstract class Component
      * @param params
      *            parameters used in translation string
      * @return translation for key if found
+     * @since 23.2
      */
     public String getTranslation(Locale locale, Object key, Object... params) {
         return LocaleUtil.getI18NProvider()
@@ -764,6 +770,8 @@ public abstract class Component
     /**
      * Scrolls the current component into the visible area of the browser
      * window.
+     *
+     * @since 23.1
      */
     public void scrollIntoView() {
         scrollIntoView(null);
@@ -775,6 +783,7 @@ public abstract class Component
      *
      * @param scrollOptions
      *            options to define the scrolling behavior
+     * @since 24.0
      */
     public void scrollIntoView(ScrollOptions scrollOptions) {
         getElement().scrollIntoView(scrollOptions);
@@ -790,6 +799,7 @@ public abstract class Component
      *         if no ancestor with the correct type could be found.
      * @param <T>
      *            the type of the ancestor component to return
+     * @since 23.2
      */
     public <T> T findAncestor(Class<T> componentType) {
         Optional<Component> optionalParent = getParent();
@@ -806,6 +816,8 @@ public abstract class Component
 
     /**
      * Removes the component from its parent.
+     *
+     * @since 24.0
      */
     public void removeFromParent() {
         getElement().removeFromParent();

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
@@ -127,6 +127,7 @@ public class ComponentEventBus implements Serializable {
      * @return an object which can be used to remove the event listener
      * @throws IllegalArgumentException
      *             if the event type is not annotated with {@link DomEvent}
+     * @since 1.1
      */
     public <T extends ComponentEvent<?>> Registration addListener(
             Class<T> eventType, ComponentEventListener<T> listener,
@@ -189,6 +190,7 @@ public class ComponentEventBus implements Serializable {
      *            the component event type
      * @return A collection with all registered listeners for a given event
      *         type. Empty if no listeners are found.
+     * @since 23.2
      */
     public Collection<?> getListeners(
             Class<? extends ComponentEvent> eventType) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -70,6 +70,7 @@ public class ComponentUtil {
      *            The HTML tag associated with the component class.
      * @param componentClass
      *            The component class to be registered with the given tag.
+     * @since 24.5
      */
     public static void registerComponentClass(String tag,
             Class<? extends Component> componentClass) {
@@ -91,6 +92,7 @@ public class ComponentUtil {
      * @return A set of component classes associated with the specified HTML
      *         tag. Returns an empty set if no classes are associated with the
      *         tag or if running in production mode.
+     * @since 24.5
      */
     public static Set<Class<? extends Component>> getComponentsByTag(
             String tag) {
@@ -106,6 +108,7 @@ public class ComponentUtil {
      * @return An unmodifiable map of HTML tags to sets of component classes.
      *         This map is only populated in development mode and will be empty
      *         in production mode.
+     * @since 24.5
      */
     public static Map<String, Set<Class<? extends Component>>> getAllTagMappings() {
         return Collections.unmodifiableMap(tagToComponentsMap);
@@ -438,6 +441,7 @@ public class ComponentUtil {
      * @return a handle that can be used for removing the listener
      * @throws IllegalArgumentException
      *             if the event type is not annotated with {@link DomEvent}
+     * @since 1.1
      */
     public static <T extends ComponentEvent<?>> Registration addListener(
             Component component, Class<T> eventType,
@@ -457,6 +461,7 @@ public class ComponentUtil {
      *            the event type for which the listener(s) are registered.
      * @return a boolean indicating whether at least one listener registered to
      *         the component for the given event type.
+     * @since 23.0.7
      */
     public static <T extends ComponentEvent<?>> boolean hasEventListener(
             Component component, Class<? extends T> eventType) {
@@ -470,6 +475,7 @@ public class ComponentUtil {
      *            the component event type
      * @return A collection with all registered listeners for a given event
      *         type. Empty if no listeners are found.
+     * @since 23.2
      */
     public static Collection<?> getListeners(Component component,
             Class<? extends ComponentEvent> eventType) {
@@ -706,6 +712,7 @@ public class ComponentUtil {
      * @return a router instance
      * @throws IllegalStateException
      *             if no router instance is available
+     * @since 23.2
      */
     public static Router getRouter(HasElement component) {
         Router router = null;
@@ -731,6 +738,7 @@ public class ComponentUtil {
      * @param component
      *            Component to find current route component for
      * @return Optional containing Route component if found
+     * @since 24.4.9
      */
     public static Optional<Component> getRouteComponent(Component component) {
         if (component.getClass().isAnnotationPresent(Route.class)) {
@@ -757,6 +765,7 @@ public class ComponentUtil {
      *            the parent component from which to get the child components
      *
      * @return the child components of the given parent component
+     * @since 24.10
      */
     public static Stream<Component> getChildren(Component parent) {
         // This should not ever be called for a Composite as it will return

--- a/flow-server/src/main/java/com/vaadin/flow/component/DomEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/DomEvent.java
@@ -93,6 +93,7 @@ public @interface DomEvent {
      * Controls if the event is let to propagate to parent elements.
      *
      * @return true if the event is not let to propagate to parent elements
+     * @since 24.2
      */
     public boolean stopPropagation() default false;
 
@@ -100,6 +101,7 @@ public @interface DomEvent {
      * Controls if the browser is asked to prevent the default browser behavior.
      *
      * @return true if default behavior is should be prevented
+     * @since 24.2
      */
     public boolean preventDefault() default false;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -154,6 +154,7 @@ public interface Focusable<T extends Component>
      *            with the {@code key} for the shortcut to trigger
      * @return {@link ShortcutRegistration} for configuring the shortcut and
      *         removing
+     * @since 1.3
      */
     default ShortcutRegistration addFocusShortcut(Key key,
             KeyModifier... keyModifiers) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
@@ -43,7 +43,7 @@ import com.vaadin.flow.dom.ElementConstants;
  * details.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  */
 public interface HasAriaLabel extends HasElement {
     /**
@@ -90,6 +90,7 @@ public interface HasAriaLabel extends HasElement {
      * @param ariaLabelledBy
      *            the string with the id of the element that will be used as
      *            label or {@code null} to clear
+     * @since 24.1
      */
     default void setAriaLabelledBy(String ariaLabelledBy) {
         if (ariaLabelledBy != null) {
@@ -107,6 +108,7 @@ public interface HasAriaLabel extends HasElement {
      *
      * @return an optional aria-labelledby of the component if no
      *         aria-labelledby has been set
+     * @since 24.1
      */
     default Optional<String> getAriaLabelledBy() {
         return Optional.ofNullable(getElement()

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
@@ -61,6 +61,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      *
      * @param components
      *            the components to add
+     * @since 23.2
      */
     default void add(Collection<Component> components) {
         Objects.requireNonNull(components, "Components should not be null");
@@ -75,6 +76,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      *
      * @param text
      *            the text to add, not <code>null</code>
+     * @since 1.3
      */
     default void add(String text) {
         add(new Text(text));
@@ -102,6 +104,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      * @throws IllegalArgumentException
      *             if there is a component whose non {@code null} parent is not
      *             this component
+     * @since 23.2
      */
     default void remove(Collection<Component> components) {
         Objects.requireNonNull(components, "Components should not be null");
@@ -148,6 +151,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      *            be non-negative and may not exceed the children count
      * @param component
      *            the component to add, value should not be null
+     * @since 1.1
      */
     default void addComponentAtIndex(int index, Component component) {
         Objects.requireNonNull(component, "Component should not be null");
@@ -168,6 +172,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      *
      * @param component
      *            the component to add, value should not be null
+     * @since 1.1
      */
     default void addComponentAsFirst(Component component) {
         addComponentAtIndex(0, component);
@@ -191,6 +196,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      *            the new component to be replaced. Can be <code>null</code>,
      *            which will make the oldComponent to be removed from the layout
      *            without adding any other
+     * @since 24.10
      */
     default void replace(Component oldComponent, Component newComponent) {
         if (oldComponent == null && newComponent == null) {
@@ -222,6 +228,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      * @param component
      *            the component to look up, can not be <code>null</code>
      * @return the index of the component or -1 if the component is not a child
+     * @since 24.10
      */
     default int indexOf(Component component) {
         if (component == null) {
@@ -244,6 +251,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      * Gets the number of children components.
      *
      * @return the number of components
+     * @since 24.10
      */
     default int getComponentCount() {
         return (int) getChildren().count();
@@ -260,6 +268,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      *             if the index is less than 0 or greater than or equals to the
      *             number of children components
      * @see #getComponentCount()
+     * @since 24.10
      */
     default Component getComponentAt(int index) {
         if (index < 0) {
@@ -279,6 +288,7 @@ public interface HasComponents extends HasElement, HasEnabled {
      * @see Component#getChildren()
      *
      * @return the children components of this component
+     * @since 24.10
      */
     default Stream<Component> getChildren() {
         if (this instanceof Component parent) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.dom.Element;
  * }</pre>
  *
  * @author Vaadin Ltd
- * @since 2.4
+ * @since 5.0
  */
 public interface HasHelper extends HasElement {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.dom.ElementConstants;
  * }</pre>
  *
  * @author Vaadin Ltd
- * @since
+ * @since 4.0
  */
 public interface HasLabel extends HasElement {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasPlaceholder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasPlaceholder.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component;
  * The default implementations sets the <code>placeholder</code> property for
  * this element. Override all methods in this interface if the placeholder
  * should be set in some other way.
+ *
+ * @since 24.3
  */
 public interface HasPlaceholder extends HasElement {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -52,6 +52,7 @@ public interface HasSize extends HasElement {
      *            the width of the object.
      * @param unit
      *            the unit used for the width.
+     * @since 4.0
      */
     default void setWidth(float width, Unit unit) {
         if (unit == null) {
@@ -72,6 +73,7 @@ public interface HasSize extends HasElement {
      * @param minWidth
      *            the min-width value (if <code>null</code>, the property will
      *            be removed)
+     * @since 1.3
      */
     default void setMinWidth(String minWidth) {
         getElement().getStyle().set(ElementConstants.STYLE_MIN_WIDTH, minWidth);
@@ -85,6 +87,7 @@ public interface HasSize extends HasElement {
      *            the min-width of the object.
      * @param unit
      *            the unit used for the min-width.
+     * @since 4.0
      */
     default void setMinWidth(float minWidth, Unit unit) {
         if (unit == null) {
@@ -105,6 +108,7 @@ public interface HasSize extends HasElement {
      * @param maxWidth
      *            the max-width value (if <code>null</code>, the property will
      *            be removed)
+     * @since 1.3
      */
     default void setMaxWidth(String maxWidth) {
         getElement().getStyle().set(ElementConstants.STYLE_MAX_WIDTH, maxWidth);
@@ -118,6 +122,7 @@ public interface HasSize extends HasElement {
      *            the max-width of the object.
      * @param unit
      *            the unit used for the max-width.
+     * @since 4.0
      */
     default void setMaxWidth(float maxWidth, Unit unit) {
         if (unit == null) {
@@ -147,6 +152,7 @@ public interface HasSize extends HasElement {
      * min-width which has been set using {@link #setMinWidth(String)}.
      *
      * @return the min-width which has been set for the component
+     * @since 1.3
      */
     default String getMinWidth() {
         return getElement().getStyle().get(ElementConstants.STYLE_MIN_WIDTH);
@@ -160,6 +166,7 @@ public interface HasSize extends HasElement {
      * max-width which has been set using {@link #setMaxWidth(String)}.
      *
      * @return the max-width which has been set for the component
+     * @since 1.3
      */
     default String getMaxWidth() {
         return getElement().getStyle().get(ElementConstants.STYLE_MAX_WIDTH);
@@ -170,6 +177,7 @@ public interface HasSize extends HasElement {
      *
      * @return an optional width unit for the component, or an empty optional if
      *         no width unit has been set
+     * @since 7.0
      */
     default Optional<Unit> getWidthUnit() {
         return Unit.getUnit(getWidth());
@@ -200,6 +208,7 @@ public interface HasSize extends HasElement {
      *            the height of the object.
      * @param unit
      *            the unit used for the height.
+     * @since 4.0
      */
     default void setHeight(float height, Unit unit) {
         if (unit == null) {
@@ -220,6 +229,7 @@ public interface HasSize extends HasElement {
      * @param minHeight
      *            the min-height value (if <code>null</code>, the property will
      *            be removed)
+     * @since 1.3
      */
     default void setMinHeight(String minHeight) {
         getElement().getStyle().set(ElementConstants.STYLE_MIN_HEIGHT,
@@ -234,6 +244,7 @@ public interface HasSize extends HasElement {
      *            the min-height of the object.
      * @param unit
      *            the unit used for the min-height.
+     * @since 4.0
      */
     default void setMinHeight(float minHeight, Unit unit) {
         if (unit == null) {
@@ -254,6 +265,7 @@ public interface HasSize extends HasElement {
      * @param maxHeight
      *            the max-height value (if <code>null</code>, the property will
      *            be removed)
+     * @since 1.3
      */
     default void setMaxHeight(String maxHeight) {
         getElement().getStyle().set(ElementConstants.STYLE_MAX_HEIGHT,
@@ -268,6 +280,7 @@ public interface HasSize extends HasElement {
      *            the max-height of the object.
      * @param unit
      *            the unit used for the max-height.
+     * @since 4.0
      */
     default void setMaxHeight(float maxHeight, Unit unit) {
         if (unit == null) {
@@ -295,6 +308,7 @@ public interface HasSize extends HasElement {
      * min-height which has been set using {@link #setMinHeight(String)}.
      *
      * @return the min-height which has been set for the component
+     * @since 1.3
      */
     default String getMinHeight() {
         return getElement().getStyle().get(ElementConstants.STYLE_MIN_HEIGHT);
@@ -307,6 +321,7 @@ public interface HasSize extends HasElement {
      * max-height which has been set using {@link #setMaxHeight(String)}.
      *
      * @return the max-height which has been set for the component
+     * @since 1.3
      */
     default String getMaxHeight() {
         return getElement().getStyle().get(ElementConstants.STYLE_MAX_HEIGHT);
@@ -317,6 +332,7 @@ public interface HasSize extends HasElement {
      *
      * @return an optional height unit for the component, or an empty optional
      *         if no height unit has been set
+     * @since 7.0
      */
     default Optional<Unit> getHeightUnit() {
         return Unit.getUnit(getHeight());
@@ -365,6 +381,8 @@ public interface HasSize extends HasElement {
      * layout. This applies additional CSS styles that allow the component to
      * shrink below 100% if there are other components with fixed or relative
      * sizes in the layout.
+     *
+     * @since 1.3
      */
     default void setWidthFull() {
         setWidth("100%");
@@ -389,6 +407,8 @@ public interface HasSize extends HasElement {
      * layout. This applies additional CSS styles that allow the component to
      * shrink below 100% if there are other components with fixed or relative
      * sizes in the layout.
+     *
+     * @since 1.3
      */
     default void setHeightFull() {
         setHeight("100%");
@@ -415,6 +435,7 @@ public interface HasSize extends HasElement {
      * @param unit
      *            Unit
      * @return Css format size string
+     * @since 4.0
      */
     static String getCssSize(float size, Unit unit) {
         if (size < 0) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
@@ -131,6 +131,7 @@ public interface HasText extends HasElement {
      *
      * @param value
      *            the {@code "white-space"} style value, not {@code null}
+     * @since 9.0
      */
     default void setWhiteSpace(WhiteSpace value) {
         getElement().getStyle().set("white-space",
@@ -145,6 +146,7 @@ public interface HasText extends HasElement {
      * returned.
      *
      * @return the {@code "white-space"} style value, may be {@code null}
+     * @since 9.0
      */
     default WhiteSpace getWhiteSpace() {
         String value = getElement().getStyle().get("white-space");

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
@@ -51,6 +51,7 @@ public interface HasValidation extends Serializable {
      *
      * @param enabled
      *            whether to enable manual validation mode.
+     * @since 24.2
      */
     default void setManualValidation(boolean enabled) {
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatEvent.java
@@ -13,7 +13,7 @@ import java.util.EventObject;
 /**
  * Event created for an application heartbeat from the client.
  *
- * @since 2.0
+ * @since 23.0
  */
 public class HeartbeatEvent extends EventObject {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatListener.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
 /**
  * Listener for listening to the heartbeat of the application.
  *
- * @since 2.0
+ * @since 23.0
  */
 @FunctionalInterface
 public interface HeartbeatListener extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -121,6 +121,7 @@ public class Html extends Component {
      *
      * @param html
      *            the HTML to wrap
+     * @since 23.3
      */
     public void setHtmlContent(String html) {
         setOuterHtml(html, true);

--- a/flow-server/src/main/java/com/vaadin/flow/component/Key.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Key.java
@@ -1962,6 +1962,8 @@ public interface Key extends Serializable {
      * hankaku/zenkaku/kanji ) key on Japanese keyboards
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key BACKQUOTE = Key.of("Backquote");
 
@@ -1972,6 +1974,8 @@ public interface Key extends Serializable {
      * a UK (102) keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key BACKSLASH = Key.of("Backslash");
 
@@ -1979,6 +1983,8 @@ public interface Key extends Serializable {
      * <code>[{</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key BRACKET_LEFT = Key.of("BracketLeft");
 
@@ -1986,6 +1992,8 @@ public interface Key extends Serializable {
      * <code>]}</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key BRACKET_RIGHT = Key.of("BracketRight");
 
@@ -1993,6 +2001,8 @@ public interface Key extends Serializable {
      * <code>,&lt;</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key COMMA = Key.of("Comma");
 
@@ -2000,6 +2010,8 @@ public interface Key extends Serializable {
      * <code>0)</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_0 = Key.of("Digit0");
 
@@ -2007,6 +2019,8 @@ public interface Key extends Serializable {
      * <code>1!</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_1 = Key.of("Digit1");
 
@@ -2014,6 +2028,8 @@ public interface Key extends Serializable {
      * <code>2@</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_2 = Key.of("Digit2");
 
@@ -2021,6 +2037,8 @@ public interface Key extends Serializable {
      * <code>3#</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_3 = Key.of("Digit3");
 
@@ -2028,6 +2046,8 @@ public interface Key extends Serializable {
      * <code>4$</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_4 = Key.of("Digit4");
 
@@ -2035,6 +2055,8 @@ public interface Key extends Serializable {
      * <code>5%</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_5 = Key.of("Digit5");
 
@@ -2042,6 +2064,8 @@ public interface Key extends Serializable {
      * <code>6^</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_6 = Key.of("Digit6");
 
@@ -2049,6 +2073,8 @@ public interface Key extends Serializable {
      * <code>7&amp;</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_7 = Key.of("Digit7");
 
@@ -2056,6 +2082,8 @@ public interface Key extends Serializable {
      * <code>8*</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_8 = Key.of("Digit8");
 
@@ -2063,6 +2091,8 @@ public interface Key extends Serializable {
      * <code>9(</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key DIGIT_9 = Key.of("Digit9");
 
@@ -2070,6 +2100,8 @@ public interface Key extends Serializable {
      * <code>=+</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key EQUAL = Key.of("Equal");
 
@@ -2078,6 +2110,8 @@ public interface Key extends Serializable {
      * keys.Labelled <code>\|</code> on a UK keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key INTL_BACKSLASH = Key.of("IntlBackslash");
 
@@ -2086,6 +2120,8 @@ public interface Key extends Serializable {
      * keys.Labelled <code>\ろ</code> ( ro ) on a Japanese keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key INTL_RO = Key.of("IntlRo");
 
@@ -2095,6 +2131,8 @@ public interface Key extends Serializable {
      * <code>\/</code> on a Russian keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key INTL_YEN = Key.of("IntlYen");
 
@@ -2103,6 +2141,8 @@ public interface Key extends Serializable {
      * (e.g., French) keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_A = Key.of("KeyA");
 
@@ -2110,6 +2150,8 @@ public interface Key extends Serializable {
      * <code>b</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_B = Key.of("KeyB");
 
@@ -2117,6 +2159,8 @@ public interface Key extends Serializable {
      * <code>c</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_C = Key.of("KeyC");
 
@@ -2124,6 +2168,8 @@ public interface Key extends Serializable {
      * <code>d</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_D = Key.of("KeyD");
 
@@ -2131,6 +2177,8 @@ public interface Key extends Serializable {
      * <code>e</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_E = Key.of("KeyE");
 
@@ -2138,6 +2186,8 @@ public interface Key extends Serializable {
      * <code>f</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_F = Key.of("KeyF");
 
@@ -2145,6 +2195,8 @@ public interface Key extends Serializable {
      * <code>g</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_G = Key.of("KeyG");
 
@@ -2152,6 +2204,8 @@ public interface Key extends Serializable {
      * <code>h</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_H = Key.of("KeyH");
 
@@ -2159,6 +2213,8 @@ public interface Key extends Serializable {
      * <code>i</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_I = Key.of("KeyI");
 
@@ -2166,6 +2222,8 @@ public interface Key extends Serializable {
      * <code>j</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_J = Key.of("KeyJ");
 
@@ -2173,6 +2231,8 @@ public interface Key extends Serializable {
      * <code>k</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_K = Key.of("KeyK");
 
@@ -2180,6 +2240,8 @@ public interface Key extends Serializable {
      * <code>l</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_L = Key.of("KeyL");
 
@@ -2187,6 +2249,8 @@ public interface Key extends Serializable {
      * <code>m</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_M = Key.of("KeyM");
 
@@ -2194,6 +2258,8 @@ public interface Key extends Serializable {
      * <code>n</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_N = Key.of("KeyN");
 
@@ -2201,6 +2267,8 @@ public interface Key extends Serializable {
      * <code>o</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_O = Key.of("KeyO");
 
@@ -2208,6 +2276,8 @@ public interface Key extends Serializable {
      * <code>p</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_P = Key.of("KeyP");
 
@@ -2216,6 +2286,8 @@ public interface Key extends Serializable {
      * (e.g., French) keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_Q = Key.of("KeyQ");
 
@@ -2223,6 +2295,8 @@ public interface Key extends Serializable {
      * <code>r</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_R = Key.of("KeyR");
 
@@ -2230,6 +2304,8 @@ public interface Key extends Serializable {
      * <code>s</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_S = Key.of("KeyS");
 
@@ -2237,6 +2313,8 @@ public interface Key extends Serializable {
      * <code>t</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_T = Key.of("KeyT");
 
@@ -2244,6 +2322,8 @@ public interface Key extends Serializable {
      * <code>u</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_U = Key.of("KeyU");
 
@@ -2251,6 +2331,8 @@ public interface Key extends Serializable {
      * <code>v</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_V = Key.of("KeyV");
 
@@ -2259,6 +2341,8 @@ public interface Key extends Serializable {
      * (e.g., French) keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_W = Key.of("KeyW");
 
@@ -2266,6 +2350,8 @@ public interface Key extends Serializable {
      * <code>x</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_X = Key.of("KeyX");
 
@@ -2274,6 +2360,8 @@ public interface Key extends Serializable {
      * (e.g., German) keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_Y = Key.of("KeyY");
 
@@ -2283,6 +2371,8 @@ public interface Key extends Serializable {
      * keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key KEY_Z = Key.of("KeyZ");
 
@@ -2290,6 +2380,8 @@ public interface Key extends Serializable {
      * <code>-_</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key MINUS = Key.of("Minus");
 
@@ -2297,6 +2389,8 @@ public interface Key extends Serializable {
      * <code>.&gt;</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key PERIOD = Key.of("Period");
 
@@ -2304,6 +2398,8 @@ public interface Key extends Serializable {
      * <code>'"</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key QUOTE = Key.of("Quote");
 
@@ -2311,6 +2407,8 @@ public interface Key extends Serializable {
      * <code>;:</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key SEMICOLON = Key.of("Semicolon");
 
@@ -2318,6 +2416,8 @@ public interface Key extends Serializable {
      * <code>/?</code> on a US keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key SLASH = Key.of("Slash");
 
@@ -2325,6 +2425,8 @@ public interface Key extends Serializable {
      * <code>Alt</code> , <code>Option</code> or <code>⌥</code> .
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key ALT_LEFT = Key.of("AltLeft");
 
@@ -2333,6 +2435,8 @@ public interface Key extends Serializable {
      * labelled <code>AltGr</code> key on many keyboard layouts.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key ALT_RIGHT = Key.of("AltRight");
 
@@ -2340,6 +2444,8 @@ public interface Key extends Serializable {
      * <code>Control</code> or <code>⌃</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key CONTROL_LEFT = Key.of("ControlLeft");
 
@@ -2347,6 +2453,8 @@ public interface Key extends Serializable {
      * <code>Control</code> or <code>⌃</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key CONTROL_RIGHT = Key.of("ControlRight");
 
@@ -2355,6 +2463,8 @@ public interface Key extends Serializable {
      * key.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key META_LEFT = Key.of("MetaLeft");
 
@@ -2363,6 +2473,8 @@ public interface Key extends Serializable {
      * key.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key META_RIGHT = Key.of("MetaRight");
 
@@ -2370,6 +2482,8 @@ public interface Key extends Serializable {
      * <code>Shift</code> or <code>⇧</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key SHIFT_LEFT = Key.of("ShiftLeft");
 
@@ -2377,6 +2491,8 @@ public interface Key extends Serializable {
      * <code>Shift</code> or <code>⇧</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key SHIFT_RIGHT = Key.of("ShiftRight");
 
@@ -2385,6 +2501,8 @@ public interface Key extends Serializable {
      * keyboard): <code>かな</code> ( kana )
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key LANG_1 = Key.of("Lang1");
 
@@ -2393,6 +2511,8 @@ public interface Key extends Serializable {
      * <code>英数</code> ( eisu )
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key LANG_2 = Key.of("Lang2");
 
@@ -2400,6 +2520,8 @@ public interface Key extends Serializable {
      * Japanese (word-processing keyboard): Katakana
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key LANG_3 = Key.of("Lang3");
 
@@ -2407,6 +2529,8 @@ public interface Key extends Serializable {
      * Japanese (word-processing keyboard): Hiragana
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key LANG_4 = Key.of("Lang4");
 
@@ -2414,6 +2538,8 @@ public interface Key extends Serializable {
      * Japanese (word-processing keyboard): Zenkaku/Hankaku
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key LANG_5 = Key.of("Lang5");
 
@@ -2422,6 +2548,8 @@ public interface Key extends Serializable {
      * control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_0 = Key.of("Numpad0");
 
@@ -2430,6 +2558,8 @@ public interface Key extends Serializable {
      * phone orremote control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_1 = Key.of("Numpad1");
 
@@ -2438,6 +2568,8 @@ public interface Key extends Serializable {
      * control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_2 = Key.of("Numpad2");
 
@@ -2446,6 +2578,8 @@ public interface Key extends Serializable {
      * control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_3 = Key.of("Numpad3");
 
@@ -2454,6 +2588,8 @@ public interface Key extends Serializable {
      * control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_4 = Key.of("Numpad4");
 
@@ -2462,6 +2598,8 @@ public interface Key extends Serializable {
      * control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_5 = Key.of("Numpad5");
 
@@ -2470,6 +2608,8 @@ public interface Key extends Serializable {
      * control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_6 = Key.of("Numpad6");
 
@@ -2478,6 +2618,8 @@ public interface Key extends Serializable {
      * PRS</code> on a phoneor remote control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_7 = Key.of("Numpad7");
 
@@ -2486,6 +2628,8 @@ public interface Key extends Serializable {
      * control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_8 = Key.of("Numpad8");
 
@@ -2494,6 +2638,8 @@ public interface Key extends Serializable {
      * WXY</code> on a phoneor remote control
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_9 = Key.of("Numpad9");
 
@@ -2501,6 +2647,8 @@ public interface Key extends Serializable {
      * <code>+</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_ADD = Key.of("NumpadAdd");
 
@@ -2508,6 +2656,8 @@ public interface Key extends Serializable {
      * Found on the Microsoft Natural Keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_BACKSPACE = Key.of("NumpadBackspace");
 
@@ -2518,6 +2668,8 @@ public interface Key extends Serializable {
      * should always be encoded as " NumLock " .
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_CLEAR = Key.of("NumpadClear");
 
@@ -2525,6 +2677,8 @@ public interface Key extends Serializable {
      * <code>CE</code> (Clear Entry)
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_CLEAR_ENTRY = Key.of("NumpadClearEntry");
 
@@ -2534,6 +2688,8 @@ public interface Key extends Serializable {
      * .
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_COMMA = Key.of("NumpadComma");
 
@@ -2542,6 +2698,8 @@ public interface Key extends Serializable {
      * (e.g.,Brazil), this key may generate a <code>,</code> .
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_DECIMAL = Key.of("NumpadDecimal");
 
@@ -2549,11 +2707,15 @@ public interface Key extends Serializable {
      * <code>/</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_DIVIDE = Key.of("NumpadDivide");
 
     /**
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_ENTER = Key.of("NumpadEnter");
 
@@ -2561,6 +2723,8 @@ public interface Key extends Serializable {
      * <code>=</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_EQUAL = Key.of("NumpadEqual");
 
@@ -2570,6 +2734,8 @@ public interface Key extends Serializable {
      * key.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_HASH = Key.of("NumpadHash");
 
@@ -2577,6 +2743,8 @@ public interface Key extends Serializable {
      * <code>M+</code> Add current entry to the value stored in memory.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_MEMORY_ADD = Key.of("NumpadMemoryAdd");
 
@@ -2584,6 +2752,8 @@ public interface Key extends Serializable {
      * <code>MC</code> Clear the value stored in memory.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_MEMORY_CLEAR = Key.of("NumpadMemoryClear");
 
@@ -2592,6 +2762,8 @@ public interface Key extends Serializable {
      * memory.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_MEMORY_RECALL = Key.of("NumpadMemoryRecall");
 
@@ -2600,6 +2772,8 @@ public interface Key extends Serializable {
      * entry.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_MEMORY_STORE = Key.of("NumpadMemoryStore");
 
@@ -2607,6 +2781,8 @@ public interface Key extends Serializable {
      * <code>M-</code> Subtract current entry from the value stored in memory.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_MEMORY_SUBTRACT = Key.of("NumpadMemorySubtract");
 
@@ -2617,6 +2793,8 @@ public interface Key extends Serializable {
      * phones and remote controls.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_MULTIPLY = Key.of("NumpadMultiply");
 
@@ -2624,6 +2802,8 @@ public interface Key extends Serializable {
      * <code>(</code> Found on the Microsoft Natural Keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_PAREN_LEFT = Key.of("NumpadParenLeft");
 
@@ -2631,6 +2811,8 @@ public interface Key extends Serializable {
      * <code>)</code> Found on the Microsoft Natural Keyboard.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_PAREN_RIGHT = Key.of("NumpadParenRight");
 
@@ -2641,6 +2823,8 @@ public interface Key extends Serializable {
      * keypads.
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_STAR = Key.of("NumpadStar");
 
@@ -2648,6 +2832,8 @@ public interface Key extends Serializable {
      * <code>-</code>
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key NUMPAD_SUBTRACT = Key.of("NumpadSubtract");
 
@@ -2655,6 +2841,8 @@ public interface Key extends Serializable {
      * Sometimes labelled <code>My Computer</code> on the keyboard
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key LAUNCH_APP_1 = Key.of("LaunchApp1");
 
@@ -2662,42 +2850,58 @@ public interface Key extends Serializable {
      * Sometimes labelled <code>Calculator</code> on the keyboard
      * <p>
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key LAUNCH_APP_2 = Key.of("LaunchApp2");
 
     /**
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key MEDIA_SELECT = Key.of("MediaSelect");
 
     /**
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key SLEEP = Key.of("Sleep");
 
     /**
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key TURBO = Key.of("Turbo");
 
     /**
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key ABORT = Key.of("Abort");
 
     /**
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key RESUME = Key.of("Resume");
 
     /**
      * This value matches DOM's KeyboardEvent's <code>event.code</code>.
+     *
+     * @since 1.3
      */
     Key SUSPEND = Key.of("Suspend");
 
     /**
      * This value is reserved for corner cases of no key value present in event
      * e.g. when browser autosuggest is used.
+     *
+     * @since 23.0.1
      */
     Key NONE = Key.of("None");
 
@@ -2794,6 +2998,7 @@ public interface Key extends Serializable {
      * @param key
      *            a {@link Key} instance.
      * @return true if the key argument is a modifier, otherwise false.
+     * @since 1.3
      */
     static boolean isModifier(Key key) {
         return Stream.of(KeyModifier.values())

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyDownEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyDownEvent.java
@@ -52,6 +52,7 @@ public class KeyDownEvent extends KeyboardEvent {
      * @param composing
      *            <code>true</code> if the key event occurred as part of a
      *            composition session
+     * @since 1.3
      */
     public KeyDownEvent(Component source, boolean fromClient,
             @EventData("event.key") String key,
@@ -88,6 +89,7 @@ public class KeyDownEvent extends KeyboardEvent {
      *            the key for this event
      * @param code
      *            the code for this event
+     * @since 1.3
      */
     public KeyDownEvent(Component source, String key, String code) {
         super(source, key, code);

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyLocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyLocation.java
@@ -33,6 +33,8 @@ public enum KeyLocation {
 
     /**
      * Right key location.
+     *
+     * @since 1.3
      */
     RIGHT(2),
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyModifier.java
@@ -35,6 +35,8 @@ public enum KeyModifier implements Key {
 
     /**
      * KeyModifier for "{@code Alt Graph}" key.
+     *
+     * @since 1.3
      */
     ALT_GRAPH(Key.ALT_GRAPH),
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyPressEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyPressEvent.java
@@ -52,6 +52,7 @@ public class KeyPressEvent extends KeyboardEvent {
      * @param composing
      *            <code>true</code> if the key event occurred as part of a
      *            composition session
+     * @since 1.3
      */
     public KeyPressEvent(Component source, boolean fromClient,
             @EventData("event.key") String key,
@@ -88,6 +89,7 @@ public class KeyPressEvent extends KeyboardEvent {
      *            the key for this event
      * @param code
      *            the code for this event
+     * @since 1.3
      */
     public KeyPressEvent(Component source, String key, String code) {
         super(source, key, code);

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyUpEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyUpEvent.java
@@ -52,6 +52,7 @@ public class KeyUpEvent extends KeyboardEvent {
      * @param composing
      *            <code>true</code> if the key event occurred as part of a
      *            composition session
+     * @since 1.3
      */
     public KeyUpEvent(Component source, boolean fromClient,
             @EventData("event.key") String key,
@@ -88,6 +89,7 @@ public class KeyUpEvent extends KeyboardEvent {
      *            the key for this event
      * @param code
      *            the code for this event
+     * @since 1.3
      */
     public KeyUpEvent(Component source, String key, String code) {
         super(source, key, code);

--- a/flow-server/src/main/java/com/vaadin/flow/component/PushConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/PushConfiguration.java
@@ -62,6 +62,7 @@ public interface PushConfiguration extends Serializable {
      *
      * @param pushServletMapping
      *            The servlet mapping to use for push
+     * @since 23.3.5
      */
     void setPushServletMapping(String pushServletMapping);
 
@@ -73,6 +74,7 @@ public interface PushConfiguration extends Serializable {
      *
      * @return the servlet mapping to use for push requests, or null to use to
      *         default
+     * @since 23.3.5
      */
     String getPushServletMapping();
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/ScrollOptions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ScrollOptions.java
@@ -19,6 +19,8 @@ import com.vaadin.flow.internal.JacksonUtils;
  * Options for scrollIntoView.
  * <p>
  * See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+ *
+ * @since 24.0
  **/
 public class ScrollOptions implements Serializable {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -259,6 +259,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      *
      * @return this <code>ShortcutRegistration</code>
      * @see #setResetFocusOnActiveElement(boolean)
+     * @since 24.3
      */
     public ShortcutRegistration resetFocusOnActiveElement() {
         if (!resetFocusOnActiveElement) {
@@ -302,6 +303,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      *            bound. Must not be null. Must not contain null. Must not have
      *            duplicate components.
      * @return this <code>ShortcutRegistration</code>
+     * @since 2.2
      */
     public ShortcutRegistration listenOn(Component... listenOnComponents) {
         Objects.requireNonNull(listenOnComponents,
@@ -394,6 +396,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * shortcut. The default value is {@code false}.
      *
      * @return Allows default key behavior
+     * @since 1.4
      */
     public boolean isBrowserDefaultAllowed() {
         return allowDefaultBehavior;
@@ -406,6 +409,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      *
      * @param browserDefaultAllowed
      *            Allow default behavior on keydown
+     * @since 1.4
      */
     public void setBrowserDefaultAllowed(boolean browserDefaultAllowed) {
         if (allowDefaultBehavior != browserDefaultAllowed) {
@@ -419,6 +423,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * shortcut) propagation in the browser. The default value is {@code false}.
      *
      * @return Allows event propagation
+     * @since 1.4
      */
     public boolean isEventPropagationAllowed() {
         return allowEventPropagation;
@@ -431,6 +436,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      *
      * @param eventPropagationAllowed
      *            Allow event propagation
+     * @since 1.4
      */
     public void setEventPropagationAllowed(boolean eventPropagationAllowed) {
         if (allowEventPropagation != eventPropagationAllowed) {
@@ -444,6 +450,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * shortcut event handler.
      *
      * @return True when focus is reset on the active element, false otherwise.
+     * @since 24.3
      */
     public boolean isResetFocusOnActiveElement() {
         return resetFocusOnActiveElement;
@@ -461,6 +468,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      *
      * @param resetFocusOnActiveElement
      *            Reset focus on active element
+     * @since 24.3
      */
     public void setResetFocusOnActiveElement(
             boolean resetFocusOnActiveElement) {
@@ -493,6 +501,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * The {@link Component}s which own the shortcuts key event listeners.
      *
      * @return Component[]
+     * @since 2.2
      */
     public Component[] getOwners() {
         if (listenOnComponents == null) {
@@ -524,6 +533,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      *            component is disabled.
      *
      * @return this registration, for chaining
+     * @since 24.7
      */
     public ShortcutRegistration setDisabledUpdateMode(
             DisabledUpdateMode disabledUpdateMode) {
@@ -540,6 +550,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * component is disabled.
      *
      * @return current disabledUpdateMode for this listener
+     * @since 24.7
      */
     public DisabledUpdateMode getDisabledUpdateMode() {
         return mode;

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -150,7 +150,7 @@ public final class Shortcuts {
      * @return a registration for removing the locator, does not affect active
      *         shortcuts or if the locator has changed from what was set for
      *         this registration
-     * @since
+     * @since 6.0.2
      */
     public static Registration setShortcutListenOnElement(
             String elementLocatorJs, Component listenOnComponent) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/Synchronize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Synchronize.java
@@ -71,6 +71,7 @@ public @interface Synchronize {
      *
      * @return {@code true} to allow inert synchronization, {@code false} to
      *         disallow. Defaults to {@code false}.
+     * @since 24.6.8
      */
     boolean allowInert() default false;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Tag.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Tag.java
@@ -49,10 +49,14 @@ public @interface Tag {
     String BUTTON = "button";
     /**
      * Tag for an <code>&lt;caption&gt;</code>.
+     *
+     * @since 24.5
      */
     String CAPTION = "caption";
     /**
      * Tag for a <code>&lt;code&gt;</code>.
+     *
+     * @since 24.9
      */
     String CODE = "code";
     /**
@@ -61,6 +65,8 @@ public @interface Tag {
     String DD = "dd";
     /**
      * Tag for an <code>&lt;details&gt;</code>.
+     *
+     * @since 6.0
      */
     String DETAILS = "details";
     /**
@@ -117,6 +123,8 @@ public @interface Tag {
     String HR = "hr";
     /**
      * Tag for an <code>&lt;iframe&gt;</code>.
+     *
+     * @since 1.3
      */
     String IFRAME = "iframe";
     /**
@@ -146,6 +154,8 @@ public @interface Tag {
 
     /**
      * Tag for an <code>&lt;object&gt;</code>.
+     *
+     * @since 9.0
      */
     String OBJECT = "object";
     /**
@@ -163,6 +173,8 @@ public @interface Tag {
 
     /**
      * Tag for an <code>&lt;param&gt;</code>.
+     *
+     * @since 9.0
      */
     String PARAM = "param";
     /**
@@ -187,18 +199,26 @@ public @interface Tag {
     String STRONG = "strong";
     /**
      * Tag for an <code>&lt;summary&gt;</code>.
+     *
+     * @since 6.0
      */
     String SUMMARY = "summary";
     /**
      * Tag for a <code>&lt;table&gt;</code>.
+     *
+     * @since 24.5
      */
     String TABLE = "table";
     /**
      * Tag for a <code>&lt;tbody&gt;</code>.
+     *
+     * @since 24.5
      */
     String TBODY = "tbody";
     /**
      * Tag for a <code>&lt;td&gt;</code>.
+     *
+     * @since 24.5
      */
     String TD = "td";
     /**
@@ -207,18 +227,26 @@ public @interface Tag {
     String TEXTAREA = "textarea";
     /**
      * Tag for a <code>&lt;tfoot&gt;</code>.
+     *
+     * @since 24.5
      */
     String TFOOT = "tfoot";
     /**
      * Tag for a <code>&lt;th&gt;</code>.
+     *
+     * @since 24.5
      */
     String TH = "th";
     /**
      * Tag for a <code>&lt;thead&gt;</code>.
+     *
+     * @since 24.5
      */
     String THEAD = "thead";
     /**
      * Tag for a <code>&lt;tr&gt;</code>.
+     *
+     * @since 24.5
      */
     String TR = "tr";
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/Text.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Text.java
@@ -77,6 +77,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 3.1.7
      */
     @Override
     public void setId(String id) {
@@ -89,6 +90,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 3.1.7
      */
     @Override
     public void setVisible(boolean visible) {
@@ -104,6 +106,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 24.2
      */
     @Override
     public void addClassName(String className) {
@@ -118,6 +121,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 24.2
      */
     @Override
     public boolean removeClassName(String className) {
@@ -133,6 +137,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 24.2
      */
     @Override
     public void setClassName(String className) {
@@ -148,6 +153,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 24.2
      */
     @Override
     public void setClassName(String className, boolean set) {
@@ -163,6 +169,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 24.2
      */
     @Override
     public void addClassNames(String... classNames) {
@@ -177,6 +184,7 @@ public class Text extends Component implements HasText {
      * Always throws an {@link UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException
+     * @since 24.2
      */
     @Override
     public void removeClassNames(String... classNames) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -150,6 +150,7 @@ public class UI extends Component
      *
      * @param internalsHandler
      *            an implementation of UIInternalsHandler.
+     * @since 3.0
      */
     protected UI(UIInternalUpdater internalsHandler) {
         super(null);
@@ -233,6 +234,7 @@ public class UI extends Component
      *            the application id
      *
      * @see #getUIId()
+     * @since 23.3
      */
     public void doInit(VaadinRequest request, int uiId, String appId) {
         if (this.uiId != -1) {
@@ -621,6 +623,7 @@ public class UI extends Component
      *            <code>null</code> as described above
      * @return a runnable that will run either the access task or the detach
      *         handler, possibly asynchronously
+     * @since 1.3
      */
     public SerializableRunnable accessLater(SerializableRunnable accessTask,
             SerializableRunnable detachHandler) {
@@ -648,6 +651,7 @@ public class UI extends Component
      *            <code>null</code> as described above
      * @return a consumer that will run either the access task or the detach
      *         handler, possibly asynchronously
+     * @since 1.3
      */
     public <T> SerializableConsumer<T> accessLater(
             SerializableConsumer<T> accessTask,
@@ -832,6 +836,7 @@ public class UI extends Component
      *
      * @param direction
      *            the direction to use, not {@code null}
+     * @since 3.1
      */
     public void setDirection(Direction direction) {
         Objects.requireNonNull(direction, "Direction cannot be null");
@@ -988,6 +993,7 @@ public class UI extends Component
      * @throws NotFoundException
      *             in case there is no route defined for the given
      *             navigationTarget matching the parameters.
+     * @since 4.0
      */
     public <T extends Component> Optional<T> navigate(Class<T> navigationTarget,
             RouteParameters parameters) {
@@ -1024,6 +1030,7 @@ public class UI extends Component
      * @throws NotFoundException
      *             in case there is no route defined for the given
      *             navigationTarget matching the parameters.
+     * @since 24.1.1
      */
     public <T extends Component> Optional<T> navigate(Class<T> navigationTarget,
             RouteParam... parameters) {
@@ -1064,6 +1071,7 @@ public class UI extends Component
      * @throws NotFoundException
      *             in case there is no route defined for the given
      *             navigationTarget matching the parameters.
+     * @since 23.2
      */
     @SuppressWarnings("unchecked")
     public <T, C extends Component & HasUrlParameter<T>> Optional<C> navigate(
@@ -1113,6 +1121,7 @@ public class UI extends Component
      * @throws NotFoundException
      *             in case there is no route defined for the given
      *             navigationTarget matching the parameters.
+     * @since 24.1
      */
     @SuppressWarnings("unchecked")
     public <C extends Component> Optional<C> navigate(
@@ -1148,6 +1157,7 @@ public class UI extends Component
      * @throws NotFoundException
      *             in case there is no route defined for the given
      *             navigationTarget matching the parameters.
+     * @since 23.2
      */
     @SuppressWarnings("unchecked")
     public <T extends Component> Optional<T> navigate(
@@ -1249,6 +1259,7 @@ public class UI extends Component
      * @param refreshRouteChain
      *            {@code true} to refresh all layouts in the route chain,
      *            {@code false} to only refresh the route instance
+     * @since 24.4
      */
     public void refreshCurrentRoute(boolean refreshRouteChain) {
         getInternals().refreshCurrentRoute(refreshRouteChain);
@@ -1262,6 +1273,7 @@ public class UI extends Component
      * Returns true if this UI instance supports navigation.
      *
      * @return true if this UI instance supports navigation, otherwise false.
+     * @since 5.0
      */
     public boolean isNavigationSupported() {
         // By default any UI supports navigation. Override this to return false
@@ -1284,6 +1296,7 @@ public class UI extends Component
      * @return the currently active route instance if available
      * @throws IllegalStateException
      *             if current view is not yet available
+     * @since 24.0
      */
     public Component getCurrentView() {
         if (getInternals().getActiveRouterTargetsChain().isEmpty()) {
@@ -1464,6 +1477,7 @@ public class UI extends Component
      * @see #addShortcutListener(ShortcutEventListener, Key, KeyModifier...) for
      *      registering a listener which receives a {@link ShortcutEvent}
      * @see Shortcuts for a more generic way to add a shortcut
+     * @since 1.3
      */
     public ShortcutRegistration addShortcutListener(Command command, Key key,
             KeyModifier... keyModifiers) {
@@ -1498,6 +1512,7 @@ public class UI extends Component
      * @return {@link ShortcutRegistration} for configuring the shortcut and
      *         removing
      * @see Shortcuts for a more generic way to add a shortcut
+     * @since 1.3
      */
     public ShortcutRegistration addShortcutListener(
             ShortcutEventListener listener, Key key,
@@ -1528,6 +1543,7 @@ public class UI extends Component
      * @param listener
      *            the heartbeat listener
      * @return handler to remove the heartbeat listener
+     * @since 23.0
      */
     public Registration addHeartbeatListener(HeartbeatListener listener) {
         Objects.requireNonNull(listener, NULL_LISTENER);
@@ -1575,6 +1591,7 @@ public class UI extends Component
      * @param component
      *            the modal component to add
      * @see #setChildComponentModal(Component, boolean)
+     * @since 23.0
      */
     public void addModal(Component component) {
         add(component);
@@ -1616,6 +1633,7 @@ public class UI extends Component
      * Check if UI has a defined modal component.
      *
      * @return {@code true} if a modal component has been set
+     * @since 23.0
      */
     public boolean hasModalComponent() {
         return getInternals().hasModalComponent();
@@ -1631,6 +1649,7 @@ public class UI extends Component
      *
      * @param component
      *            component to add to modal component
+     * @since 23.0
      */
     public void addToModalComponent(Component component) {
         if (hasModalComponent()) {
@@ -1669,6 +1688,7 @@ public class UI extends Component
      * the servlet mapping used for serving the related UI.
      *
      * @return the view location, not <code>null</code>
+     * @since 24.3
      */
     public Location getActiveViewLocation() {
         return getInternals().getActiveViewLocation();
@@ -1679,6 +1699,7 @@ public class UI extends Component
      *
      * @return a list of active router target and parent layout instances,
      *         starting from the innermost part
+     * @since 24.3
      */
     public List<HasElement> getActiveRouterTargetsChain() {
         return getInternals().getActiveRouterTargetsChain();
@@ -1703,11 +1724,15 @@ public class UI extends Component
      * Gets the new forward url.
      *
      * @return the new forward url
+     * @since 24.0
      */
     public String getForwardToClientUrl() {
         return forwardToClientUrl;
     }
 
+    /**
+     * @since 24.4
+     */
     @DomEvent(BrowserLeaveNavigationEvent.EVENT_NAME)
     public static class BrowserLeaveNavigationEvent extends ComponentEvent<UI> {
         public static final String EVENT_NAME = "ui-leave-navigation";
@@ -1731,6 +1756,9 @@ public class UI extends Component
         }
     }
 
+    /**
+     * @since 24.4
+     */
     @DomEvent(BrowserNavigateEvent.EVENT_NAME)
     public static class BrowserNavigateEvent extends ComponentEvent<UI> {
         public static final String EVENT_NAME = "ui-navigate";
@@ -1756,6 +1784,7 @@ public class UI extends Component
          * @param trigger
          *            navigation trigger
          *
+         * @since 24.8
          */
         public BrowserNavigateEvent(UI source, boolean fromClient,
                 @EventData("route") String route,
@@ -1782,6 +1811,7 @@ public class UI extends Component
      * the route chain if the {@code fullRefresh} event flag is active.
      *
      * @see #refreshCurrentRoute(boolean)
+     * @since 24.5
      */
     @DomEvent(BrowserRefreshEvent.EVENT_NAME)
     public static class BrowserRefreshEvent extends ComponentEvent<UI> {
@@ -1828,6 +1858,7 @@ public class UI extends Component
      * @deprecated(forRemoval=true) method is not enabled for client side
      *                              anymore and connectClient is triggered by
      *                              DOM event, to be removed in next major 25
+     * @since 24.1
      */
     @Deprecated
     public void connectClient(String flowRoutePath, String flowRouteQuery,
@@ -1843,6 +1874,7 @@ public class UI extends Component
      *
      * @param event
      *            the event from the browser
+     * @since 24.4
      */
     public void browserNavigate(BrowserNavigateEvent event) {
 
@@ -1935,6 +1967,7 @@ public class UI extends Component
      * @deprecated(forRemoval=true) method is not enabled for client side
      *                              anymore and leave navigation is triggered by
      *                              DOM event, to be removed in next major 25
+     * @since 24.0
      */
     @Deprecated
     public void leaveNavigation(String route, String query) {
@@ -1952,6 +1985,7 @@ public class UI extends Component
      *
      * @param event
      *            the event from the browser
+     * @since 24.4
      */
     public void leaveNavigation(BrowserLeaveNavigationEvent event) {
         navigateToPlaceholder(new Location(PathUtil.trimPath(event.route),
@@ -2078,6 +2112,8 @@ public class UI extends Component
     /**
      * Placeholder view when navigating from server-side views to client-side
      * views.
+     *
+     * @since 24.0
      */
     @Tag(Tag.DIV)
     @AnonymousAllowed

--- a/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
@@ -13,6 +13,8 @@ import java.util.stream.Stream;
 
 /**
  * Enum of supported units in Css sizes.
+ *
+ * @since 4.0
  */
 public enum Unit {
     /**
@@ -34,18 +36,26 @@ public enum Unit {
     EM("em"),
     /**
      * Unit code representing the viewport's width.
+     *
+     * @since 7.0
      */
     VW("vw"),
     /**
      * Unit code representing the viewport's height.
+     *
+     * @since 7.0
      */
     VH("vh"),
     /**
      * Unit code representing the viewport's smaller dimension.
+     *
+     * @since 7.0
      */
     VMIN("vmin"),
     /**
      * Unit code representing the viewport's larger dimension.
+     *
+     * @since 7.0
      */
     VMAX("vmax"),
     /**
@@ -66,6 +76,8 @@ public enum Unit {
     MM("mm"),
     /**
      * Unit code representing the width of the "0" (zero).
+     *
+     * @since 7.0
      */
     CH("ch"),
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
@@ -260,6 +260,7 @@ public abstract class WebComponentExporter<C extends Component>
      * @param defaultValue
      *            default value of property.
      * @return fluent {@code PropertyConfiguration} for configuring the property
+     * @since 24.8
      */
     public final PropertyConfiguration<C, BaseJsonNode> addProperty(String name,
             BaseJsonNode defaultValue) {
@@ -288,6 +289,8 @@ public abstract class WebComponentExporter<C extends Component>
 
     /**
      * Always called before {@link #configureInstance(WebComponent, Component)}.
+     *
+     * @since 2.2
      */
     public final void preConfigure() {
         isConfigureInstanceCall = true;
@@ -295,6 +298,8 @@ public abstract class WebComponentExporter<C extends Component>
 
     /**
      * Always called after {@link #configureInstance(WebComponent, Component)}.
+     *
+     * @since 2.2
      */
     public final void postConfigure() {
         isConfigureInstanceCall = false;
@@ -304,6 +309,7 @@ public abstract class WebComponentExporter<C extends Component>
      * The tag associated with the exported component.
      *
      * @return the tag
+     * @since 2.2
      */
     public final String getTag() {
         return tag;
@@ -488,6 +494,7 @@ public abstract class WebComponentExporter<C extends Component>
      * the actual type parameter.
      *
      * @return component class
+     * @since 2.2
      */
     protected Class<C> getComponentClass() {
         return (Class<C>) ReflectTools.getGenericInterfaceType(this.getClass(),

--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporterFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporterFactory.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.internal.ReflectTools;
  * @param <C>
  *            type of the component to export
  *
+ * @since 2.2
  */
 @FunctionalInterface
 public interface WebComponentExporterFactory<C extends Component>

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
@@ -94,7 +94,7 @@ import java.lang.annotation.Target;
  * {@code @CssImport("./styles/custom-style.css")}, the {@code custom-style.css}
  * will be present on the root route as well.
  *
- * @since 2.0
+ * @since 2.0.3
  *
  * @see JsModule
  */

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -104,6 +104,8 @@ public @interface JavaScript {
      * loaded.
      * <p>
      * By default, scripts are always loaded.
+     *
+     * @since 24.2
      */
     boolean developmentOnly() default false;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
@@ -78,6 +78,8 @@ public @interface JsModule {
      * loaded.
      * <p>
      * By default, scripts are always loaded.
+     *
+     * @since 24.2
      */
     boolean developmentOnly() default false;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/NpmPackage.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/NpmPackage.java
@@ -64,6 +64,7 @@ public @interface NpmPackage {
      *
      * @return {@code true} if the package should be installed as a dev
      *         dependency, {@code false} otherwise.
+     * @since 24.3
      */
     boolean dev() default false;
 
@@ -73,6 +74,7 @@ public @interface NpmPackage {
      * "dist/line-awesome/css/**:line-awesome/dist/line-awesome/css"
      *
      * @return array of assets to copy from npm package
+     * @since 24.9
      */
     String[] assets() default {};
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/AllowInert.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/AllowInert.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
  * Makes a <code>@ClientCallable</code> method callable even if the UI is inert.
  *
  * @author Vaadin Ltd
- * @since 1.0
+ * @since 23.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
 /**
  * Tracks the location in source code where components were instantiated.
  *
+ * @since 24.0
  **/
 public class ComponentTracker {
 
@@ -122,6 +123,7 @@ public class ComponentTracker {
          * @param configuration
          *            the application configuration
          * @return the source file the location refers to, or {@code null}
+         * @since 24.4.9
          */
         public File findSourceFile(AbstractConfiguration configuration) {
             String cls = className();
@@ -164,6 +166,7 @@ public class ComponentTracker {
          *            the application configuration
          * @return the Java file the location refers to, or {@code null}
          * @deprecated use findSourceFile
+         * @since 24.2
          */
         @Deprecated
         public File findJavaFile(AbstractConfiguration configuration) {
@@ -195,6 +198,7 @@ public class ComponentTracker {
      * @param component
      *            the component to find
      * @return the locations involved in creating the component
+     * @since 24.5.5
      */
     public static Location[] findCreateLocations(Component component) {
         return createLocations.get(component);
@@ -243,6 +247,7 @@ public class ComponentTracker {
      * @param component
      *            the component to find
      * @return the locations involved in creating the component
+     * @since 24.5.5
      */
     public static Location[] findAttachLocations(Component component) {
         return attachLocations.get(component);
@@ -286,6 +291,7 @@ public class ComponentTracker {
      *            reference component location
      * @param offset
      *            difference in lines to be applied
+     * @since 24.1
      */
     public static void refreshLocation(Location location, int offset) {
         refreshLocation(createLocation, location, offset);

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/DependencyTreeCache.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/DependencyTreeCache.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.function.SerializableFunction;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since 1.2
+ * @since 1.1
  * @param <T>
  *            the value type
  */

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -28,6 +28,8 @@ import com.vaadin.flow.server.HttpStatusCode;
  *
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.0
  */
 public class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/KeyboardEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/KeyboardEvent.java
@@ -68,6 +68,7 @@ public abstract class KeyboardEvent extends ComponentEvent<Component> {
      * @param composing
      *            <code>true</code> if the key event occurred as part of a
      *            composition session
+     * @since 1.3
      */
     public KeyboardEvent(Component source, boolean fromClient, String key,
             String code, int location, boolean ctrlKey, boolean shiftKey,
@@ -118,6 +119,7 @@ public abstract class KeyboardEvent extends ComponentEvent<Component> {
      *            the key for this event
      * @param code
      *            the code for this event
+     * @since 1.3
      */
     public KeyboardEvent(Component source, String key, String code) {
         this(source, false, key, code, 0, false, false, false, false, false,
@@ -138,6 +140,7 @@ public abstract class KeyboardEvent extends ComponentEvent<Component> {
      * empty Optional will be given.
      *
      * @return the optional code of the event as a {@link Key}
+     * @since 1.3
      */
     public Optional<Key> getCode() {
         return Optional.ofNullable(code);

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternalUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternalUpdater.java
@@ -21,6 +21,8 @@ import com.vaadin.flow.dom.Element;
  * given content.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 3.0
  */
 public interface UIInternalUpdater extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -249,6 +249,7 @@ public class UIInternals implements Serializable {
      *            the UI to use
      * @param internalsHandler
      *            an implementation of {@link UIInternalUpdater}
+     * @since 3.0
      */
     public UIInternals(UI ui, UIInternalUpdater internalsHandler) {
         this.internalsHandler = internalsHandler;
@@ -314,6 +315,7 @@ public class UIInternals implements Serializable {
      *
      * @param lastRequestResponse
      *            The request that was sent for the last UIDL request.
+     * @since 24.7
      */
     public void setLastRequestResponse(String lastRequestResponse) {
         this.lastRequestResponse = lastRequestResponse;
@@ -323,6 +325,7 @@ public class UIInternals implements Serializable {
      * Returns the response created for the last UIDL request.
      *
      * @return The request that was sent for the last UIDL request.
+     * @since 24.7
      */
     public String getLastRequestResponse() {
         return lastRequestResponse;
@@ -590,6 +593,7 @@ public class UIInternals implements Serializable {
      * @param <E>
      *            the handler type
      * @return unmodifiable list of registered listeners for navigation handler
+     * @since 2.0
      */
     public <E> List<E> getListeners(Class<E> handler) {
         List<E> registeredListeners = (List<E>) listeners
@@ -604,6 +608,7 @@ public class UIInternals implements Serializable {
      *
      * @param invocation
      *            the invocation to add
+     * @since 2.0
      */
     public void addJavaScriptInvocation(
             PendingJavaScriptInvocation invocation) {
@@ -712,6 +717,7 @@ public class UIInternals implements Serializable {
      * @param containsFilter
      *            string to filter invocation expressions with
      * @return true if any invocation with given expression is found.
+     * @since 24.4
      */
     public boolean containsPendingJavascript(String containsFilter) {
         return getPendingJavaScriptInvocations().anyMatch(js -> js
@@ -763,6 +769,7 @@ public class UIInternals implements Serializable {
      *
      * @param appShellTitle
      *            the appShellTitle to set
+     * @since 4.0.4
      */
     public void setAppShellTitle(String appShellTitle) {
         this.appShellTitle = appShellTitle;
@@ -788,6 +795,7 @@ public class UIInternals implements Serializable {
      * <b>NOTE</b> Intended for internal use, you should not call this method.
      *
      * @return the app shell title
+     * @since 4.0.4
      */
     public String getAppShellTitle() {
         return appShellTitle;
@@ -815,6 +823,7 @@ public class UIInternals implements Serializable {
      *
      * @param layouts
      *            stored router target chain to set as last navigated chain
+     * @since 24.8
      */
     public void setRouterTargetChain(List<RouterLayout> layouts) {
         if (routerTargetChain.isEmpty()) {
@@ -834,6 +843,7 @@ public class UIInternals implements Serializable {
      *            the component to show, not <code>null</code>
      * @param layouts
      *            the parent layouts
+     * @since 4.0
      */
     public void showRouteTarget(Location viewLocation, Component target,
             List<RouterLayout> layouts) {
@@ -942,6 +952,7 @@ public class UIInternals implements Serializable {
      *
      * @param otherUI
      *            the other UI to transfer content from.
+     * @since 3.0
      */
     public void moveElementsFrom(UI otherUI) {
         internalsHandler.moveToNewUI(otherUI, ui);
@@ -1139,6 +1150,7 @@ public class UIInternals implements Serializable {
      *
      * @param location
      *            current location.
+     * @since 24.7.1
      */
     public void setLocationForRefresh(Location location) {
         locationForRefresh = location;
@@ -1157,6 +1169,7 @@ public class UIInternals implements Serializable {
      * @param refreshRouteChain
      *            {@code true} to refresh all layouts in the route chain,
      *            {@code false} to only refresh the route instance
+     * @since 24.4
      */
     public void refreshCurrentRoute(boolean refreshRouteChain) {
         if (locationForRefresh == null) {
@@ -1174,6 +1187,7 @@ public class UIInternals implements Serializable {
      * component that implements HasErrorParameter.
      *
      * @return true if showing an error view, false otherwise
+     * @since 24.9.12
      */
     public boolean isShowingErrorView() {
         if (routerTargetChain.isEmpty()) {
@@ -1228,6 +1242,7 @@ public class UIInternals implements Serializable {
      * @param fullAppId
      *            the (full, not stripped) id of the application tied with this
      *            UI
+     * @since 24.1
      */
     public void setFullAppId(String fullAppId) {
         this.fullAppId = fullAppId;
@@ -1250,6 +1265,7 @@ public class UIInternals implements Serializable {
      * will be gone.
      *
      * @return the full app id
+     * @since 24.1
      */
     public String getFullAppId() {
         return fullAppId;
@@ -1335,6 +1351,7 @@ public class UIInternals implements Serializable {
      *
      * @return the extended client details, or {@literal null} if not yet
      *         received.
+     * @since 2.0
      */
     public ExtendedClientDetails getExtendedClientDetails() {
         return extendedClientDetails;
@@ -1345,6 +1362,7 @@ public class UIInternals implements Serializable {
      *
      * @param details
      *            the updated extended client details.
+     * @since 2.0
      */
     public void setExtendedClientDetails(ExtendedClientDetails details) {
         this.extendedClientDetails = details;
@@ -1354,6 +1372,7 @@ public class UIInternals implements Serializable {
      * Check if we have a modal component defined for the UI.
      *
      * @return {@code true} if modal component is defined
+     * @since 23.0
      */
     public boolean hasModalComponent() {
         return modalComponentStack != null && !modalComponentStack.isEmpty();
@@ -1363,6 +1382,7 @@ public class UIInternals implements Serializable {
      * Get the active modal component if modal components set.
      *
      * @return the current active modal component
+     * @since 23.0
      */
     public Component getActiveModalComponent() {
         if (hasModalComponent()) {
@@ -1384,6 +1404,7 @@ public class UIInternals implements Serializable {
      *
      * @param child
      *            the child component to toggle modal
+     * @since 23.0
      */
     public void setChildModal(Component child) {
         if (modalComponentStack == null) {
@@ -1426,6 +1447,7 @@ public class UIInternals implements Serializable {
      *
      * @param child
      *            the child component to make modeless
+     * @since 23.0
      */
     public void setChildModeless(Component child) {
         if (modalComponentStack == null) {
@@ -1480,6 +1502,7 @@ public class UIInternals implements Serializable {
      * Returns the Deployment Configuration for the application
      *
      * @return The Deployment Configuration
+     * @since 24.8
      */
     public DeploymentConfiguration getDeploymentConfiguration() {
         return getSession().getService().getDeploymentConfiguration();

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -360,6 +360,7 @@ public class ExtendedClientDetails implements Serializable {
      *
      * @return true if run on IPad false if the user is not using IPad or if no
      *         information from the browser is present
+     * @since 2.2
      */
     public boolean isIPad() {
         return navigatorPlatform != null && (navigatorPlatform
@@ -372,6 +373,7 @@ public class ExtendedClientDetails implements Serializable {
      *
      * @return {@code true} if run on IOS , {@code false} if the user is not
      *         using IOS or if no information from the browser is present
+     * @since 2.2
      */
     public boolean isIOS() {
         return isIPad() || VaadinSession.getCurrent().getBrowser().isIPhone()

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -178,6 +178,7 @@ public class History implements Serializable {
      * @param callback
      *            {@code true} if the change should make a return call to the
      *            server
+     * @since 24.4.6
      */
     public void pushState(JsonValue state, String location, boolean callback) {
         pushState(state,
@@ -213,6 +214,7 @@ public class History implements Serializable {
      * @param callback
      *            {@code true} if the change should make a return call to the
      *            server
+     * @since 24.4.6
      */
     public void pushState(JsonValue state, Location location,
             boolean callback) {
@@ -265,6 +267,7 @@ public class History implements Serializable {
      * @param callback
      *            {@code true} if the change should make a return call to the
      *            server
+     * @since 24.4.6
      */
     public void replaceState(JsonValue state, String location,
             boolean callback) {
@@ -301,6 +304,7 @@ public class History implements Serializable {
      * @param callback
      *            {@code true} if the change should make a return call to the
      *            server
+     * @since 24.4.6
      */
     public void replaceState(JsonValue state, Location location,
             boolean callback) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -196,6 +196,7 @@ public class Page implements Serializable {
      * @param url
      *            the URL to load the JavaScript module from, not
      *            <code>null</code>
+     * @since 2.0
      */
     public void addJsModule(String url) {
         if (UrlUtil.isExternal(url) || url.startsWith("/")) {
@@ -218,6 +219,7 @@ public class Page implements Serializable {
      *
      * @param expression
      *            the JavaScript expression which return a Promise
+     * @since 2.1
      */
     public void addDynamicImport(String expression) {
         addDependency(new Dependency(Type.DYNAMIC_IMPORT, expression));
@@ -262,6 +264,7 @@ public class Page implements Serializable {
      *            parameters to pass to the expression
      * @return a pending result that can be used to get a value returned from
      *         the expression
+     * @since 2.0
      */
     public PendingJavaScriptResult executeJs(String expression,
             Serializable... parameters) {
@@ -303,6 +306,7 @@ public class Page implements Serializable {
      *
      * @see BrowserWindowResizeListener#browserWindowResized(BrowserWindowResizeEvent)
      * @see Registration
+     * @since 1.2
      */
     public Registration addBrowserWindowResizeListener(
             BrowserWindowResizeListener resizeListener) {
@@ -342,6 +346,7 @@ public class Page implements Serializable {
      *
      * @param url
      *            the URL to open.
+     * @since 2.0
      */
     public void open(String url) {
         open(url, "_blank");
@@ -384,6 +389,7 @@ public class Page implements Serializable {
      *            the URL to open.
      * @param windowName
      *            the name of the window.
+     * @since 2.2
      */
     public void open(String url, String windowName) {
         // The vaadin-redirect-pending event might be useful to block other
@@ -401,6 +407,7 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @since 2.0
      */
     public void setLocation(String uri) {
         open(uri, "_self");
@@ -412,6 +419,7 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @since 2.0
      */
     public void setLocation(URI uri) {
         setLocation(uri.toString());
@@ -424,6 +432,8 @@ public class Page implements Serializable {
 
     /**
      * Callback for receiving extended client-side details.
+     *
+     * @since 2.0
      */
     @FunctionalInterface
     public interface ExtendedClientDetailsReceiver extends Serializable {
@@ -444,6 +454,7 @@ public class Page implements Serializable {
      *
      * @param receiver
      *            the callback to which the details are provided
+     * @since 2.0
      */
     public void retrieveExtendedClientDetails(
             ExtendedClientDetailsReceiver receiver) {
@@ -524,6 +535,7 @@ public class Page implements Serializable {
      *
      * @param callback
      *            to be notified when the url is resolved.
+     * @since 7.0
      */
     public void fetchCurrentURL(SerializableConsumer<URL> callback) {
         Objects.requireNonNull(callback,
@@ -554,6 +566,7 @@ public class Page implements Serializable {
      *
      * @param callback
      *            to be notified when the direction is resolved.
+     * @since 24.0
      */
     public void fetchPageDirection(SerializableConsumer<Direction> callback) {
         executeJs("return document.dir").then(String.class, dir -> {

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Viewport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Viewport.java
@@ -41,6 +41,8 @@ public @interface Viewport {
     /**
      * Sets the viewport to the height of the device rather than the rendered
      * space.
+     *
+     * @since 1.3
      */
     String DEVICE_HEIGHT = "height=device-height, initial-scale=1.0, viewport-fit=cover";
 
@@ -48,6 +50,8 @@ public @interface Viewport {
      * Sets the viewport at the width and height of the device. The device-width
      * and device-height properties are translated to 100vw and 100vh
      * respectively.
+     *
+     * @since 1.3
      */
     String DEVICE_DIMENSIONS = "width=device-width, height=device-height, initial-scale=1.0, viewport-fit=cover";
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/WebStorage.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/WebStorage.java
@@ -20,6 +20,8 @@ import com.vaadin.flow.component.UI;
  * data that you want to be stored on the client side, instead of e.g. database
  * on the server. An example could be certain UI settings that the same users
  * might want to have set differently based on their device.
+ *
+ * @since 24.2
  */
 public interface WebStorage extends Serializable {
 
@@ -243,6 +245,7 @@ public interface WebStorage extends Serializable {
      * @return a CompletableFuture that will be completed with the value once
      *         transferred from the client side or <code>null</code> if the
      *         value was not available.
+     * @since 24.5
      */
     public static CompletableFuture<String> getItem(String key) {
         return getItem(Storage.LOCAL_STORAGE, key);
@@ -264,6 +267,7 @@ public interface WebStorage extends Serializable {
      * @return a CompletableFuture that will be completed with the value once
      *         transferred from the client side or <code>null</code> if the
      *         value was not available.
+     * @since 24.5
      */
     public static CompletableFuture<String> getItem(Storage storage,
             String key) {
@@ -288,6 +292,7 @@ public interface WebStorage extends Serializable {
      * @return a CompletableFuture that will be completed with the value once
      *         transferred from the client side or <code>null</code> if the
      *         value was not available.
+     * @since 24.5
      */
     public static CompletableFuture<String> getItem(UI ui, Storage storage,
             String key) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/Id.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/Id.java
@@ -106,7 +106,7 @@ import com.vaadin.flow.dom.Element;
  *
  *
  * @author Vaadin Ltd
- * @since
+ * @since 5.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/AbstractInjectableElementInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/AbstractInjectableElementInitializer.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 5.0
  *
  */
 public abstract class AbstractInjectableElementInitializer

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerPublishedEventHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerPublishedEventHandler.java
@@ -22,7 +22,7 @@ import elemental.json.JsonValue;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  * @deprecated Polymer template support is deprecated - we recommend you to use
  *             {@code LitTemplate} instead. Read more details from <a href=

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerTemplate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerTemplate.java
@@ -16,7 +16,7 @@ import java.io.Serializable;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 5.0
  *
  * @deprecated Polymer template support is deprecated - we recommend you to use
  *             {@code LitTemplate} instead. Read more details from <a href=

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdCollector.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdCollector.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.internal.ReflectTools;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 5.0
  */
 public class IdCollector {
     private static final String DEPRECATED_ID = "com.vaadin.flow.component.polymertemplate.Id";

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdMapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdMapper.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 5.0
  */
 public class IdMapper implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/InjectableFieldConsumer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/InjectableFieldConsumer.java
@@ -16,7 +16,7 @@ import java.lang.reflect.Field;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 5.0
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/ParserData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/ParserData.java
@@ -19,7 +19,7 @@ import java.util.Map;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 5.0
  *
  */
 public class ParserData {

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponent.java
@@ -138,6 +138,7 @@ public final class WebComponent<C extends Component> implements Serializable {
      *            data the event should carry. This data is placed as the {@code
      *         detail} property of the event, nullable
      * @see #fireEvent(String, JsonNode, EventOptions) for full set of options
+     * @since 24.8
      */
     public void fireEvent(String eventName, JsonNode objectData) {
         fireEvent(eventName, objectData, BASIC_OPTIONS);
@@ -160,6 +161,7 @@ public final class WebComponent<C extends Component> implements Serializable {
      * @throws NullPointerException
      *             if either {@code eventName} or {@code options} is
      *             {@code null}
+     * @since 24.8
      */
     public void fireEvent(String eventName, JsonNode objectData,
             EventOptions options) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentConfiguration.java
@@ -90,6 +90,7 @@ public interface WebComponentConfiguration<C extends Component>
      *            set using the web component's attributes.
      * @return web component binding which can be used by the web component host
      *         to communicate with the component it is hosting
+     * @since 24.8
      */
     WebComponentBinding<C> createWebComponentBinding(Instantiator instantiator,
             Element element, JsonNode newAttributeDefaults);

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -62,6 +62,8 @@ public class WebComponentUI extends UI {
     /**
      * Event used for sending the activation event for an exported web component
      * from the client to the server.
+     *
+     * @since 2.1
      */
     @DomEvent("connect-web-component")
     public static class WebComponentConnectEvent extends ComponentEvent<UI> {
@@ -91,6 +93,7 @@ public class WebComponentUI extends UI {
          *            initial attribute values as a JsonObject. If present,
          *            these will override the default value designated by the
          *            {@code WebComponentExporter} but only for this instance.
+         * @since 24.8
          */
         public WebComponentConnectEvent(UI source, boolean fromClient,
                 @EventData("tag") String tag,

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
@@ -77,6 +77,7 @@ public class WebComponentWrapper extends Component {
      *            {@code rootElement}. These are copies of the original elements
      *            and the copies are created by
      *            {@link com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry}
+     * @since 2.2
      */
     protected WebComponentWrapper(Element rootElement,
             WebComponentBinding<?> binding, List<Element> bootstrapElements) {

--- a/flow-server/src/main/java/com/vaadin/flow/di/AbstractLookupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/AbstractLookupInitializer.java
@@ -56,7 +56,7 @@ import com.vaadin.flow.server.startup.LookupServletContainerInitializer;
  * </ul>
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public interface AbstractLookupInitializer {

--- a/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
@@ -177,6 +177,7 @@ public class DefaultInstantiator implements Instantiator {
      * application.properties property file.
      *
      * @return parameter value or null if not found
+     * @since 24.4
      */
     protected String getInitProperty(String propertyName) {
         DeploymentConfiguration deploymentConfiguration = service

--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -67,6 +67,7 @@ public interface Instantiator extends Serializable {
      *
      * @return a stream of all Index HTML request listeners to use, not
      *         <code>null</code>
+     * @since 3.0
      */
     default Stream<IndexHtmlRequestListener> getIndexHtmlRequestListeners(
             Stream<IndexHtmlRequestListener> indexHtmlRequestListeners) {
@@ -119,6 +120,7 @@ public interface Instantiator extends Serializable {
      * @param instance
      *            the instance to check
      * @return the user-defined class
+     * @since 24.3.9
      */
     default Class<?> getApplicationClass(Object instance) {
         Objects.requireNonNull(instance, "Instance cannot be null");
@@ -133,6 +135,7 @@ public interface Instantiator extends Serializable {
      * @param clazz
      *            the class to check
      * @return the user-defined class
+     * @since 24.3.9
      */
     default Class<?> getApplicationClass(Class<?> clazz) {
         Class<?> appClass = clazz;
@@ -205,6 +208,7 @@ public interface Instantiator extends Serializable {
      * Get the MenuAccessControl.
      *
      * @return MenuAccessControl instance
+     * @since 24.4
      */
     default MenuAccessControl getMenuAccessControl() {
         return getOrCreate(MenuAccessControl.class);

--- a/flow-server/src/main/java/com/vaadin/flow/di/InstantiatorFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/InstantiatorFactory.java
@@ -14,7 +14,7 @@ import com.vaadin.flow.server.VaadinService;
  * A factory for an {@link Instantiator}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public interface InstantiatorFactory {

--- a/flow-server/src/main/java/com/vaadin/flow/di/Lookup.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Lookup.java
@@ -60,7 +60,7 @@ import com.vaadin.flow.server.VaadinServlet;
  *
  * @see Instantiator
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  */
 public interface Lookup {
 

--- a/flow-server/src/main/java/com/vaadin/flow/di/LookupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/LookupInitializer.java
@@ -49,7 +49,7 @@ import com.vaadin.flow.server.startup.DefaultApplicationConfigurationFactory;
  * Default implementation of {@link AbstractLookupInitializer}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  * @see AbstractLookupInitializer
  */
@@ -66,7 +66,6 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * Default implementation of {@link Lookup}.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     protected static class LookupImpl implements Lookup {
@@ -148,7 +147,6 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * Default implementation of {@link ResourceProvider}.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     protected static class ResourceProviderImpl implements ResourceProvider {
@@ -228,7 +226,6 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * Default implementation of {@link AppShellPredicate}.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     protected static class AppShellPredicateImpl implements AppShellPredicate {
@@ -337,6 +334,7 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * @param implementation
      *            service implementation class
      * @return an instantiated service implementation object
+     * @since 6.0.1
      */
     protected <T> T instantiate(Class<T> serviceClass,
             Class<?> implementation) {
@@ -354,6 +352,7 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * This method is public only for internal purposes.
      *
      * @return a set of classes
+     * @since 24.0
      */
     public static Set<Class<?>> getDefaultImplementations() {
         return Set.of(RegularOneTimeInitializerPredicate.class,

--- a/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
@@ -27,7 +27,7 @@ package com.vaadin.flow.di;
  * is executed only once.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0.1
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/di/ResourceProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/ResourceProvider.java
@@ -21,7 +21,7 @@ import java.util.List;
  * identified by the provided context.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public interface ResourceProvider {

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DisabledUpdateMode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DisabledUpdateMode.java
@@ -44,6 +44,7 @@ public enum DisabledUpdateMode {
      *            the second mode, or <code>null</code>
      * @return the most permissive mode, or <code>null</code> if both parameters
      *         are <code>null</code>
+     * @since 1.3
      */
     public static DisabledUpdateMode mostPermissive(DisabledUpdateMode mode1,
             DisabledUpdateMode mode2) {

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
@@ -228,6 +228,7 @@ public interface DomListenerRegistration extends Registration {
      *
      * @return timeout in milliseconds, or <code>0</code> if debouncing is
      *         disabled
+     * @since 2.0
      */
     default int getDebounceTimeout() {
         /*
@@ -245,6 +246,7 @@ public interface DomListenerRegistration extends Registration {
      * @see #throttle(int)
      *
      * @return debounce phases
+     * @since 2.0
      */
     default Set<DebouncePhase> getDebouncePhases() {
         /*
@@ -258,6 +260,7 @@ public interface DomListenerRegistration extends Registration {
      * Gets the event type that the listener is registered for.
      *
      * @return DOM event type of the listener
+     * @since 2.0
      */
     default String getEventType() {
         /*
@@ -297,6 +300,7 @@ public interface DomListenerRegistration extends Registration {
      *            the name of the property to synchronize, not <code>null</code>
      *            or <code>""</code>
      * @return this registration, for chaining
+     * @since 1.3
      */
     default DomListenerRegistration synchronizeProperty(String propertyName) {
         if (propertyName == null || propertyName.isEmpty()) {
@@ -366,6 +370,7 @@ public interface DomListenerRegistration extends Registration {
      *      docs for related JS DOM API</a>
      *
      * @return the DomListenerRegistration for further configuration
+     * @since 24.2
      */
     default public DomListenerRegistration stopPropagation() {
         addEventData("event.stopPropagation()");
@@ -386,6 +391,7 @@ public interface DomListenerRegistration extends Registration {
      *      docs for related JS DOM API</a>
      *
      * @return the DomListenerRegistration for further configuration
+     * @since 24.2
      */
     default public DomListenerRegistration preventDefault() {
         addEventData("event.preventDefault()");
@@ -399,6 +405,7 @@ public interface DomListenerRegistration extends Registration {
      * events.
      *
      * @return the DomListenerRegistration for further configuration
+     * @since 24.4
      */
     public DomListenerRegistration allowInert();
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -365,6 +365,7 @@ public class Element extends Node<Element> {
      * @param requestHandler
      *            the resource value, not null
      * @return this element
+     * @since 24.8
      */
     public Element setAttribute(String attribute,
             ElementRequestHandler requestHandler) {
@@ -551,6 +552,7 @@ public class Element extends Node<Element> {
      * client.
      *
      * @return this element
+     * @since 2.0
      */
     public Element removeFromTree() {
         return removeFromTree(true);
@@ -568,6 +570,7 @@ public class Element extends Node<Element> {
      * @param sendDetach
      *            if the detach event should be sent to the client
      * @return this element
+     * @since 24.2
      */
     public Element removeFromTree(boolean sendDetach) {
         Node<?> parent = getParentNode();
@@ -785,6 +788,7 @@ public class Element extends Node<Element> {
      * @param value
      *            the property value, not <code>null</code>
      * @return this element
+     * @since 4.0
      */
     public <T> Element setPropertyList(String name, List<T> value) {
         if (value == null) {
@@ -809,6 +813,7 @@ public class Element extends Node<Element> {
      * @param value
      *            the property value, not <code>null</code>
      * @return this element
+     * @since 4.0
      */
     public Element setPropertyMap(String name, Map<String, ?> value) {
         if (value == null) {
@@ -1428,6 +1433,7 @@ public class Element extends Node<Element> {
      *            {@link JsonCodec}
      * @return a pending result that can be used to get a return value from the
      *         execution
+     * @since 2.0
      */
     public PendingJavaScriptResult callJsFunction(String functionName,
             Serializable... arguments) {
@@ -1494,6 +1500,7 @@ public class Element extends Node<Element> {
      *            parameters to pass to the expression
      * @return a pending result that can be used to get a value returned from
      *         the expression
+     * @since 2.0
      */
     public PendingJavaScriptResult executeJs(String expression,
             Serializable... parameters) {
@@ -1650,6 +1657,7 @@ public class Element extends Node<Element> {
      *      "https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Mozilla
      *      docs</a>
      * @return the element
+     * @since 23.1
      */
     public Element scrollIntoView() {
         return scrollIntoView(null);
@@ -1664,6 +1672,7 @@ public class Element extends Node<Element> {
      * @param scrollOptions
      *            the scroll options to pass to the method
      * @return the element
+     * @since 24.0
      */
     public Element scrollIntoView(ScrollOptions scrollOptions) {
         // for an unknown reason, needs to be called deferred to work on a newly

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
@@ -22,10 +22,14 @@ public class ElementConstants {
     public static final String STYLE_WIDTH = "width";
     /**
      * The style property for min-width.
+     *
+     * @since 1.3
      */
     public static final String STYLE_MIN_WIDTH = "min-width";
     /**
      * The style property for max-width.
+     *
+     * @since 1.3
      */
     public static final String STYLE_MAX_WIDTH = "max-width";
     /**
@@ -34,30 +38,44 @@ public class ElementConstants {
     public static final String STYLE_HEIGHT = "height";
     /**
      * The style property for min-height.
+     *
+     * @since 1.3
      */
     public static final String STYLE_MIN_HEIGHT = "min-height";
     /**
      * The style property for max-height.
+     *
+     * @since 1.3
      */
     public static final String STYLE_MAX_HEIGHT = "max-height";
     /**
      * The style property for background.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BACKGROUND = "background";
     /**
      * The style property for background-color.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BACKGROUND_COLOR = "background-color";
     /**
      * The style property for background-image.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BACKGROUND_IMAGE = "background-image";
     /**
      * The style property for background-position.
+     *
+     * @since 24.9
      */
     public static final String STYLE_BACKGROUND_POSITION = "background-position";
     /**
      * The style property for background-size.
+     *
+     * @since 24.9
      */
     public static final String STYLE_BACKGROUND_SIZE = "background-size";
     /**
@@ -66,245 +84,364 @@ public class ElementConstants {
     public static final String STYLE_COLOR = "color";
     /**
      * The style property for border.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BORDER = "border";
     /**
      * The style property for border-left.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BORDER_LEFT = "border-left";
     /**
      * The style property for border-right.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BORDER_RIGHT = "border-right";
     /**
      * The style property for border-top.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BORDER_TOP = "border-top";
     /**
      * The style property for border-bottom.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BORDER_BOTTOM = "border-bottom";
     /**
      * The style property for border-radius.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BORDER_RADIUS = "border-radius";
     /**
      * The style property for box-sizing.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BOX_SIZING = "box-sizing";
     /**
      * The style property for box-shadow.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BOX_SHADOW = "box-shadow";
     /**
      * The style property for clear.
+     *
+     * @since 24.3
      */
     public static final String STYLE_CLEAR = "clear";
     /**
      * The style property for cursor.
+     *
+     * @since 24.3
      */
     public static final String STYLE_CURSOR = "cursor";
     /**
      * The style property for display.
+     *
+     * @since 24.3
      */
     public static final String STYLE_DISPLAY = "display";
     /**
      * The style property for float.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FLOAT = "float";
     /**
      * The style property for filter.
+     *
+     * @since 24.9
      */
     public static final String STYLE_FILTER = "filter";
     /**
      * The style property for font.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FONT = "font";
     /**
      * The style property for gap.
+     *
+     * @since 24.9
      */
     public static final String STYLE_GAP = "gap";
     /**
      * The style property for margin.
+     *
+     * @since 24.3
      */
     public static final String STYLE_MARGIN = "margin";
     /**
      * The style property for margin-left.
+     *
+     * @since 24.3
      */
     public static final String STYLE_MARGIN_LEFT = "margin-left";
     /**
      * The style property for margin-right.
+     *
+     * @since 24.3
      */
     public static final String STYLE_MARGIN_RIGHT = "margin-right";
     /**
      * The style property for margin-top.
+     *
+     * @since 24.3
      */
     public static final String STYLE_MARGIN_TOP = "margin-top";
     /**
      * The style property for margin-bottom.
+     *
+     * @since 24.3
      */
     public static final String STYLE_MARGIN_BOTTOM = "margin-bottom";
     /**
      * The style property for margin-inline-start.
+     *
+     * @since 24.3
      */
     public static final String STYLE_MARGIN_INLINE_START = "margin-inline-start";
     /**
      * The style property for margin-inline-end.
+     *
+     * @since 24.3
      */
     public static final String STYLE_MARGIN_INLINE_END = "margin-inline-end";
     /**
      * The style property for outline.
+     *
+     * @since 24.3
      */
     public static final String STYLE_OUTLINE = "outline";
     /**
      * The style property for opacity.
+     *
+     * @since 24.3
      */
     public static final String STYLE_OPACITY = "opacity";
     /**
      * The style property for overflow.
+     *
+     * @since 24.3
      */
     public static final String STYLE_OVERFLOW = "overflow";
     /**
      * The style property for padding.
+     *
+     * @since 24.3
      */
     public static final String STYLE_PADDING = "padding";
     /**
      * The style property for padding-left.
+     *
+     * @since 24.3
      */
     public static final String STYLE_PADDING_LEFT = "padding-left";
     /**
      * The style property for padding-right.
+     *
+     * @since 24.3
      */
     public static final String STYLE_PADDING_RIGHT = "padding-right";
     /**
      * The style property for padding-top.
+     *
+     * @since 24.3
      */
     public static final String STYLE_PADDING_TOP = "padding-top";
     /**
      * The style property for padding-bottom.
+     *
+     * @since 24.3
      */
     public static final String STYLE_PADDING_BOTTOM = "padding-bottom";
     /**
      * The style property for position.
+     *
+     * @since 24.3
      */
     public static final String STYLE_POSITION = "position";
     /**
      * The style property for scale.
+     *
+     * @since 24.3
      */
     public static final String STYLE_SCALE = "scale";
     /**
      * The style property for rotate.
+     *
+     * @since 24.9
      */
     public static final String STYLE_ROTATE = "rotate";
     /**
      * The style property for text-align.
+     *
+     * @since 24.3
      */
     public static final String STYLE_TEXT_ALIGN = "text-align";
     /**
      * The style property for text-decoration.
+     *
+     * @since 24.3
      */
     public static final String STYLE_TEXT_DECORATION = "text-decoration";
     /**
      * The style property for transform.
+     *
+     * @since 24.3
      */
     public static final String STYLE_TRANSFORM = "transform";
     /**
      * The style property for transform-origin.
+     *
+     * @since 24.4
      */
     public static final String STYLE_TRANSFORM_ORIGIN = "transform-origin";
     /**
      * The style property for transition.
+     *
+     * @since 24.3
      */
     public static final String STYLE_TRANSITION = "transition";
     /**
      * The style property for visibility.
+     *
+     * @since 24.3
      */
     public static final String STYLE_VISIBILITY = "visibility";
     /**
      * The style property for white-space.
+     *
+     * @since 24.3
      */
     public static final String STYLE_WHITE_SPACE = "white-space";
     /**
      * The style property for left.
+     *
+     * @since 24.3
      */
     public static final String STYLE_LEFT = "left";
     /**
      * The style property for right.
+     *
+     * @since 24.3
      */
     public static final String STYLE_RIGHT = "right";
     /**
      * The style property for top.
+     *
+     * @since 24.3
      */
     public static final String STYLE_TOP = "top";
     /**
      * The style property for bottom.
+     *
+     * @since 24.3
      */
     public static final String STYLE_BOTTOM = "bottom";
     /**
      * The style property for z-index.
+     *
+     * @since 24.3
      */
     public static final String STYLE_Z_INDEX = "z-index";
     /**
      * The style property for font-weight.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FONT_WEIGHT = "font-weight";
     /**
      * The style property for font-size.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FONT_SIZE = "font-size";
     /**
      * The style property for line-height.
+     *
+     * @since 24.3
      */
     public static final String STYLE_LINE_HEIGHT = "line-height";
     /**
      * The style property for align-items.
+     *
+     * @since 24.3
      */
     public static final String STYLE_ALIGN_ITEMS = "align-items";
     /**
      * The style property for align-self.
+     *
+     * @since 24.3
      */
     public static final String STYLE_ALIGN_SELF = "align-self";
     /**
      * The style property for flex-wrap.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FLEX_WRAP = "flex-wrap";
     /**
      * The style property for flex-grow.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FLEX_GROW = "flex-grow";
     /**
      * The style property for flex-shrink.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FLEX_SHRINK = "flex-shrink";
     /**
      * The style property for justify-content.
+     *
+     * @since 24.3
      */
     public static final String STYLE_JUSTIFY_CONTENT = "justify-content";
     /**
      * The style property for flex-direction.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FLEX_DIRECTION = "flex-direction";
     /**
      * The style property for flex-basis.
+     *
+     * @since 24.3
      */
     public static final String STYLE_FLEX_BASIS = "flex-basis";
 
     /**
      * The label property.
+     *
+     * @since 4.0
      */
     public static final String LABEL_PROPERTY_NAME = "label";
     /**
      * The aria-label property.
      *
      * @deprecated use {@link #ARIA_LABEL_ATTRIBUTE_NAME} instead
+     * @since 9.0
      */
     public static final String ARIA_LABEL_PROPERTY_NAME = "aria-label";
     /**
      * The aria-label attribute.
+     *
+     * @since 24.1
      */
     public static final String ARIA_LABEL_ATTRIBUTE_NAME = "aria-label";
     /**
      * The aria-labelledby attribute.
+     *
+     * @since 24.1
      */
     public static final String ARIA_LABELLEDBY_ATTRIBUTE_NAME = "aria-labelledby";
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
@@ -248,6 +248,7 @@ public class ElementUtil {
      * @param node
      *            JSoup node to convert
      * @return element with the matching hierarchy as the given node, or empty
+     * @since 2.2
      */
     public static Optional<Element> fromJsoup(Node node) {
         Element ret;
@@ -313,6 +314,7 @@ public class ElementUtil {
      *            {@code true} for ignoring parent inert, {@code false} for not
      *            ignoring
      * @see #setInert(Element, boolean)
+     * @since 23.0
      */
     public static void setIgnoreParentInert(Element element,
             boolean ignoreParentInert) {
@@ -339,6 +341,7 @@ public class ElementUtil {
      * @param inert
      *            {@code true} for inert
      * @see #setIgnoreParentInert(Element, boolean)
+     * @since 23.0
      */
     public static void setInert(Element element, boolean inert) {
         final Optional<InertData> optionalInertData = element.getNode()
@@ -360,6 +363,7 @@ public class ElementUtil {
      *            the state node, not <code>null</code>
      * @return the element for the node, or an empty Optional if the state node
      *         is not mapped to any particular element.
+     * @since 24.2.4
      */
     public static Optional<Element> from(StateNode node) {
         assert node != null;

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -146,6 +146,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * @param children
      *            the element(s) to add
      * @return this element
+     * @since 23.2
      */
     public N appendChild(Collection<Element> children) {
         if (children == null) {
@@ -190,6 +191,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * @param children
      *            the element(s) to add
      * @return this element
+     * @since 23.2
      */
     public N appendVirtualChild(Collection<Element> children) {
         if (children == null) {
@@ -341,6 +343,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * @param children
      *            the child element(s) to insert
      * @return this element
+     * @since 23.2
      */
     public N insertChild(int index, Collection<Element> children) {
         if (children == null) {
@@ -470,6 +473,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * @param children
      *            the child element(s) to remove
      * @return this element
+     * @since 23.2
      */
     public N removeChild(Collection<Element> children) {
         if (children == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
@@ -99,6 +99,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setBackground(String value) {
         return set(STYLE_BACKGROUND, value);
@@ -111,6 +112,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setBackgroundColor(String value) {
         return set(STYLE_BACKGROUND_COLOR, value);
@@ -123,6 +125,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.9
      */
     default Style setBackgroundPosition(String value) {
         return set(STYLE_BACKGROUND_POSITION, value);
@@ -135,6 +138,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.9
      */
     default Style setBackgroundSize(String value) {
         return set(STYLE_BACKGROUND_SIZE, value);
@@ -147,6 +151,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setBorder(String value) {
         return set(STYLE_BORDER, value);
@@ -159,6 +164,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setBorderLeft(String value) {
         return set(STYLE_BORDER_LEFT, value);
@@ -171,6 +177,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setBorderRight(String value) {
         return set(STYLE_BORDER_RIGHT, value);
@@ -183,6 +190,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setBorderTop(String value) {
         return set(STYLE_BORDER_TOP, value);
@@ -195,6 +203,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setBorderBottom(String value) {
         return set(STYLE_BORDER_BOTTOM, value);
@@ -207,11 +216,15 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setBorderRadius(String value) {
         return set(STYLE_BORDER_RADIUS, value);
     }
 
+    /**
+     * @since 24.1
+     */
     public enum BoxSizing {
         CONTENT_BOX, BORDER_BOX, INITIAL, INHERIT
     }
@@ -223,6 +236,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setBoxSizing(BoxSizing value) {
         return applyOrErase(STYLE_BOX_SIZING, value);
@@ -235,6 +249,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setBoxShadow(String value) {
         return set(STYLE_BOX_SHADOW, value);
@@ -242,6 +257,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the clear property.
+     *
+     * @since 24.1
      */
     public enum Clear {
         NONE, LEFT, RIGHT, BOTH, INITIAL, INHERIT
@@ -254,6 +271,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setClear(Clear value) {
         return applyOrErase(STYLE_CLEAR, value);
@@ -266,6 +284,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setCursor(String value) {
         return set(STYLE_CURSOR, value);
@@ -278,6 +297,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setColor(String value) {
         return set(STYLE_COLOR, value);
@@ -290,11 +310,15 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.9
      */
     default Style setFilter(String value) {
         return applyOrErase(STYLE_FILTER, value);
     }
 
+    /**
+     * @since 24.1
+     */
     public enum Display {
         INLINE,
         BLOCK,
@@ -328,6 +352,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setDisplay(Display value) {
         return applyOrErase(STYLE_DISPLAY, value);
@@ -336,6 +361,8 @@ public interface Style extends Serializable {
     // PostFixed with "Css" to avoid a collision with java.lang.Float
     /**
      * Css values for the float property.
+     *
+     * @since 24.1
      */
     public enum FloatCss {
         NONE, LEFT, RIGHT, INITIAL, INHERIT
@@ -348,6 +375,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setFloat(FloatCss value) {
         return applyOrErase(STYLE_FLOAT, value);
@@ -360,6 +388,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setFont(String value) {
         return set(STYLE_FONT, value);
@@ -372,6 +401,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.9
      */
     default Style setGap(String value) {
         return applyOrErase(STYLE_GAP, value);
@@ -384,6 +414,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setHeight(String value) {
         return set(STYLE_HEIGHT, value);
@@ -396,6 +427,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMinHeight(String value) {
         return set(STYLE_MIN_HEIGHT, value);
@@ -408,6 +440,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMaxHeight(String value) {
         return set(STYLE_MAX_HEIGHT, value);
@@ -420,6 +453,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setMargin(String value) {
         return set(STYLE_MARGIN, value);
@@ -432,6 +466,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMarginLeft(String value) {
         return set(STYLE_MARGIN_LEFT, value);
@@ -444,6 +479,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMarginRight(String value) {
         return set(STYLE_MARGIN_RIGHT, value);
@@ -456,6 +492,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMarginTop(String value) {
         return set(STYLE_MARGIN_TOP, value);
@@ -468,6 +505,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMarginBottom(String value) {
         return set(STYLE_MARGIN_BOTTOM, value);
@@ -480,6 +518,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMarginInlineStart(String value) {
         return set(STYLE_MARGIN_INLINE_START, value);
@@ -492,6 +531,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMarginInlineEnd(String value) {
         return set(STYLE_MARGIN_INLINE_END, value);
@@ -504,6 +544,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setOutline(String value) {
         return set(STYLE_OUTLINE, value);
@@ -516,11 +557,15 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setOpacity(String value) {
         return set(STYLE_OPACITY, value);
     }
 
+    /**
+     * @since 24.1
+     */
     public enum Overflow {
         VISIBLE, HIDDEN, CLIP, SCROLL, AUTO, INITIAL, INHERIT
     }
@@ -532,6 +577,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setOverflow(Overflow value) {
         return applyOrErase(STYLE_OVERFLOW, value);
@@ -544,6 +590,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setPadding(String value) {
         return set(STYLE_PADDING, value);
@@ -556,6 +603,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setPaddingLeft(String value) {
         return set(STYLE_PADDING_LEFT, value);
@@ -568,6 +616,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setPaddingRight(String value) {
         return set(STYLE_PADDING_RIGHT, value);
@@ -580,6 +629,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setPaddingTop(String value) {
         return set(STYLE_PADDING_TOP, value);
@@ -592,6 +642,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setPaddingBottom(String value) {
         return set(STYLE_PADDING_BOTTOM, value);
@@ -599,6 +650,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the position property.
+     *
+     * @since 24.1
      */
     public enum Position {
         STATIC, RELATIVE, ABSOLUTE, FIXED, STICKY;
@@ -611,6 +664,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setPosition(Position value) {
         return applyOrErase(STYLE_POSITION, value);
@@ -623,6 +677,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.9
      */
     default Style setRotate(String value) {
         return applyOrErase(STYLE_ROTATE, value);
@@ -635,6 +690,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setScale(String value) {
         return set(STYLE_SCALE, value);
@@ -642,6 +698,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the text-align property.
+     *
+     * @since 24.1
      */
     public enum TextAlign {
         LEFT, RIGHT, CENTER, JUSTIFY, INITIAL, INHERIT
@@ -654,6 +712,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setTextAlign(TextAlign value) {
         return applyOrErase(STYLE_TEXT_ALIGN, value);
@@ -666,6 +725,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setTextDecoration(String value) {
         return set(STYLE_TEXT_DECORATION, value);
@@ -678,6 +738,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setTransform(String value) {
         return set(STYLE_TRANSFORM, value);
@@ -690,6 +751,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.4
      */
     default Style setTransformOrigin(String value) {
         return set(STYLE_TRANSFORM_ORIGIN, value);
@@ -702,6 +764,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setTransition(String value) {
         return set(STYLE_TRANSITION, value);
@@ -709,6 +772,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the visibility property.
+     *
+     * @since 24.1
      */
     public enum Visibility {
         VISIBLE, HIDDEN, COLLAPSE, INITIAL, INHERIT
@@ -721,6 +786,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setVisibility(Visibility value) {
         return applyOrErase(STYLE_VISIBILITY, value);
@@ -733,6 +799,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setWidth(String value) {
         return set(STYLE_WIDTH, value);
@@ -745,6 +812,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMinWidth(String value) {
         return set(STYLE_MIN_WIDTH, value);
@@ -757,6 +825,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setMaxWidth(String value) {
         return set(STYLE_MAX_WIDTH, value);
@@ -764,6 +833,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the white-space property.
+     *
+     * @since 24.1
      */
     public enum WhiteSpace {
         NORMAL, NOWRAP, PRE, PRE_LINE, PRE_WRAP, BREAK_SPACES, INITIAL, INHERIT
@@ -776,6 +847,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setWhiteSpace(WhiteSpace value) {
         return applyOrErase(STYLE_WHITE_SPACE, value);
@@ -788,6 +860,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setLeft(String value) {
         return set(STYLE_LEFT, value);
@@ -800,6 +873,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setRight(String value) {
         return set(STYLE_RIGHT, value);
@@ -812,6 +886,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setTop(String value) {
         return set(STYLE_TOP, value);
@@ -824,6 +899,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setBottom(String value) {
         return set(STYLE_BOTTOM, value);
@@ -836,6 +912,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.1
      */
     default Style setZIndex(Integer value) {
         return applyOrErase(STYLE_Z_INDEX, value);
@@ -843,6 +920,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the <code>font-weight</code> property.
+     *
+     * @since 24.3
      */
     public enum FontWeight {
         NORMAL, LIGHTER, BOLD, BOLDER, INITIAL, INHERIT
@@ -855,6 +934,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFontWeight(FontWeight value) {
         return applyOrErase(STYLE_FONT_WEIGHT, value);
@@ -867,6 +947,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFontWeight(Integer value) {
         return applyOrErase(STYLE_FONT_WEIGHT, value);
@@ -879,6 +960,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFontWeight(String value) {
         return set(STYLE_FONT_WEIGHT, value);
@@ -891,6 +973,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFontSize(String value) {
         return set(STYLE_FONT_SIZE, value);
@@ -903,6 +986,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setLineHeight(String value) {
         return set(STYLE_LINE_HEIGHT, value);
@@ -910,6 +994,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the <code>align-items</code> property.
+     *
+     * @since 24.3
      */
     public enum AlignItems {
         NORMAL,
@@ -934,6 +1020,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setAlignItems(AlignItems value) {
         return applyOrErase(STYLE_ALIGN_ITEMS, value);
@@ -941,6 +1028,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the <code>align-self</code> property.
+     *
+     * @since 24.3
      */
     public enum AlignSelf {
         AUTO,
@@ -966,6 +1055,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setAlignSelf(AlignSelf value) {
         return applyOrErase(STYLE_ALIGN_SELF, value);
@@ -973,6 +1063,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the <code>flex-wrap</code> property.
+     *
+     * @since 24.3
      */
     public enum FlexWrap {
         NOWRAP, WRAP, WRAP_REVERSE, INITIAL
@@ -985,6 +1077,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFlexWrap(FlexWrap value) {
         return applyOrErase(STYLE_FLEX_WRAP, value);
@@ -997,6 +1090,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFlexGrow(String value) {
         return set(STYLE_FLEX_GROW, value);
@@ -1009,6 +1103,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFlexShrink(String value) {
         return set(STYLE_FLEX_SHRINK, value);
@@ -1016,6 +1111,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the <code>justify-content</code> property.
+     *
+     * @since 24.3
      */
     public enum JustifyContent {
         CENTER,
@@ -1042,6 +1139,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setJustifyContent(JustifyContent value) {
         return applyOrErase(STYLE_JUSTIFY_CONTENT, value);
@@ -1049,6 +1147,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the <code>justify-content</code> property.
+     *
+     * @since 24.3
      */
     public enum FlexDirection {
         ROW, ROW_REVERSE, COLUMN, COLUMN_REVERSE, INITIAL
@@ -1061,6 +1161,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFlexDirection(FlexDirection value) {
         return applyOrErase(STYLE_FLEX_DIRECTION, value);
@@ -1068,6 +1169,8 @@ public interface Style extends Serializable {
 
     /**
      * Css values for the <code>flex-basis</code> property.
+     *
+     * @since 24.3
      */
     public enum FlexBasis {
         AUTO, MAX_CONTENT, MIN_CONTENT, FIT_CONTENT, CONTENT, INITIAL
@@ -1080,6 +1183,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFlexBasis(FlexBasis value) {
         return applyOrErase(STYLE_FLEX_BASIS, value);
@@ -1092,6 +1196,7 @@ public interface Style extends Serializable {
      *            the style property value (if <code>null</code>, the property
      *            will be removed)
      * @return this style instance
+     * @since 24.3
      */
     default Style setFlexBasis(String value) {
         return set(STYLE_FLEX_BASIS, value);

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -69,6 +69,7 @@ public interface DeploymentConfiguration
      * resynchronization of the application state from the server.
      *
      * @return The maximum message suspension timeout
+     * @since 3.0.1
      */
     int getMaxMessageSuspendTimeout();
 
@@ -77,6 +78,7 @@ public interface DeploymentConfiguration
      * reconnect before removing the server-side component from memory.
      *
      * @return time to wait after a disconnect has happened
+     * @since 2.0
      */
     int getWebComponentDisconnect();
 
@@ -121,6 +123,7 @@ public interface DeploymentConfiguration
      * communication should use.
      *
      * @return The push servlet mapping to use
+     * @since 23.3.5
      */
     default String getPushServletMapping() {
         return "";
@@ -219,6 +222,7 @@ public interface DeploymentConfiguration
      *
      * @return <code>true</code> to serve precompressed Brotli files,
      *         <code>false</code> to not serve Brotli files.
+     * @since 1.3
      */
     default boolean isBrotli() {
         return getBooleanProperty(InitParameters.SERVLET_PARAMETER_BROTLI,
@@ -238,6 +242,7 @@ public interface DeploymentConfiguration
      * list of JS files to load.
      *
      * @return polyfills to load
+     * @since 2.0
      */
     default List<String> getPolyfills() {
         return Arrays
@@ -252,6 +257,7 @@ public interface DeploymentConfiguration
      * or through the classpath.
      *
      * @return true if stats.json is served from an external location
+     * @since 2.2
      */
     default boolean isStatsExternal() {
         return getBooleanProperty(Constants.EXTERNAL_STATS_FILE, false);
@@ -262,6 +268,7 @@ public interface DeploymentConfiguration
      * this will default to '/vaadin-static/VAADIN/config/stats.json'
      *
      * @return external stats.json location
+     * @since 2.2
      */
     default String getExternalStatsUrl() {
         return getStringProperty(Constants.EXTERNAL_STATS_URL,
@@ -285,6 +292,7 @@ public interface DeploymentConfiguration
      * is actually requested by the user, saving some server resources.
      *
      * @return true if initial UIDL should be included in page
+     * @since 3.0
      */
     default boolean isEagerServerLoad() {
         return getBooleanProperty(InitParameters.SERVLET_PARAMETER_INITIAL_UIDL,
@@ -299,6 +307,7 @@ public interface DeploymentConfiguration
      *
      * @return {@code true} if dev mode live reload is enabled, {@code false}
      *         otherwise
+     * @since 3.1
      */
     boolean isDevModeLiveReloadEnabled();
 
@@ -307,6 +316,7 @@ public interface DeploymentConfiguration
      * production mode. In development mode, it is enabled by default.
      *
      * @return {@code true} if dev tools are enabled, {@code false} otherwise
+     * @since 23.1
      */
     boolean isDevToolsEnabled();
 
@@ -317,6 +327,7 @@ public interface DeploymentConfiguration
      * By default, it returns {@link SessionLockCheckStrategy#ASSERT}.
      *
      * @return the lock checking strategy, never null.
+     * @since 24.4
      */
     default SessionLockCheckStrategy getSessionLockCheckStrategy() {
         return SessionLockCheckStrategy.ASSERT;
@@ -327,6 +338,7 @@ public interface DeploymentConfiguration
      * instead of Vaadin router.
      *
      * @return {@code true} if React is used, default is {@code true}
+     * @since 24.4
      */
     default boolean isReactEnabled() {
         return getBooleanProperty(InitParameters.REACT_ENABLE, true);
@@ -340,6 +352,7 @@ public interface DeploymentConfiguration
      * application.
      *
      * @return this application's name
+     * @since 24.5
      */
     default String getApplicationName() {
         return getStringProperty(InitParameters.APPLICATION_IDENTIFIER,

--- a/flow-server/src/main/java/com/vaadin/flow/function/VaadinApplicationInitializationBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/VaadinApplicationInitializationBootstrap.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.server.VaadinContext;
  * depends on {@link Lookup} presence.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -98,6 +98,8 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
      * Configuration name for the system parameter that determines whether
      * Hotswapper should always trigger a full page reload instead of computing
      * an appropriate UI refresh strategy.
+     *
+     * @since 24.7.1
      */
     public static final String FORCE_RELOAD_PROPERTY = "vaadin.hotswap.forcePageReload";
 
@@ -577,6 +579,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
      *            {@literal true} to always force a page reload,
      *            {@literal false} to let the {@link Hotswapper} decide the
      *            refresh strategy.
+     * @since 24.7.1
      */
     public static void forcePageReload(VaadinService vaadinService,
             boolean forceReload) {
@@ -591,6 +594,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
      *            the {@link VaadinService} instance.
      * @return {@literal true} if full page reload if forced, otherwise
      *         {@literal false}.
+     * @since 24.7.1
      */
     public static boolean isForcedPageReload(VaadinService vaadinService) {
         return getForceReloadHolder(vaadinService).isActive();

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/VaadinHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/VaadinHotswapper.java
@@ -96,6 +96,7 @@ public interface VaadinHotswapper {
      *
      * @param event
      *            an event containing information about the hotswap operation.
+     * @since 24.5.3
      */
     default void onHotswapComplete(HotswapCompleteEvent event) {
         // no-op by default

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/impl/ErrorViewHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/impl/ErrorViewHotswapper.java
@@ -23,7 +23,7 @@ import java.util.Set;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 25.0
+ * @since 24.9.12
  */
 @Priority(100)
 public class ErrorViewHotswapper implements VaadinHotswapper {

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/DefaultI18NProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/DefaultI18NProvider.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Default i18n provider that will be initialized if custom {@link I18NProvider}
  * is not available.
+ *
+ * @since 24.3
  */
 public class DefaultI18NProvider implements I18NProvider {
 
@@ -55,6 +57,7 @@ public class DefaultI18NProvider implements I18NProvider {
      *            locale.
      * @param classLoader
      *            ClassLoader to use for loading translation bundles.
+     * @since 24.3.9
      */
     public DefaultI18NProvider(List<Locale> providedLocales,
             ClassLoader classLoader) {

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
@@ -61,6 +61,7 @@ public interface I18NProvider extends Serializable {
      * @param params
      *            parameters used in translation string
      * @return translation for key if found
+     * @since 23.2
      */
     default String getTranslation(Object key, Locale locale, Object... params) {
         return getTranslation(key.toString(), locale, params);
@@ -74,6 +75,7 @@ public interface I18NProvider extends Serializable {
      *            locale to use
      * @return a map of all available translations (the default implementation
      *         just returns an empty map)
+     * @since 24.8
      */
     default Map<String, String> getAllTranslations(Locale locale) {
         return Map.of();
@@ -89,6 +91,7 @@ public interface I18NProvider extends Serializable {
      * @param locale
      *            locale to use
      * @return a map of translations
+     * @since 24.8
      */
     default Map<String, String> getTranslations(Collection<String> keys,
             Locale locale) {
@@ -108,6 +111,7 @@ public interface I18NProvider extends Serializable {
      * @return translation for key if found
      * @throws IllegalStateException
      *             thrown if no I18NProvider found from the VaadinService
+     * @since 24.5
      */
     static String translate(String key, Object... params) {
         return translate(LocaleUtil.getLocale(), key, params);
@@ -126,6 +130,7 @@ public interface I18NProvider extends Serializable {
      * @return translation for key if found
      * @throws IllegalStateException
      *             thrown if no I18NProvider found from the VaadinService
+     * @since 24.5
      */
     static String translate(Locale locale, String key, Object... params) {
         return LocaleUtil.getI18NProvider()

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/I18NUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/I18NUtil.java
@@ -32,6 +32,8 @@ import static com.vaadin.flow.i18n.DefaultI18NProvider.BUNDLE_FOLDER;
  * locales.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.3
  */
 public final class I18NUtil {
 
@@ -45,6 +47,7 @@ public final class I18NUtil {
      * For internal use only. May be renamed or removed in a future release.
      *
      * @return {@code true} if default property file found
+     * @since 24.3.9
      */
     public static boolean containsDefaultTranslation(ClassLoader classLoader) {
         URL resource = classLoader.getResource(DefaultI18NProvider.BUNDLE_FOLDER
@@ -64,6 +67,7 @@ public final class I18NUtil {
      * For internal use only. May be renamed or removed in a future release.
      *
      * @return List of locales parsed from property files.
+     * @since 24.3.9
      */
     public static List<Locale> getDefaultTranslationLocales(
             ClassLoader classLoader) {

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/LocaleChangeEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/LocaleChangeEvent.java
@@ -49,6 +49,7 @@ public class LocaleChangeEvent extends EventObject {
      * Returns the UI where the locale changed in.
      *
      * @return the ui
+     * @since 3.1
      */
     public UI getUI() {
         return (UI) getSource();

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/TranslationFileRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/TranslationFileRequestHandler.java
@@ -103,6 +103,7 @@ public class TranslationFileRequestHandler extends SynchronizedRequestHandler
      *         handler does not handle the given request type
      * @throws IOException
      *             if an IO error occurred
+     * @since 24.9.11
      */
     @Override
     public boolean handleSessionExpired(VaadinRequest request,

--- a/flow-server/src/main/java/com/vaadin/flow/internal/AnnotationReader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/AnnotationReader.java
@@ -60,6 +60,7 @@ public class AnnotationReader {
      * @return a list the CssImport annotations found
      * @see #getAnnotationFor(Class, Class) for what order the annotations are
      *      in the list
+     * @since 2.0.12
      */
     public static List<CssImport> getCssImportAnnotations(
             Class<? extends Component> componentClass) {
@@ -88,6 +89,7 @@ public class AnnotationReader {
      * @param componentClass
      *            the component class to search for the annotation
      * @return a list the JavaScript annotations found
+     * @since 2.0
      */
     public static List<JsModule> getJsModuleAnnotations(
             Class<? extends Component> componentClass) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ApplicationClassLoaderAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ApplicationClassLoaderAccess.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.server.VaadinContext;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
@@ -27,6 +27,8 @@ import jakarta.servlet.http.HttpServletRequest;
  * Helper methods for use in bootstrapping.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 4.0
  */
 public final class BootstrapHandlerHelper implements Serializable {
 
@@ -140,6 +142,7 @@ public final class BootstrapHandlerHelper implements Serializable {
      * @param pushServletMapping
      *            Original pushServletMapping value
      * @return cleaned-up value, or null if the original value is blank.
+     * @since 23.3.5
      */
     public static String getCleanedPushServletMapping(
             String pushServletMapping) {
@@ -167,6 +170,7 @@ public final class BootstrapHandlerHelper implements Serializable {
      *            {@link ServletConfig} to find the registration for.
      * @return an optional {@link ServletRegistration}, or an empty optional if
      *         a registration is not available.
+     * @since 23.3.5
      */
     public static Optional<ServletRegistration> getServletRegistration(
             ServletConfig servletConfig) {
@@ -191,6 +195,7 @@ public final class BootstrapHandlerHelper implements Serializable {
      *            {@link ServletRegistration} from which to look up the
      *            mappings.
      * @return first URL mapping, ignoring '/VAADIN/*' and '/vaadinServlet/*'
+     * @since 23.3.5
      */
     public static String findFirstUrlMapping(ServletRegistration registration) {
         String firstMapping = registration.getMappings().stream()

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.server.communication.FragmentedMessageHolder;
  *
  * @author Vaadin Ltd
  *
+ * @since 3.1
  */
 public interface BrowserLiveReload extends FragmentedMessageHolder {
 
@@ -85,6 +86,7 @@ public interface BrowserLiveReload extends FragmentedMessageHolder {
      * @param refreshLayouts
      *            {@code true} to refresh all layouts in the route chain,
      *            {@code false} to only refresh the route component
+     * @since 24.5
      */
     default void refresh(boolean refreshLayouts) {
         reload();
@@ -97,6 +99,7 @@ public interface BrowserLiveReload extends FragmentedMessageHolder {
      *            the path of the file to update, relative to the servlet path
      * @param content
      *            the new content of the file
+     * @since 24.1
      */
     void update(String path, String content);
 
@@ -107,6 +110,7 @@ public interface BrowserLiveReload extends FragmentedMessageHolder {
      *            the atmosphere resource that received the message
      * @param msg
      *            the received message
+     * @since 23.1
      */
     void onMessage(AtmosphereResource resource, String msg);
 
@@ -117,6 +121,7 @@ public interface BrowserLiveReload extends FragmentedMessageHolder {
      *            the event name
      * @param eventData
      *            the event data
+     * @since 24.8
      */
     void sendHmrEvent(String event, JsonNode eventData);
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadAccess.java
@@ -18,6 +18,7 @@ import com.vaadin.flow.server.VaadinService;
  * plugins.
  *
  * @deprecated Use {@link BrowserLiveReloadAccessor} instead
+ * @since 24.0.8
  */
 @Deprecated
 public class BrowserLiveReloadAccess {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadAccessor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadAccessor.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 8.0
  *
  */
 public interface BrowserLiveReloadAccessor {
@@ -70,6 +70,7 @@ public interface BrowserLiveReloadAccessor {
      *            a Vaadin Context
      * @return an {@link Optional} containing a {@link BrowserLiveReload}
      *         instance or <code>EMPTY</code> if disabled or in production mode
+     * @since 24.0
      */
     static Optional<BrowserLiveReload> getLiveReloadFromContext(
             VaadinContext context) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ConstantPoolKey.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ConstantPoolKey.java
@@ -44,6 +44,7 @@ public class ConstantPoolKey implements Serializable {
      *
      * @param json
      *            the JSON constant, not <code>null</code>
+     * @since 24.8
      */
     public ConstantPoolKey(JsonNode json) {
         assert json != null;
@@ -84,6 +85,7 @@ public class ConstantPoolKey implements Serializable {
      * @param clientConstantPoolUpdate
      *            the constant pool update that is to be sent to the client, not
      *            <code>null</code>
+     * @since 24.8
      */
     public void export(ObjectNode clientConstantPoolUpdate) {
         clientConstantPoolUpdate.set(getId(), json);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
@@ -16,6 +16,9 @@ import java.net.HttpURLConnection;
 
 import com.vaadin.flow.server.RequestHandler;
 
+/**
+ * @since 8.0
+ */
 public interface DevModeHandler extends RequestHandler {
 
     /**
@@ -62,6 +65,7 @@ public interface DevModeHandler extends RequestHandler {
      * Gets the project root folder.
      *
      * @return the project root folder
+     * @since 9.0
      */
     File getProjectRoot();
 
@@ -69,6 +73,7 @@ public interface DevModeHandler extends RequestHandler {
      * Get the listening port of the dev server.
      *
      * @return the listening port
+     * @since 23.1
      */
     int getPort();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.server.startup.VaadinInitializerException;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 8.0
  *
  */
 public interface DevModeHandlerManager {
@@ -55,6 +55,7 @@ public interface DevModeHandlerManager {
     /**
      * Stops a running {@link DevModeHandler}.
      *
+     * @since 23.3
      */
     void stopDevModeHandler();
 
@@ -63,6 +64,7 @@ public interface DevModeHandlerManager {
      *
      * @param devModeHandler
      *            the dev mode handler to use
+     * @since 9.0
      */
     void setDevModeHandler(DevModeHandler devModeHandler);
 
@@ -79,6 +81,7 @@ public interface DevModeHandlerManager {
      *
      * @param url
      *            the url to open
+     * @since 23.3
      */
     void launchBrowserInDevelopmentMode(String url);
 
@@ -89,6 +92,7 @@ public interface DevModeHandlerManager {
      *
      * @param applicationUrl
      *            the application url
+     * @since 24.5
      */
     void setApplicationUrl(String applicationUrl);
 
@@ -97,6 +101,7 @@ public interface DevModeHandlerManager {
      *
      * @param command
      *            the command to run
+     * @since 24.5
      */
     void registerShutdownCommand(Command command);
 
@@ -119,6 +124,7 @@ public interface DevModeHandlerManager {
      *            the Vaadin context
      * @return an {@link Optional} containing a {@link DevModeHandler} instance
      *         or <code>EMPTY</code> if disabled
+     * @since 9.0
      */
     static Optional<DevModeHandler> getDevModeHandler(VaadinContext context) {
         return Optional.ofNullable(context)

--- a/flow-server/src/main/java/com/vaadin/flow/internal/EncodeUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/EncodeUtil.java
@@ -78,6 +78,7 @@ public final class EncodeUtil {
      * @param value
      *            the string to encode, not <code>null</code>
      * @return the encoded string
+     * @since 24.8.7
      */
     public static String rfc2047Encode(String value) {
         byte[] source = value.getBytes(UTF_8);
@@ -112,6 +113,7 @@ public final class EncodeUtil {
      *            the string to check, not <code>null</code>
      * @return <code>true</code> if the string contains only US-ASCII
      *         characters,
+     * @since 24.8.7
      */
     public static boolean isPureUSASCII(String text) {
         return StandardCharsets.US_ASCII.newEncoder().canEncode(text);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
@@ -93,6 +93,7 @@ public final class JacksonUtils {
      * Create a nullNode for null value.
      *
      * @return NullNode
+     * @since 24.8
      */
     public static ValueNode nullNode() {
         return (ValueNode) objectMapper.nullNode();
@@ -105,6 +106,7 @@ public final class JacksonUtils {
      *            JsonArray to change
      * @return ArrayNode of elemental json array object or null for null
      *         jsonArray
+     * @since 24.8
      */
     public static ArrayNode mapElemental(JsonArray jsonArray) {
         if (jsonArray == null || jsonArray instanceof JsonNull) {
@@ -124,6 +126,7 @@ public final class JacksonUtils {
      *            JsonObject to change
      * @return ObjectNode of elemental json object object or null for null
      *         jsonObject
+     * @since 24.8
      */
     public static ObjectNode mapElemental(JsonObject jsonObject) {
         if (jsonObject == null) {
@@ -142,6 +145,7 @@ public final class JacksonUtils {
      * @param jsonValue
      *            JsonValue to change
      * @return ObjectNode of elemental json value
+     * @since 24.8
      */
     public static BaseJsonNode mapElemental(JsonValue jsonValue) {
         if (jsonValue == null || jsonValue instanceof JsonNull) {
@@ -169,6 +173,7 @@ public final class JacksonUtils {
      * @param jsonNodes
      *            ArrayNode to convert
      * @return JsonArray of ArrayNode content
+     * @since 24.8
      */
     public static JsonArray createElementalArray(ArrayNode jsonNodes) {
         return (JsonArray) parseNode(jsonNodes);
@@ -548,6 +553,7 @@ public final class JacksonUtils {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.8
      */
     public static <T> T readToObject(JsonNode jsonObject, Class<T> tClass) {
         Objects.requireNonNull(jsonObject, CANNOT_CONVERT_NULL_TO_OBJECT);
@@ -569,6 +575,7 @@ public final class JacksonUtils {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.8
      */
     public static <T> T readValue(JsonNode jsonValue, Class<T> tClass) {
         return readToObject(jsonValue, tClass);
@@ -584,6 +591,7 @@ public final class JacksonUtils {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.8
      */
     public static <T> T readValue(JsonNode jsonValue,
             TypeReference<T> typeReference) {
@@ -633,6 +641,7 @@ public final class JacksonUtils {
      * @param keyPath
      *            the nested key path
      * @return the value of the last key found, or {@code null}
+     * @since 24.10.3
      */
     public static JsonNode getNestedKey(ObjectNode objectNode,
             List<String> keyPath) {
@@ -670,6 +679,7 @@ public final class JacksonUtils {
      *            a function that converts intermediate {@code null} and
      *            non-{@code ObjectNode} values into {@code ObjectNode}s when
      *            necessary for recursive traversal
+     * @since 24.10.3
      */
     public static void setNestedKey(ObjectNode objectNode, List<String> keyPath,
             JsonNode valueNode,
@@ -703,6 +713,7 @@ public final class JacksonUtils {
      *            the root object containing to process
      * @param keyPath
      *            the nested key path
+     * @since 24.10.3
      */
     public static void removeNestedKey(ObjectNode objectNode,
             List<String> keyPath) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -56,6 +56,8 @@ public class JsonCodec {
     /**
      * Type id for a complex type array identifying a
      * {@link ReturnChannelRegistration} reference.
+     *
+     * @since 2.0
      */
     public static final int RETURN_CHANNEL_TYPE = 2;
 
@@ -141,6 +143,7 @@ public class JsonCodec {
      * @param type
      *            the type to check
      * @return whether the type can be encoded
+     * @since 2.2
      */
     public static boolean canEncodeWithTypeInfo(Class<?> type) {
         return canEncodeWithoutTypeInfo(type)

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonUtils.java
@@ -311,6 +311,7 @@ public final class JsonUtils {
      * @param bean
      *            the bean to convert, not {@code null}
      * @return a JSON representation of the bean
+     * @since 4.0
      */
     public static JsonObject beanToJson(Object bean) {
         Objects.requireNonNull(bean, CANNOT_CONVERT_NULL_TO_A_JSON_OBJECT);
@@ -328,6 +329,7 @@ public final class JsonUtils {
      * @param list
      *            the list to convert, not {@code null}
      * @return a JSON representation of the bean
+     * @since 4.0
      */
     public static JsonArray listToJson(List<?> list) {
         Objects.requireNonNull(list, CANNOT_CONVERT_NULL_TO_A_JSON_OBJECT);
@@ -344,6 +346,7 @@ public final class JsonUtils {
      * @param map
      *            the map to convert, not {@code null}
      * @return a JSON representation of the bean
+     * @since 4.0
      */
     public static JsonObject mapToJson(Map<String, ?> map) {
         Objects.requireNonNull(map, CANNOT_CONVERT_NULL_TO_A_JSON_OBJECT);
@@ -364,6 +367,7 @@ public final class JsonUtils {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.1
      */
     public static <T> T readToObject(JsonObject jsonObject, Class<T> tClass) {
         Objects.requireNonNull(jsonObject, CANNOT_CONVERT_NULL_TO_OBJECT);
@@ -385,6 +389,7 @@ public final class JsonUtils {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.4
      */
     public static <T> T readValue(JsonValue jsonValue, Class<T> tClass) {
         Objects.requireNonNull(jsonValue, CANNOT_CONVERT_NULL_TO_OBJECT);
@@ -406,6 +411,7 @@ public final class JsonUtils {
      * @return converted object instance
      * @param <T>
      *            type of result instance
+     * @since 24.4
      */
     public static <T> T readValue(JsonValue jsonValue,
             TypeReference<T> typeReference) {
@@ -424,6 +430,7 @@ public final class JsonUtils {
      * @param object
      *            Java object to convert
      * @return converted JSON value
+     * @since 24.4
      */
     public static JsonValue writeValue(Object object) {
         try {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/LocaleUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/LocaleUtil.java
@@ -88,6 +88,7 @@ public final class LocaleUtil {
      * <p>
      *
      * @return the optional value of I18nProvider
+     * @since 24.0.4
      */
     public static Optional<I18NProvider> getI18NProvider() {
         return Optional.ofNullable(VaadinService.getCurrent())
@@ -105,6 +106,7 @@ public final class LocaleUtil {
      * @param i18NProvider
      *            - supplier for the i18n provider
      * @return the locale for the UI
+     * @since 24.0.4
      */
     public static Locale getLocale(
             Supplier<Optional<I18NProvider>> i18NProvider) {
@@ -124,6 +126,7 @@ public final class LocaleUtil {
      * -> if I18NProvider is null, then default locale is returned.
      *
      * @return the locale for the UI
+     * @since 24.5
      */
     public static Locale getLocale() {
         return getLocale(LocaleUtil::getI18NProvider);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/MessageDigestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/MessageDigestUtil.java
@@ -49,6 +49,7 @@ public class MessageDigestUtil {
      *            the string to hash
      *
      * @return 32 bytes making up the hash
+     * @since 24.0
      */
     public static byte[] sha256(String string, Charset charset) {
         return getSha256(null).digest(string.getBytes(charset));
@@ -64,6 +65,7 @@ public class MessageDigestUtil {
      *            salt to be added into hash calculation
      *
      * @return 32 bytes making up the hash
+     * @since 24.5
      */
     public static byte[] sha256(String string, byte[] salt, Charset charset) {
         return getSha256(salt).digest(string.getBytes(charset));
@@ -76,6 +78,7 @@ public class MessageDigestUtil {
      *            the byte array to hash
      *
      * @return sha256 hash string
+     * @since 24.7
      */
     public static String sha256Hex(byte[] content) {
         return sha256Hex(content, null);
@@ -89,6 +92,7 @@ public class MessageDigestUtil {
      * @param salt
      *            salt to be added to the calculation
      * @return sha256 hash string
+     * @since 24.7
      */
     public static String sha256Hex(byte[] content, byte[] salt) {
         byte[] digest = getSha256(salt).digest(content);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/NetworkUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/NetworkUtil.java
@@ -15,6 +15,8 @@ import java.net.ServerSocket;
  * Utility class for network related methods.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.0
  */
 public class NetworkUtil {
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/Pair.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/Pair.java
@@ -16,7 +16,7 @@ import java.io.Serializable;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since 1.0
+ * @since 2.0
  */
 public class Pair<U extends Serializable, V extends Serializable>
         implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ReflectTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ReflectTools.java
@@ -506,6 +506,7 @@ public class ReflectTools implements Serializable {
      * @param clazz
      *            instantiation target class
      * @return an IllegalArgumentException with descriptive message
+     * @since 24.5
      */
     public static IllegalArgumentException convertInstantiationException(
             Exception exception, Class<?> clazz) {
@@ -618,6 +619,7 @@ public class ReflectTools implements Serializable {
      * @param interfaceType
      *            class type of interface to get generic for
      * @return List of Class if found else empty List, never {@literal null}
+     * @since 23.1
      */
     public static List<Class<?>> getGenericInterfaceTypes(Class<?> clazz,
             Class<?> interfaceType) {
@@ -778,6 +780,7 @@ public class ReflectTools implements Serializable {
      *         if there is no shared ancestor. Or if the implementation treats
      *         bootstrap loaders as {@code null} (as per
      *         {@link ClassLoader#getParent()}).
+     * @since 2.0.1
      */
     public static Optional<ClassLoader> findClosestCommonClassLoaderAncestor(
             ClassLoader classLoaderA, ClassLoader classLoaderB) {
@@ -817,6 +820,7 @@ public class ReflectTools implements Serializable {
      *            annotation FQN
      * @return {@code true} is {@code element} has annotation whose FQN is
      *         {@code annotationFqn}, {@code false} otherwise
+     * @since 5.0
      */
     public static boolean hasAnnotation(AnnotatedElement element,
             String annotationFqn) {
@@ -833,6 +837,7 @@ public class ReflectTools implements Serializable {
      *            annotation simple name
      * @return {@code true} is {@code element} has annotation whose simple name
      *         is {@code simpleName}, {@code false} otherwise
+     * @since 6.0
      */
     public static boolean hasAnnotationWithSimpleName(AnnotatedElement element,
             String simpleName) {
@@ -849,6 +854,7 @@ public class ReflectTools implements Serializable {
      *            the method name
      * @return an optional value, or an empty optional if element has no
      *         annotation with required {@code annotationFqn}
+     * @since 5.0
      */
     public static Object getAnnotationMethodValue(Annotation annotation,
             String methodName) {
@@ -874,6 +880,7 @@ public class ReflectTools implements Serializable {
      *            annotation FQN
      * @return an optional annotation, or an empty optional if element has no
      *         annotation with required {@code annotationFqn}
+     * @since 5.0
      */
     public static Optional<Annotation> getAnnotation(AnnotatedElement element,
             String annotationFqn) {
@@ -892,6 +899,7 @@ public class ReflectTools implements Serializable {
      * @param clazz
      *            the class to check
      * @return true if the class can be instantiated, otherwise false
+     * @since 6.0
      */
     public static boolean isInstantiableService(Class<?> clazz) {
         if (clazz.isInterface()) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCache.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCache.java
@@ -134,6 +134,7 @@ public class ReflectionCache<C, T> {
      * @param action
      *            the action to run
      * @return a registration for removing the action
+     * @since 1.1
      */
     public static Registration addClearAllAction(Runnable action) {
         return Registration.addAndRemove(clearAllActions, action);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCacheHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCacheHotswapper.java
@@ -16,6 +16,8 @@ import com.vaadin.flow.server.VaadinService;
 /**
  * Clears all mappings from all reflection caches and related resources when one
  * or more classes has been changed.
+ *
+ * @since 24.5
  */
 public class ReflectionCacheHotswapper implements VaadinHotswapper {
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
@@ -81,6 +81,7 @@ public class ResponseWriter implements Serializable {
      *
      * @param deploymentConfiguration
      *            the deployment configuration to use, not <code>null</code>
+     * @since 1.3
      */
     public ResponseWriter(DeploymentConfiguration deploymentConfiguration) {
         this(DEFAULT_BUFFER_SIZE, deploymentConfiguration.isBrotli());
@@ -459,6 +460,7 @@ public class ResponseWriter implements Serializable {
      *            the request for the resource
      * @return true if the servlet should attempt to serve a Brotli version of
      *         the resource, false otherwise
+     * @since 1.3
      */
     protected boolean acceptsBrotliResource(HttpServletRequest request) {
         return acceptsEncoding(request, "br");

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -360,6 +360,7 @@ public class StateNode implements Serializable {
      *
      * @param action
      *            the action to execute, not {@code null}
+     * @since 23.0
      */
     public void forEachChild(Consumer<StateNode> action) {
         forEachFeature(n -> n.forEachChild(action));
@@ -393,6 +394,8 @@ public class StateNode implements Serializable {
     /**
      * Removes the node from its parent and unlinks the node (and children) from
      * the state tree.
+     *
+     * @since 2.0
      */
     public void removeFromTree() {
         removeFromTree(false);
@@ -404,6 +407,7 @@ public class StateNode implements Serializable {
      *
      * @param sendDetach
      *            if removal should send detach event for the element
+     * @since 24.2
      */
     public void removeFromTree(boolean sendDetach) {
         if (getOwner() instanceof StateTree) {
@@ -438,6 +442,8 @@ public class StateNode implements Serializable {
      * Prepares the tree below this node for resynchronization by detaching all
      * descendants, setting their internal state to not yet attached, and
      * calling the attach listeners.
+     *
+     * @since 3.1
      */
     protected void prepareForResync() {
         visitNodeTreeBottomUp(StateNode::fireDetachListeners);
@@ -538,6 +544,7 @@ public class StateNode implements Serializable {
      *            the desired feature type, not <code>null</code>
      * @return a feature instance, or an empty optional if the feature is not
      *         yet initialized for this node
+     * @since 1.1
      */
     public <T extends NodeFeature> Optional<T> getFeatureIfInitialized(
             Class<T> featureType) {
@@ -1042,6 +1049,7 @@ public class StateNode implements Serializable {
      * Non-visible node should not participate in any RPC communication.
      *
      * @return {@code true} if the node is effectively visible
+     * @since 24.0.8
      */
     public boolean isVisible() {
         if (hasFeature(ElementData.class)) {
@@ -1065,6 +1073,7 @@ public class StateNode implements Serializable {
      *
      * @return {@code true} if the node is inert, {@code false} if not
      * @see InertData
+     * @since 23.0
      */
     public boolean isInert() {
         if (hasFeature(InertData.class)) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -471,6 +471,8 @@ public class StateTree implements NodeOwner {
      * Prepares the tree for resynchronization, meaning that the client will
      * receive the same changes as when the component tree was initially
      * attached, so that it can build the DOM tree from scratch.
+     *
+     * @since 3.1
      */
     public void prepareForResync() {
         preparingForResync = true;
@@ -491,6 +493,7 @@ public class StateTree implements NodeOwner {
      *
      * @return {@code true} if the tree is preparing for resynchronization,
      *         {@code false} otherwise
+     * @since 24.7.5
      */
     public boolean isPreparingForResync() {
         return preparingForResync;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StringUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StringUtil.java
@@ -56,6 +56,7 @@ public final class StringUtil {
      *            if {@code true} then ' is also considered a string and
      *            comments will not be considered inside it
      * @return the code with removed comments
+     * @since 9.0.5
      */
     public static String removeComments(String code,
             boolean useStringApostrophe) {
@@ -160,6 +161,7 @@ public final class StringUtil {
      *            the suffix
      * @return the string without the suffix at the end or the same string if
      *         the suffix was not found
+     * @since 24.1.1
      */
     public static String stripSuffix(String string, String suffix) {
         if (string.endsWith(suffix)) {
@@ -176,6 +178,7 @@ public final class StringUtil {
      *            content to generate hash for
      * @return hash String for given content. In case content is null or empty
      *         returns empty String.
+     * @since 9.0.6
      */
     public static String getHash(String content) {
         return getHash(content, StandardCharsets.UTF_16);
@@ -190,6 +193,7 @@ public final class StringUtil {
      *            charset for encoding
      * @return hash String for given content. In case content is null or empty *
      *         returns empty String.
+     * @since 24.0
      */
     public static String getHash(String content, Charset charset) {
         return getHash(content, null, charset);
@@ -207,6 +211,7 @@ public final class StringUtil {
      *            charset for encoding
      * @return hash String for given content. In case content is null or empty *
      *         returns empty String.
+     * @since 24.5
      */
     public static String getHash(String content, byte[] salt, Charset charset) {
         if (content == null || content.isEmpty()) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/Template.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/Template.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
  * will be copied to {@code META-INF/VAADIN/config/templates}.
  *
  * @author Vaadin Ltd
+ * @since 9.0
  */
 public interface Template extends Serializable {
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -62,6 +62,7 @@ public class UrlUtil {
      *
      * @param uri
      *            the uri to encode
+     * @since 9.0
      */
     public static String encodeURI(String uri) {
         try {
@@ -88,6 +89,7 @@ public class UrlUtil {
      *
      * @param path
      *            the path to encode
+     * @since 9.0
      */
     public static String encodeURIComponent(String path) {
         try {
@@ -115,6 +117,7 @@ public class UrlUtil {
      * @param encoded
      *            the percent-encoded string
      * @return the decoded string
+     * @since 24.9.12
      */
     public static String decodeURIComponent(String encoded) {
         if (encoded == null || encoded.isEmpty()) {
@@ -168,6 +171,7 @@ public class UrlUtil {
      * @return a relative path that when applied to the servlet path, refers to
      *         the absolute path without containing the context path or servlet
      *         path
+     * @since 23.3
      */
     public static String getServletPathRelative(String absolutePath,
             HttpServletRequest request) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
@@ -102,6 +102,7 @@ public class UsageStatistics {
      *
      * @param name
      *            the feature name want to be removed, not <code>null</code>
+     * @since 3.0
      */
     public static void removeEntry(String name) {
         entries.remove(name);
@@ -109,6 +110,8 @@ public class UsageStatistics {
 
     /**
      * Reset the usage entries.
+     *
+     * @since 9.0.4
      */
     public static void resetEntries() {
         entries.clear();

--- a/flow-server/src/main/java/com/vaadin/flow/internal/VaadinContextInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/VaadinContextInitializer.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.server.VaadinServlet;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/AbstractListChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/AbstractListChange.java
@@ -79,6 +79,7 @@ public abstract class AbstractListChange<T extends Serializable>
      *
      * @param index
      *            Integer value.
+     * @since 23.2.2
      */
     public void setIndex(int index) {
         assert (index > -1) : "Index can't be negative.";

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/ListAddChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/ListAddChange.java
@@ -130,6 +130,7 @@ public class ListAddChange<T extends Serializable>
      *
      * @param item
      *            Item to be removed.
+     * @since 23.2.2
      */
     public void removeItem(T item) {
         assert (newItems.size() > 1)

--- a/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
@@ -53,6 +53,7 @@ public interface EndpointRequestUtil extends Serializable {
      * Checks if Hilla is available.
      *
      * @return true if Hilla is available, false otherwise
+     * @since 24.0
      */
     static boolean isHillaAvailable() {
         try {
@@ -69,6 +70,7 @@ public interface EndpointRequestUtil extends Serializable {
      * @param classFinder
      *            class finder to check the presence of Hilla endpoint class
      * @return true if Hilla is available, false otherwise
+     * @since 24.4
      */
     static boolean isHillaAvailable(ClassFinder classFinder) {
         try {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -59,6 +59,8 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
  * that require path parameters.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.5
  */
 public class MenuRegistry {
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractServerHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractServerHandlers.java
@@ -195,6 +195,7 @@ public abstract class AbstractServerHandlers<T>
      *
      * @param method
      *            method to check return type for
+     * @since 2.2
      */
     protected void ensureSupportedReturnType(Method method) {
         if (!void.class.equals(method.getReturnType())) {
@@ -212,6 +213,7 @@ public abstract class AbstractServerHandlers<T>
      * Gets the annotation FQN which is used to mark methods as handlers.
      *
      * @return the handler marker annotation
+     * @since 5.0
      */
     protected abstract String getHandlerAnnotationFqn();
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ComponentMapping.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ComponentMapping.java
@@ -82,6 +82,7 @@ public class ComponentMapping extends ServerSideFeature {
      *            <code>null</code>
      * @return the mapped component, or an empty optional if no component is
      *         mapped
+     * @since 1.1
      */
     public static Optional<Component> getComponent(StateNode node) {
         assert node != null;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
@@ -504,6 +504,7 @@ public class ElementListenerMap extends NodeMap {
      *            the name of the event, not <code>null</code>
      * @return an unmodifiable set of event data expressions, not
      *         <code>null</code>
+     * @since 3.0
      */
     public Set<String> getExpressions(String eventName) {
         assert eventName != null;
@@ -518,6 +519,7 @@ public class ElementListenerMap extends NodeMap {
      *            the property name to check, not <code>null</code>
      * @return the most permissive update mode, or <code>null</code> if
      *         synchronization is not configured for the given property
+     * @since 1.3
      */
     public DisabledUpdateMode getPropertySynchronizationMode(
             String propertyName) {
@@ -543,6 +545,7 @@ public class ElementListenerMap extends NodeMap {
      *            the property name to check, not <code>null</code>
      * @return {@code true} if allowInert is enabled for any listener for the
      *         given property, {@code false otherwise}
+     * @since 24.6.8
      */
     public boolean hasAllowInertForProperty(String propertyName) {
         assert propertyName != null;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/InertData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/InertData.java
@@ -38,6 +38,8 @@ import com.vaadin.flow.shared.util.UniqueSerializable;
  * does not ignore parent inert by default. The inert data feature is
  * initialized when the node will be made explicitly inert or to explicitly
  * ignore parent inert data.
+ *
+ * @since 23.0
  */
 public class InertData extends ServerSideFeature {
     // Null is ignored by Map.computeIfAbsent -> using a marker value instead

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeFeatureRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeFeatureRegistry.java
@@ -36,6 +36,8 @@ public class NodeFeatureRegistry {
 
     /**
      * Comparator for finding the priority order between node feature types.
+     *
+     * @since 1.1
      */
     public static final Comparator<Class<? extends NodeFeature>> PRIORITY_COMPARATOR = Comparator
             .comparingInt(feature -> getData(feature).priority);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeFeatures.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeFeatures.java
@@ -127,11 +127,15 @@ public final class NodeFeatures {
 
     /**
      * Id for {@link ReturnChannelMap}.
+     *
+     * @since 2.0
      */
     public static final int RETURN_CHANNEL_MAP = 25;
 
     /**
      * Id for {@link InertData}.
+     *
+     * @since 23.0
      */
     public static final int INERT_DATA = 26;
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeMap.java
@@ -504,6 +504,7 @@ public abstract class NodeMap extends NodeFeature {
      * @param newValue
      *            the new value for the {@code key}
      * @return
+     * @since 4.0
      */
     protected boolean producePutChange(String key, boolean hadValueEarlier,
             Serializable newValue) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeProperties.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeProperties.java
@@ -30,6 +30,8 @@ public final class NodeProperties {
 
     /**
      * Key for {@link ElementData#getJavaClass()}.
+     *
+     * @since 24.4
      */
     public static final String JAVA_CLASS = "jc";
 
@@ -63,6 +65,8 @@ public final class NodeProperties {
 
     /**
      * JsonObject {@code @name} type value for {@link VirtualChildrenList}.
+     *
+     * @since 24.5
      */
     public static final String INJECT_BY_NAME = "@name";
 
@@ -98,6 +102,8 @@ public final class NodeProperties {
      * property to be able to restore when making a hidden element visible
      * again. Used only when the element is inside a shadow root, and the CSS
      * "display: none" is set in addition the "hidden" attribute.
+     *
+     * @since 5.0
      */
     public static final String VISIBILITY_STYLE_DISPLAY_PROPERTY = "styleDisplay";
 
@@ -106,6 +112,8 @@ public final class NodeProperties {
      * transmitting URI (not just any string).
      * <p>
      * Used in the {@link ElementAttributeMap}.
+     *
+     * @since 3.1.7
      */
     public static final String URI_ATTRIBUTE = "uri";
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PropertyChangeDeniedException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PropertyChangeDeniedException.java
@@ -16,6 +16,7 @@ package com.vaadin.flow.internal.nodefeature;
  *
  * @author Vaadin Ltd
  *
+ * @since 4.0
  */
 public class PropertyChangeDeniedException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMap.java
@@ -31,7 +31,6 @@ public class PushConfigurationMap extends NodeMap implements PushConfiguration {
      * Map for storing push parameters.
      *
      * @author Vaadin Ltd
-     * @since 1.0
      */
     public static class PushConfigurationParametersMap extends NodeMap {
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReturnChannelMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReturnChannelMap.java
@@ -161,6 +161,7 @@ public class ReturnChannelMap extends ServerSideFeature {
      * Return if map contains any registered channels.
      *
      * @return {@code true} if registered channels exist.
+     * @since 23.0.2
      */
     public boolean hasChannels() {
         return !channels.isEmpty();

--- a/flow-server/src/main/java/com/vaadin/flow/internal/springcsrf/SpringCsrfToken.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/springcsrf/SpringCsrfToken.java
@@ -12,6 +12,8 @@ import java.io.Serializable;
 
 /**
  * A pojo for Spring CSRF token.
+ *
+ * @since 9.0
  */
 public class SpringCsrfToken implements Serializable {
     private String headerName;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/springcsrf/SpringCsrfTokenUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/springcsrf/SpringCsrfTokenUtil.java
@@ -21,6 +21,8 @@ import com.vaadin.flow.server.VaadinRequest;
 
 /**
  * A util class for helping dealing with Spring CSRF token.
+ *
+ * @since 9.0
  */
 public class SpringCsrfTokenUtil {
     private static final String CONTENT_ATTRIBUTE = "content";

--- a/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
 /**
  * This is abstract error view for routing exceptions.
  *
+ * @since 24.3
  */
 public abstract class AbstractRouteNotFoundError extends Component {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/AccessDeniedException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AccessDeniedException.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.router;
 /**
  * Exception for access denied error view.
  *
+ * @since 24.3
  */
 public class AccessDeniedException extends RuntimeException {
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
@@ -43,6 +43,7 @@ public class AfterNavigationEvent extends EventObject {
      *            NavigationEvent that is on going
      * @param routeParameters
      *            route parameters, not <code>null</code>
+     * @since 24.3
      */
     public AfterNavigationEvent(LocationChangeEvent event,
             RouteParameters routeParameters) {
@@ -64,6 +65,7 @@ public class AfterNavigationEvent extends EventObject {
      * Get the {@link LocationChangeEvent}.
      *
      * @return the {@link LocationChangeEvent}, not {@code null}
+     * @since 4.0
      */
     public LocationChangeEvent getLocationChangeEvent() {
         return event;
@@ -87,6 +89,7 @@ public class AfterNavigationEvent extends EventObject {
      * Check if event is for a refresh of a preserveOnRefresh view.
      *
      * @return true if refresh of a preserve on refresh view
+     * @since 23.2.8
      */
     public boolean isRefreshEvent() {
         return event.getTrigger().equals(NavigationTrigger.REFRESH);
@@ -96,6 +99,7 @@ public class AfterNavigationEvent extends EventObject {
      * Gets the route parameters associated with this event.
      *
      * @return route parameters retrieved from the navigation url.
+     * @since 24.3
      */
     public RouteParameters getRouteParameters() {
         return routeParameters;

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
@@ -31,6 +31,7 @@ public class BeforeEnterEvent extends BeforeEvent {
      *            navigation target, not <code>null</code>
      * @param layouts
      *            navigation layout chain, not <code>null</code>
+     * @since 2.0
      */
     public BeforeEnterEvent(NavigationEvent event, Class<?> navigationTarget,
             List<Class<? extends RouterLayout>> layouts) {
@@ -49,6 +50,7 @@ public class BeforeEnterEvent extends BeforeEvent {
      *            route parameters, not <code>null</code>
      * @param layouts
      *            navigation layout chain, not <code>null</code>
+     * @since 4.0
      */
     public BeforeEnterEvent(NavigationEvent event, Class<?> navigationTarget,
             RouteParameters parameters,
@@ -74,6 +76,7 @@ public class BeforeEnterEvent extends BeforeEvent {
      * @param layouts
      *            the layout chain for the navigation target, not
      *            <code>null</code>
+     * @since 2.0
      */
     public BeforeEnterEvent(Router router, NavigationTrigger trigger,
             Location location, Class<?> navigationTarget, UI ui,
@@ -101,6 +104,7 @@ public class BeforeEnterEvent extends BeforeEvent {
      * @param layouts
      *            the layout chain for the navigation target, not
      *            <code>null</code>
+     * @since 4.0
      */
     public BeforeEnterEvent(Router router, NavigationTrigger trigger,
             Location location, Class<?> navigationTarget,
@@ -115,6 +119,7 @@ public class BeforeEnterEvent extends BeforeEvent {
      * Check if event is for a refresh of a preserveOnRefresh view.
      *
      * @return true if refresh of a preserve on refresh view
+     * @since 23.2.8
      */
     public boolean isRefreshEvent() {
         return getTrigger().equals(NavigationTrigger.REFRESH);
@@ -124,6 +129,7 @@ public class BeforeEnterEvent extends BeforeEvent {
      * Check if the event is fired by an error handler.
      *
      * @return {@literal true} if the event is fired by an error handler.
+     * @since 24.3
      */
     public boolean isErrorEvent() {
         return errorEvent;

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEvent.java
@@ -62,6 +62,7 @@ public abstract class BeforeEvent extends EventObject {
      *            navigation target, not <code>null</code>
      * @param layouts
      *            Navigation layout chain, not <code>null</code>
+     * @since 2.0
      */
     public BeforeEvent(NavigationEvent event, Class<?> navigationTarget,
             List<Class<? extends RouterLayout>> layouts) {
@@ -80,6 +81,7 @@ public abstract class BeforeEvent extends EventObject {
      *            route parameters, not <code>null</code>
      * @param layouts
      *            Navigation layout chain, not <code>null</code>
+     * @since 4.0
      */
     public BeforeEvent(NavigationEvent event, Class<?> navigationTarget,
             RouteParameters parameters,
@@ -106,6 +108,7 @@ public abstract class BeforeEvent extends EventObject {
      * @param layouts
      *            the layout chain for the navigation target, not
      *            <code>null</code>
+     * @since 2.0
      */
     public BeforeEvent(Router router, NavigationTrigger trigger,
             Location location, Class<?> navigationTarget, UI ui,
@@ -133,6 +136,7 @@ public abstract class BeforeEvent extends EventObject {
      * @param layouts
      *            the layout chain for the navigation target, not
      *            <code>null</code>
+     * @since 4.0
      */
     public BeforeEvent(Router router, NavigationTrigger trigger,
             Location location, Class<?> navigationTarget,
@@ -161,6 +165,7 @@ public abstract class BeforeEvent extends EventObject {
      * {@link #forwardTo(String, QueryParameters)} methods.
      *
      * @return forward route is not found in the route registry.
+     * @since 4.0
      */
     public boolean hasUnknownForward() {
         return unknownForward != null;
@@ -172,6 +177,7 @@ public abstract class BeforeEvent extends EventObject {
      * {@link #rerouteTo(String, QueryParameters)} method.
      *
      * @return reroute is not found in the route registry.
+     * @since 4.0
      */
     public boolean hasUnknownReroute() {
         return unknownReroute != null;
@@ -181,6 +187,7 @@ public abstract class BeforeEvent extends EventObject {
      * Gets the unknown forward.
      *
      * @return the unknown forward.
+     * @since 4.0
      */
     public String getUnknownForward() {
         return unknownForward;
@@ -190,6 +197,7 @@ public abstract class BeforeEvent extends EventObject {
      * Gets the unknown reroute.
      *
      * @return the unknown reroute.
+     * @since 4.0
      */
     public String getUnknownReroute() {
         return unknownReroute;
@@ -199,6 +207,7 @@ public abstract class BeforeEvent extends EventObject {
      * Gets the external forward url.
      *
      * @return the external forward url or {@code null} if none has been set
+     * @since 23.2.3
      */
     public String getExternalForwardUrl() {
         return externalForwardUrl;
@@ -232,6 +241,7 @@ public abstract class BeforeEvent extends EventObject {
      * Check if we have a forward target.
      *
      * @return forward target exists
+     * @since 1.3
      */
     public boolean hasForwardTarget() {
         return forwardTarget != null;
@@ -241,6 +251,7 @@ public abstract class BeforeEvent extends EventObject {
      * Check if we have a forward for an external URL.
      *
      * @return forward target exists
+     * @since 23.2.3
      */
     public boolean hasExternalForwardUrl() {
         return externalForwardUrl != null;
@@ -260,6 +271,7 @@ public abstract class BeforeEvent extends EventObject {
      * some other view.
      *
      * @return navigation handler
+     * @since 1.3
      */
     public NavigationHandler getForwardTarget() {
         return forwardTarget;
@@ -290,6 +302,7 @@ public abstract class BeforeEvent extends EventObject {
      *            previously set forward target
      * @param targetState
      *            the target navigation state of the rerouting
+     * @since 1.3
      */
     public void forwardTo(NavigationHandler forwardTarget,
             NavigationState targetState) {
@@ -308,6 +321,7 @@ public abstract class BeforeEvent extends EventObject {
      *
      * @param targetState
      *            the target navigation state, not {@code null}
+     * @since 1.3
      */
     public void forwardTo(NavigationState targetState) {
         Objects.requireNonNull(targetState, "targetState cannot be null");
@@ -326,6 +340,7 @@ public abstract class BeforeEvent extends EventObject {
      *
      * @param forwardTargetComponent
      *            the component type to display, not {@code null}
+     * @since 1.3
      */
     public void forwardTo(Class<? extends Component> forwardTargetComponent) {
         Objects.requireNonNull(forwardTargetComponent,
@@ -348,6 +363,7 @@ public abstract class BeforeEvent extends EventObject {
      *            the component type to display, not {@code null}
      * @param useForwardCallback
      *            {@literal true} to request navigation callback from client
+     * @since 24.4.9
      */
     public void forwardTo(Class<? extends Component> forwardTargetComponent,
             boolean useForwardCallback) {
@@ -377,6 +393,7 @@ public abstract class BeforeEvent extends EventObject {
      *            route parameter type
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <T, C extends Component & HasUrlParameter<T>> void forwardTo(
             Class<? extends C> forwardTargetComponent, T routeParameter) {
@@ -403,6 +420,7 @@ public abstract class BeforeEvent extends EventObject {
      *            route parameters type
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <T, C extends Component & HasUrlParameter<T>> void forwardTo(
             Class<? extends C> forwardTargetComponent,
@@ -426,6 +444,7 @@ public abstract class BeforeEvent extends EventObject {
      *            the component type to display, not {@code null}
      * @param parameters
      *            route parameters for the target
+     * @since 4.0
      */
     public void forwardTo(Class<? extends Component> forwardTargetComponent,
             RouteParameters parameters) {
@@ -452,6 +471,7 @@ public abstract class BeforeEvent extends EventObject {
      *            route parameter type
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <T, C extends Component & HasUrlParameter<T>> void forwardTo(
             Class<? extends C> forwardTargetComponent, T routeParameter,
@@ -479,6 +499,7 @@ public abstract class BeforeEvent extends EventObject {
      *            query parameters for the target
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <C extends Component> void forwardTo(
             Class<? extends C> forwardTargetComponent,
@@ -504,6 +525,7 @@ public abstract class BeforeEvent extends EventObject {
      *            query parameters for the target
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <C extends Component> void forwardTo(
             Class<? extends C> forwardTargetComponent,
@@ -527,6 +549,7 @@ public abstract class BeforeEvent extends EventObject {
      *
      * @param location
      *            forward target location string
+     * @since 1.3
      */
     public void forwardTo(String location) {
         final Optional<NavigationState> navigationState = getSource()
@@ -547,6 +570,7 @@ public abstract class BeforeEvent extends EventObject {
      *
      * @param externalForwardUrl
      *            forward target location string
+     * @since 23.2.3
      */
     public void forwardToUrl(String externalForwardUrl) {
         this.externalForwardUrl = externalForwardUrl;
@@ -568,6 +592,7 @@ public abstract class BeforeEvent extends EventObject {
      *            location parameter
      * @param <T>
      *            location parameter type
+     * @since 1.3
      */
     public <T> void forwardTo(String location, T locationParam) {
         forwardTo(location, Collections.singletonList(locationParam));
@@ -589,6 +614,7 @@ public abstract class BeforeEvent extends EventObject {
      *            location parameters
      * @param <T>
      *            location parameters type
+     * @since 1.3
      */
     public <T> void forwardTo(String location, List<T> locationParams) {
         forwardTo(getNavigationState(location, locationParams));
@@ -605,6 +631,7 @@ public abstract class BeforeEvent extends EventObject {
      *            forward target location string
      * @param queryParameters
      *            query parameters for the target
+     * @since 24.1.13
      */
     public void forwardTo(String locationString,
             QueryParameters queryParameters) {
@@ -693,6 +720,7 @@ public abstract class BeforeEvent extends EventObject {
      *            route parameter type
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <T, C extends Component & HasUrlParameter<T>> void rerouteTo(
             Class<? extends C> routeTargetType, T routeParameter) {
@@ -717,6 +745,7 @@ public abstract class BeforeEvent extends EventObject {
      *            route parameter type
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <T, C extends Component & HasUrlParameter<T>> void rerouteTo(
             Class<? extends C> routeTargetType, List<T> routeParameters) {
@@ -738,6 +767,7 @@ public abstract class BeforeEvent extends EventObject {
      *            the component type to display, not {@code null}
      * @param parameters
      *            parameters for the target url.
+     * @since 4.0
      */
     public void rerouteTo(Class<? extends Component> routeTargetType,
             RouteParameters parameters) {
@@ -764,6 +794,7 @@ public abstract class BeforeEvent extends EventObject {
      *            route parameter type
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <T, C extends Component & HasUrlParameter<T>> void rerouteTo(
             Class<? extends C> routeTargetType, T routeParameter,
@@ -791,6 +822,7 @@ public abstract class BeforeEvent extends EventObject {
      *            query parameters for the target
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <C extends Component> void rerouteTo(
             Class<? extends C> routeTargetType, RouteParameters routeParameters,
@@ -815,6 +847,7 @@ public abstract class BeforeEvent extends EventObject {
      *            query parameters for the target
      * @param <C>
      *            navigation target type
+     * @since 24.1.13
      */
     public <C extends Component> void rerouteTo(
             Class<? extends C> routeTargetType,
@@ -901,6 +934,7 @@ public abstract class BeforeEvent extends EventObject {
      *            reroute target location string
      * @param queryParameters
      *            query parameters for the target
+     * @since 24.1.13
      */
     public void rerouteTo(String route, QueryParameters queryParameters) {
         final Optional<NavigationState> navigationState = getSource()
@@ -967,6 +1001,7 @@ public abstract class BeforeEvent extends EventObject {
      * @throws NullPointerException
      *             if no forward target is set. Check
      *             {@link #hasForwardTarget()} before accessing this method.
+     * @since 1.3
      */
     public Class<? extends Component> getForwardTargetType() {
         return forwardTargetState.getNavigationTarget();
@@ -979,6 +1014,7 @@ public abstract class BeforeEvent extends EventObject {
      * @throws NullPointerException
      *             if no forward target is set. Check
      *             {@link #hasForwardTarget()} before accessing this method.
+     * @since 4.0
      */
     public RouteParameters getForwardTargetRouteParameters() {
         return forwardTargetState.getRouteParameters();
@@ -991,6 +1027,7 @@ public abstract class BeforeEvent extends EventObject {
      * @throws NullPointerException
      *             if no forward target is set. Check
      *             {@link #hasForwardTarget()} before accessing this method.
+     * @since 4.0
      */
     public String getForwardUrl() {
         return forwardTargetState.getResolvedPath();
@@ -1003,6 +1040,7 @@ public abstract class BeforeEvent extends EventObject {
      * @throws NullPointerException
      *             if no reroute target is set. Check
      *             {@link #hasRerouteTarget()} before accessing this method.
+     * @since 2.2
      */
     public Class<? extends Component> getRerouteTargetType() {
         return rerouteTargetState.getNavigationTarget();
@@ -1015,6 +1053,7 @@ public abstract class BeforeEvent extends EventObject {
      * @throws NullPointerException
      *             if no reroute target is set. Check
      *             {@link #hasRerouteTarget()} before accessing this method.
+     * @since 4.0
      */
     public RouteParameters getRerouteTargetRouteParameters() {
         return rerouteTargetState.getRouteParameters();
@@ -1027,6 +1066,7 @@ public abstract class BeforeEvent extends EventObject {
      * @throws NullPointerException
      *             if no reroute target is set. Check
      *             {@link #hasRerouteTarget()} before accessing this method.
+     * @since 4.0
      */
     public String getRerouteUrl() {
         return rerouteTargetState.getResolvedPath();
@@ -1045,6 +1085,7 @@ public abstract class BeforeEvent extends EventObject {
      * Gets the route parameters associated with this event.
      *
      * @return route parameters retrieved from the navigation url.
+     * @since 4.0
      */
     public RouteParameters getRouteParameters() {
         return parameters;
@@ -1054,6 +1095,7 @@ public abstract class BeforeEvent extends EventObject {
      * Check if we have query parameters for forwarded and rerouted URL.
      *
      * @return query parameters exists
+     * @since 24.1.13
      */
     public boolean hasRedirectQueryParameters() {
         return redirectQueryParameters != null;
@@ -1065,6 +1107,7 @@ public abstract class BeforeEvent extends EventObject {
      * and rerouted URL.
      *
      * @return query parameters for forwarding and rerouting
+     * @since 24.1.13
      */
     public QueryParameters getRedirectQueryParameters() {
         return redirectQueryParameters;
@@ -1075,6 +1118,7 @@ public abstract class BeforeEvent extends EventObject {
      * navigation target}.
      *
      * @return layout chain
+     * @since 2.0
      */
     public List<Class<? extends RouterLayout>> getLayouts() {
         return layouts;
@@ -1162,6 +1206,7 @@ public abstract class BeforeEvent extends EventObject {
      *
      * @return {@literal true} if callback should be used,
      *         {@literal false otherwise}
+     * @since 24.4.9
      */
     public boolean isUseForwardCallback() {
         return useForwardCallback;

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveEvent.java
@@ -27,7 +27,6 @@ public class BeforeLeaveEvent extends BeforeEvent {
      * The action to resume a postponed {@link BeforeEnterEvent}.
      *
      * @author Vaadin Ltd
-     * @since 1.0.
      */
     public class ContinueNavigationAction implements Serializable {
 
@@ -86,6 +85,8 @@ public class BeforeLeaveEvent extends BeforeEvent {
          * <p>
          * This is so that the client router pending promise closes. Also
          * updates the correct url on back navigation if blocking back.
+         *
+         * @since 24.1.13
          */
         public void cancel() {
             BeforeLeaveEvent.this.continueNavigationAction = null;
@@ -107,6 +108,7 @@ public class BeforeLeaveEvent extends BeforeEvent {
      *            navigation target, not <code>null</code>
      * @param layouts
      *            navigation layout chain, not <code>null</code>
+     * @since 2.0
      */
     public BeforeLeaveEvent(NavigationEvent event, Class<?> navigationTarget,
             List<Class<? extends RouterLayout>> layouts) {
@@ -124,6 +126,7 @@ public class BeforeLeaveEvent extends BeforeEvent {
      *            route parameters, not <code>null</code>
      * @param layouts
      *            navigation layout chain, not <code>null</code>
+     * @since 4.0
      */
     public BeforeLeaveEvent(NavigationEvent event, Class<?> navigationTarget,
             RouteParameters parameters,
@@ -148,6 +151,7 @@ public class BeforeLeaveEvent extends BeforeEvent {
      * @param layouts
      *            the layout chain for the navigation target, not
      *            <code>null</code>
+     * @since 2.0
      */
     public BeforeLeaveEvent(Router router, NavigationTrigger trigger,
             Location location, Class<?> navigationTarget, UI ui,
@@ -174,6 +178,7 @@ public class BeforeLeaveEvent extends BeforeEvent {
      * @param layouts
      *            the layout chain for the navigation target, not
      *            <code>null</code>
+     * @since 4.0
      */
     public BeforeLeaveEvent(Router router, NavigationTrigger trigger,
             Location location, Class<?> navigationTarget,

--- a/flow-server/src/main/java/com/vaadin/flow/router/DefaultRoutePathProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/DefaultRoutePathProvider.java
@@ -15,7 +15,7 @@ import org.osgi.service.component.annotations.Component;
  * Default implementation for {@link RoutePathProvider}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  *
  */
 @Component(service = RoutePathProvider.class, property = Constants.SERVICE_RANKING

--- a/flow-server/src/main/java/com/vaadin/flow/router/ErrorNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/ErrorNavigationEvent.java
@@ -63,6 +63,7 @@ public class ErrorNavigationEvent extends NavigationEvent {
      * @param state
      *            includes navigation state info including for example the
      *            scroll position and the complete href of the RouterLink
+     * @since 4.0
      */
     @Deprecated
     public ErrorNavigationEvent(Router router, Location location, UI ui,
@@ -90,6 +91,7 @@ public class ErrorNavigationEvent extends NavigationEvent {
      * @param state
      *            includes navigation state info including for example the
      *            scroll position and the complete href of the RouterLink
+     * @since 24.8
      */
     public ErrorNavigationEvent(Router router, Location location, UI ui,
             NavigationTrigger trigger, ErrorParameter<?> errorParameter,
@@ -119,6 +121,7 @@ public class ErrorNavigationEvent extends NavigationEvent {
      * @param recreateLayoutChain
      *            if set to {@code true}, the complete layout chain up to the
      *            navigation target will be re-instantiated
+     * @since 24.10.1
      */
     public ErrorNavigationEvent(Router router, Location location, UI ui,
             NavigationTrigger trigger, ErrorParameter<?> errorParameter,

--- a/flow-server/src/main/java/com/vaadin/flow/router/EventUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/EventUtil.java
@@ -114,6 +114,7 @@ public final class EventUtil {
      *            in this collection will be excluded from the result
      *
      * @return list of found BeforeEnterObservers in the chain tree.
+     * @since 2.2
      */
     public static List<BeforeEnterObserver> collectBeforeEnterObserversFromChain(
             Collection<? extends HasElement> chain,
@@ -139,6 +140,7 @@ public final class EventUtil {
      *            collection will be excluded from the result
      *
      * @return list of found BeforeEnterObservers in the element hierarchy tree.
+     * @since 2.2
      */
     public static List<BeforeEnterObserver> collectBeforeEnterObserversFromChainElement(
             HasElement element,

--- a/flow-server/src/main/java/com/vaadin/flow/router/InvalidLocationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/InvalidLocationException.java
@@ -12,7 +12,7 @@ package com.vaadin.flow.router;
  * Thrown to indicate that a {@link Location} instance is invalid.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 8.0
  *
  * @see Location
  */

--- a/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.internal.UrlUtil;
 /**
  * Utility class exposing reusable utility methods for location.
  *
- * @since 2.7
+ * @since 8.0
  */
 public class LocationUtil {
 
@@ -93,6 +93,7 @@ public class LocationUtil {
      *            true to remove a potential query string and a URI fragment,
      *            false to use the path as is
      * @return tha path split into parts
+     * @since 23.3.1
      */
     public static List<String> parsePathToSegments(String path,
             boolean removeExtraParts) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  * </p>
  *
  * @see Route
+ * @since 24.4
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
@@ -17,6 +17,8 @@ import com.vaadin.flow.component.Component;
  * Data class for menu item information.
  * <p>
  * Only for read as data is immutable.
+ *
+ * @since 24.4
  */
 public record MenuData(String title, Double order, boolean exclude, String icon,
         Class<? extends Component> menuClass) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
@@ -77,6 +77,7 @@ public class NavigationEvent extends EventObject {
      * @param forwardTo
      *            indicates if this event is created as a result of
      *            {@link BeforeEvent#forwardTo} or not
+     * @since 4.0
      */
     @Deprecated
     public NavigationEvent(Router router, Location location, UI ui,
@@ -112,6 +113,7 @@ public class NavigationEvent extends EventObject {
      *            if set to {@code true}, the complete layout chain up to the
      *            navigation target will be re-instantiated. Requires
      *            {@code forceInstantiation} to be true to have an effect.
+     * @since 24.4
      */
     @Deprecated
     public NavigationEvent(Router router, Location location, UI ui,
@@ -143,6 +145,7 @@ public class NavigationEvent extends EventObject {
      * @param forwardTo
      *            indicates if this event is created as a result of
      *            {@link BeforeEvent#forwardTo} or not
+     * @since 24.8
      */
     public NavigationEvent(Router router, Location location, UI ui,
             NavigationTrigger trigger, BaseJsonNode state, boolean forwardTo) {
@@ -177,6 +180,7 @@ public class NavigationEvent extends EventObject {
      *            if set to {@code true}, the complete layout chain up to the
      *            navigation target will be re-instantiated. Requires
      *            {@code forceInstantiation} to be true to have an effect.
+     * @since 24.8
      */
     public NavigationEvent(Router router, Location location, UI ui,
             NavigationTrigger trigger, BaseJsonNode state, boolean forwardTo,
@@ -227,6 +231,7 @@ public class NavigationEvent extends EventObject {
      * the complete href of the RouterLink that triggers this navigation.
      *
      * @return the navigation state
+     * @since 4.0
      */
     public Optional<BaseJsonNode> getState() {
         return state == null ? Optional.empty() : Optional.of(state);
@@ -238,6 +243,7 @@ public class NavigationEvent extends EventObject {
      *
      * @return {@code true} if this event is created as a result calling
      *         {@link BeforeEvent#forwardTo}, {@code false} otherwise
+     * @since 4.0
      */
     public boolean isForwardTo() {
         return forwardTo;
@@ -249,6 +255,7 @@ public class NavigationEvent extends EventObject {
      *
      * @return {@code true} if navigation target should be instantiated in any
      *         case
+     * @since 24.4
      */
     public boolean isForceInstantiation() {
         return forceInstantiation;
@@ -260,6 +267,7 @@ public class NavigationEvent extends EventObject {
      *
      * @return {@code true} if layout chain up to the navigation target should
      *         be instantiated in any case
+     * @since 24.4
      */
     public boolean isRecreateLayoutChain() {
         return recreateLayoutChain;

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationState.java
@@ -36,6 +36,7 @@ public class NavigationState implements Serializable {
      *
      * @param router
      *            the router managing navigation
+     * @since 1.3
      */
     public NavigationState(Router router) {
         this.router = router;
@@ -79,6 +80,7 @@ public class NavigationState implements Serializable {
      * Gets the route target for this navigation state.
      *
      * @return the route target to navigate to.
+     * @since 4.0
      */
     public RouteTarget getRouteTarget() {
         if (routeTarget == null && navigationTarget != null) {
@@ -132,6 +134,7 @@ public class NavigationState implements Serializable {
      * Gets the route parameters map.
      *
      * @return route parameters.
+     * @since 4.0
      */
     public RouteParameters getRouteParameters() {
         return routeParameters;

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationStateBuilder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationStateBuilder.java
@@ -28,6 +28,7 @@ public class NavigationStateBuilder {
      *
      * @param router
      *            the router managing navigation
+     * @since 1.3
      */
     public NavigationStateBuilder(Router router) {
         currentState = new NavigationState(router);
@@ -43,6 +44,7 @@ public class NavigationStateBuilder {
      * @param parameters
      *            the route parameters of the navigation target
      * @return this builder, for chaining
+     * @since 4.0
      */
     public NavigationStateBuilder withTarget(
             Class<? extends Component> navigationTarget,
@@ -61,6 +63,7 @@ public class NavigationStateBuilder {
      * @param parameters
      *            the route parameters of the navigation target
      * @return this builder, for chaining
+     * @since 4.0
      */
     public NavigationStateBuilder withTarget(RouteTarget routeTarget,
             RouteParameters parameters) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
@@ -48,22 +48,30 @@ public enum NavigationTrigger {
     /**
      * Navigation was triggered via
      * {@link UI#navigate(String, QueryParameters)}. It's for internal use only.
+     *
+     * @since 4.0
      */
     UI_NAVIGATE,
 
     /**
      * Navigation was triggered by client-side.
+     *
+     * @since 3.0
      */
     CLIENT_SIDE,
 
     /**
      * Navigation is for a reload event on a preserveOnRefresh route.
+     *
+     * @since 23.2.8
      */
     REFRESH,
 
     /**
      * Navigation was triggered via {@link UI#refreshCurrentRoute(boolean)}.
      * It's for internal use only.
+     *
+     * @since 24.5.8
      */
     REFRESH_ROUTE,
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/ParameterDeserializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/ParameterDeserializer.java
@@ -95,6 +95,7 @@ public final class ParameterDeserializer {
      * @param parameters
      *            the list of route parameters to deserialize
      * @return the deserialized url parameter, can be {@code null}
+     * @since 4.0
      */
     public static Object deserializeRouteParameters(Class<?> navigationTarget,
             List<String> parameters) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/PreserveOnRefresh.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/PreserveOnRefresh.java
@@ -51,6 +51,7 @@ public @interface PreserveOnRefresh {
      * Default is {@code false} so only url match is repopulated.
      *
      * @return {@code true} if partial chain match should be checked and used
+     * @since 24.8
      */
     boolean partialMatch() default false;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
@@ -108,6 +108,7 @@ public class QueryParameters implements Serializable {
      * @param value
      *            the value
      * @return query parameters information
+     * @since 23.2
      */
     public static QueryParameters of(String key, String value) {
         return simple(Collections.singletonMap(key, value));
@@ -123,6 +124,7 @@ public class QueryParameters implements Serializable {
      * @param queryString
      *            the query string
      * @return query parameters information
+     * @since 7.0
      */
     public static QueryParameters fromString(String queryString) {
         if (queryString == null || queryString.isBlank()) {
@@ -198,6 +200,7 @@ public class QueryParameters implements Serializable {
      *            the key of query parameters to fetch
      * @return query parameters or an empty list if there are no parameters with
      *         the given key
+     * @since 24.2
      */
     public List<String> getParameters(String key) {
         return parameters.getOrDefault(key, Collections.emptyList());
@@ -213,6 +216,7 @@ public class QueryParameters implements Serializable {
      *            the key of query parameters to fetch
      * @return query parameter value or empty if there are no parameters with
      *         the given key
+     * @since 24.2
      */
     public Optional<String> getSingleParameter(String key) {
         return parameters.getOrDefault(key, Collections.emptyList()).stream()
@@ -242,6 +246,7 @@ public class QueryParameters implements Serializable {
      * @param keys
      *            Names of the parameters to be excluded
      * @return QueryParameters
+     * @since 24.2
      */
     public QueryParameters excluding(String... keys) {
         if (keys == null || keys.length == 0) {
@@ -259,6 +264,7 @@ public class QueryParameters implements Serializable {
      * @param keys
      *            Names of the parameters to be included
      * @return QueryParameters.
+     * @since 24.2
      */
     public QueryParameters including(String... keys) {
         if (keys == null || keys.length == 0) {
@@ -282,6 +288,7 @@ public class QueryParameters implements Serializable {
      * @param values
      *            Values for the parameter as Strings
      * @return QueryParameters.
+     * @since 24.2
      */
     public QueryParameters merging(String key, String... values) {
         if (key == null || key.isEmpty() || values == null
@@ -301,6 +308,7 @@ public class QueryParameters implements Serializable {
      * @param parameters
      *            Map of new parameters to be included
      * @return QueryParameters
+     * @since 24.2
      */
     public QueryParameters mergingAll(Map<String, List<String>> parameters) {
         Objects.requireNonNull(parameters);

--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -104,6 +104,7 @@ public @interface Route {
      * Default is to register route at startup.
      *
      * @return setting to false skips automatic registration
+     * @since 1.3
      */
     boolean registerAtStartup() default true;
 
@@ -113,6 +114,7 @@ public @interface Route {
      * for.
      *
      * @return {@code false} skips automatic layout
+     * @since 24.5
      */
     boolean autoLayout() default true;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteAccessDeniedError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteAccessDeniedError.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 /**
  * This is a default error view shown on access denied routing exceptions.
  *
- * @since 1.0
+ * @since 24.3
  */
 @Tag(Tag.DIV)
 @AnonymousAllowed

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteAlias.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteAlias.java
@@ -92,6 +92,7 @@ public @interface RouteAlias {
      * for.
      *
      * @return {@code false} skips automatic layout
+     * @since 24.5
      */
     boolean autoLayout() default true;
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteAliasData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteAliasData.java
@@ -58,6 +58,7 @@ public class RouteAliasData extends RouteBaseData<RouteAliasData> {
      *            navigation target path parameters
      * @param navigationTarget
      *            route navigation target
+     * @since 4.0
      */
     public RouteAliasData(List<Class<? extends RouterLayout>> parentLayouts,
             String template, Map<String, RouteParameterData> parameters,

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteBaseData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteBaseData.java
@@ -75,6 +75,7 @@ public abstract class RouteBaseData<T extends RouteBaseData>
      *            navigation target path parameters
      * @param navigationTarget
      *            route navigation target
+     * @since 4.0
      */
     public RouteBaseData(List<Class<? extends RouterLayout>> parentLayouts,
             String template, Map<String, RouteParameterData> parameters,
@@ -110,6 +111,7 @@ public abstract class RouteBaseData<T extends RouteBaseData>
      * Get the full route template of {@link Route}.
      *
      * @return route template.
+     * @since 4.0
      */
     public String getTemplate() {
         return template;
@@ -119,6 +121,7 @@ public abstract class RouteBaseData<T extends RouteBaseData>
      * Get {@link Route} route parameters if any.
      *
      * @return route parameters names mapped with their defined regex.
+     * @since 4.0
      */
     public Map<String, RouteParameterData> getRouteParameters() {
         return parameters;
@@ -128,6 +131,7 @@ public abstract class RouteBaseData<T extends RouteBaseData>
      * Get {@link Route} route parameters in a list if any.
      *
      * @return route parameters in a list. Never null.
+     * @since 24.5
      */
     public List<RouteParameterData> getRouteParametersList() {
         return parameters != null ? parameters.values().stream().toList()

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
@@ -108,6 +108,7 @@ public class RouteConfiguration implements Serializable {
      * @param path
      *            path to check for availability
      * @return true if there exists a route for the given path
+     * @since 4.0
      */
     public boolean isPathAvailable(String path) {
         if (handledRegistry instanceof AbstractRouteRegistry) {
@@ -420,6 +421,7 @@ public class RouteConfiguration implements Serializable {
      * @param navigationTarget
      *            target class.
      * @return main template for the given target.
+     * @since 4.0
      */
     public Optional<String> getTemplate(
             Class<? extends Component> navigationTarget) {
@@ -487,6 +489,7 @@ public class RouteConfiguration implements Serializable {
      * @throws NotFoundException
      *             in case the navigationTarget is not registered with a url
      *             template matching the given parameters.
+     * @since 4.0
      */
     public String getUrl(Class<? extends Component> navigationTarget,
             RouteParameters parameters) {
@@ -534,6 +537,7 @@ public class RouteConfiguration implements Serializable {
      * Automatically adds access controls from UI if available.
      *
      * @return list of accessible menu routes available for handled registry
+     * @since 24.5
      */
     public List<RouteData> getRegisteredAccessibleMenuRoutes() {
         UI ui = UI.getCurrent();
@@ -557,6 +561,7 @@ public class RouteConfiguration implements Serializable {
      * @param accessControls
      *            the access controls to use for checking access
      * @return list of accessible menu routes available for handled registry
+     * @since 24.5
      */
     public List<RouteData> getRegisteredAccessibleMenuRoutes(
             Collection<BeforeEnterListener> accessControls) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteData.java
@@ -43,6 +43,7 @@ public class RouteData extends RouteBaseData<RouteData> {
      *            list of aliases for this route
      * @throws IllegalArgumentException
      *             if parameters is not empty.
+     * @since 1.3
      */
     public RouteData(List<Class<? extends RouterLayout>> parentLayouts,
             String template, List<Class<?>> parameters,
@@ -68,6 +69,7 @@ public class RouteData extends RouteBaseData<RouteData> {
      *            route navigation target
      * @param routeAliases
      *            list of aliases for this route
+     * @since 4.0
      */
     public RouteData(List<Class<? extends RouterLayout>> parentLayouts,
             String template, Map<String, RouteParameterData> parameters,
@@ -92,6 +94,7 @@ public class RouteData extends RouteBaseData<RouteData> {
      *            list of aliases for this route
      * @param menuData
      *            menu data for this route
+     * @since 24.4
      */
     public RouteData(List<Class<? extends RouterLayout>> parentLayouts,
             String template, Map<String, RouteParameterData> parameters,
@@ -117,6 +120,7 @@ public class RouteData extends RouteBaseData<RouteData> {
      * Get the menu data for this route.
      *
      * @return the menu data for this route
+     * @since 24.4
      */
     public MenuData getMenuData() {
         return menuData;

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParam.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParam.java
@@ -13,6 +13,8 @@ import com.vaadin.flow.internal.Pair;
 /**
  * Route parameter containing the name and the value used mainly when
  * constructing a {@link RouteParameters} instance.
+ *
+ * @since 4.0
  */
 public class RouteParam extends Pair<String, String> {
 
@@ -35,6 +37,7 @@ public class RouteParam extends Pair<String, String> {
      *            the name of the parameter.
      * @param value
      *            the value of the parameter.
+     * @since 24.2
      */
     public RouteParam(String name, int value) {
         super(name, Integer.toString(value));
@@ -47,6 +50,7 @@ public class RouteParam extends Pair<String, String> {
      *            the name of the parameter.
      * @param value
      *            the value of the parameter.
+     * @since 24.2
      */
     public RouteParam(String name, long value) {
         super(name, Long.toString(value));

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterData.java
@@ -15,6 +15,8 @@ import com.vaadin.flow.router.internal.ParameterInfo;
 
 /**
  * Immutable data representing one url parameter.
+ *
+ * @since 4.0
  */
 public class RouteParameterData implements Serializable {
 
@@ -57,6 +59,7 @@ public class RouteParameterData implements Serializable {
      * Return true for optional parameter.
      *
      * @return true for optional parameter
+     * @since 24.5
      */
     public boolean isOptional() {
         return new ParameterInfo(getTemplate()).isOptional();
@@ -66,6 +69,7 @@ public class RouteParameterData implements Serializable {
      * Return true for parameter with varargs.
      *
      * @return true for parameter with varargs
+     * @since 24.5
      */
     public boolean isVarargs() {
         return new ParameterInfo(getTemplate()).isVarargs();

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterFormatOption.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterFormatOption.java
@@ -14,6 +14,8 @@ package com.vaadin.flow.router;
  * represented according with the specified flags.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 4.0
  */
 public enum RouteParameterFormatOption {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterRegex.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterRegex.java
@@ -12,6 +12,8 @@ import java.io.Serializable;
 
 /**
  * Predefined regex used with template parameters.
+ *
+ * @since 4.0
  */
 public class RouteParameterRegex implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParameters.java
@@ -21,6 +21,8 @@ import com.vaadin.flow.router.internal.PathUtil;
 /**
  * Immutable container which stores the route parameters extracted from a
  * navigation url received from the client.
+ *
+ * @since 4.0
  */
 public final class RouteParameters implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/RoutePathProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RoutePathProvider.java
@@ -13,7 +13,7 @@ package com.vaadin.flow.router;
  * components annotated with {@code @Route(Route.NAMING_CONVENTION)}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 9.0
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -71,6 +71,7 @@ public class Router implements Serializable {
      *            the UI that navigation should be set up for
      * @param location
      *            the location object of the route
+     * @since 3.0
      */
     public void initializeUI(UI ui, Location location) {
         ui.getPage().getHistory()
@@ -110,6 +111,7 @@ public class Router implements Serializable {
      * @param location
      *            the location object of the route
      * @return NavigationTarget for the given location if found
+     * @since 3.0
      */
     public Optional<NavigationState> resolveNavigationTarget(
             Location location) {
@@ -130,6 +132,7 @@ public class Router implements Serializable {
      *
      * @return an instance of {@link NavigationState} for NotFoundException or
      *         empty if there is none in the application.
+     * @since 3.0
      */
     public Optional<NavigationState> resolveRouteNotFoundNavigationTarget() {
         Optional<ErrorTargetEntry> errorTargetEntry = getErrorNavigationTarget(
@@ -186,6 +189,7 @@ public class Router implements Serializable {
      * @return the HTTP status code resulting from the navigation
      * @see UI#navigate(String)
      * @see UI#navigate(String, QueryParameters)
+     * @since 24.8
      */
     public int navigate(UI ui, Location location, NavigationTrigger trigger,
             BaseJsonNode state) {
@@ -219,6 +223,7 @@ public class Router implements Serializable {
      * @return the HTTP status code resulting from the navigation
      * @see UI#navigate(String)
      * @see UI#navigate(String, QueryParameters)
+     * @since 24.8
      */
     public int navigate(UI ui, Location location, NavigationTrigger trigger,
             BaseJsonNode state, boolean forceInstantiation,
@@ -263,6 +268,7 @@ public class Router implements Serializable {
      * @return the HTTP status code resulting from the navigation
      * @see UI#navigate(String)
      * @see UI#navigate(String, QueryParameters)
+     * @since 4.0
      */
     @Deprecated
     public int navigate(UI ui, Location location, NavigationTrigger trigger,
@@ -297,6 +303,7 @@ public class Router implements Serializable {
      * @return the HTTP status code resulting from the navigation
      * @see UI#navigate(String)
      * @see UI#navigate(String, QueryParameters)
+     * @since 24.4
      */
     @Deprecated
     public int navigate(UI ui, Location location, NavigationTrigger trigger,
@@ -369,6 +376,7 @@ public class Router implements Serializable {
      *            navigation state info
      * @return the HTTP status code to return to the client if handling an
      *         initial rendering request
+     * @since 24.9.11
      */
     public int handleExceptionNavigation(UI ui, Location location,
             Exception exception, NavigationTrigger trigger,
@@ -451,6 +459,7 @@ public class Router implements Serializable {
      *            optional callback to run after successful navigation (before
      *            clearing navigation state), may be {@code null}
      * @return the HTTP status code resulting from the navigation
+     * @since 24.9.11
      */
     public int executeNavigation(UI ui, Location location,
             NavigationEvent navigationEvent, NavigationHandler handler,
@@ -491,6 +500,7 @@ public class Router implements Serializable {
      * @param exception
      *            exception to search error view for
      * @return optional error target entry corresponding to the given exception
+     * @since 1.3
      */
     public Optional<ErrorTargetEntry> getErrorNavigationTarget(
             Exception exception) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLayout.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLayout.java
@@ -55,6 +55,7 @@ public interface RouterLayout extends HasElement {
      *
      * @param oldContent
      *            the old content to remove, not <code>null</code>
+     * @since 2.0
      */
     default void removeRouterLayoutContent(HasElement oldContent) {
         oldContent.getElement().removeFromParent();

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -62,6 +62,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *
      * @param navigationTarget
      *            navigation target
+     * @since 23.2
      */
     public RouterLink(Class<? extends Component> navigationTarget) {
         this(navigationTarget, RouteParameters.empty());
@@ -93,6 +94,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            url parameter type
      * @param <C>
      *            navigation target type
+     * @since 23.2
      */
     public <T, C extends Component & HasUrlParameter<T>> RouterLink(
             Class<? extends C> navigationTarget, T parameter) {
@@ -128,6 +130,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @param parameters
      *            route parameters for navigation target
+     * @since 23.2
      */
     public RouterLink(Class<? extends Component> navigationTarget,
             RouteParameters parameters) {
@@ -145,6 +148,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @param parameters
      *            route parameters for navigation target
+     * @since 4.0
      */
     public RouterLink(String text, Class<? extends Component> navigationTarget,
             RouteParameters parameters) {
@@ -162,6 +166,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @throws IllegalArgumentException
      *             if navigation target requires parameters
+     * @since 23.2
      */
     public RouterLink(Router router,
             Class<? extends Component> navigationTarget)
@@ -202,6 +207,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            url parameter type
      * @param <C>
      *            navigation target type
+     * @since 23.2
      */
     public <T, C extends Component & HasUrlParameter<T>> RouterLink(
             Router router, Class<? extends C> navigationTarget, T parameter) {
@@ -243,6 +249,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @param parameters
      *            route parameters for navigation target
+     * @since 23.2
      */
     public RouterLink(Router router,
             Class<? extends Component> navigationTarget,
@@ -263,6 +270,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @param parameters
      *            route parameters for navigation target
+     * @since 4.0
      */
     public RouterLink(Router router, String text,
             Class<? extends Component> navigationTarget,
@@ -316,6 +324,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @param parameters
      *            route parameters for navigation target
+     * @since 4.0
      */
     public void setRoute(Router router,
             Class<? extends Component> navigationTarget,
@@ -339,6 +348,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @throws IllegalArgumentException
      *             if navigation target requires parameters
+     * @since 2.1
      */
     public void setRoute(Class<? extends Component> navigationTarget) {
         setRoute(getRouter(), navigationTarget);
@@ -355,6 +365,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            url parameter type
      * @param <C>
      *            navigation target type
+     * @since 2.1
      */
     public <T, C extends Component & HasUrlParameter<T>> void setRoute(
             Class<? extends C> navigationTarget, T parameter) {
@@ -368,6 +379,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
      *            navigation target
      * @param parameters
      *            route parameters for navigation target
+     * @since 4.0
      */
     public void setRoute(Class<? extends Component> navigationTarget,
             RouteParameters parameters) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RoutesChangedEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RoutesChangedEvent.java
@@ -75,6 +75,7 @@ public class RoutesChangedEvent extends EventObject {
      * @param clazz
      *            a route navigation target
      * @return true if the route was added for this change and false otherwise
+     * @since 3.1
      */
     public boolean isRouteAdded(Class<? extends Component> clazz) {
         return checkIfRouteIsPresent(added, clazz);
@@ -87,6 +88,7 @@ public class RoutesChangedEvent extends EventObject {
      * @param clazz
      *            a route navigation target
      * @return true if the route was removed for this change and false otherwise
+     * @since 3.1
      */
     public boolean isRouteRemoved(Class<? extends Component> clazz) {
         return checkIfRouteIsPresent(removed, clazz);
@@ -104,6 +106,7 @@ public class RoutesChangedEvent extends EventObject {
      * @param path
      *            the URL of a route
      * @return true if the route was added for this change and false otherwise
+     * @since 3.1
      */
     public boolean isPathAdded(String path) {
         return checkIfRouteIsPresent(added, path);
@@ -115,6 +118,7 @@ public class RoutesChangedEvent extends EventObject {
      * @param path
      *            the URL of a route
      * @return true if the route was removed for this change and false otherwise
+     * @since 3.1
      */
     public boolean isPathRemoved(String path) {
         return checkIfRouteIsPresent(removed, path);
@@ -124,6 +128,7 @@ public class RoutesChangedEvent extends EventObject {
      * Get every single navigation targets of all added routes in this change.
      *
      * @return immutable list of all added navigation targets
+     * @since 3.1
      */
     public List<Class<? extends Component>> getAddedNavigationTargets() {
         return Collections.unmodifiableList(
@@ -135,6 +140,7 @@ public class RoutesChangedEvent extends EventObject {
      * Get every single navigation targets of all removed routes in this change.
      *
      * @return immutable list of all removed navigation targets
+     * @since 3.1
      */
     public List<Class<? extends Component>> getRemovedNavigationTargets() {
         return Collections.unmodifiableList(
@@ -146,6 +152,7 @@ public class RoutesChangedEvent extends EventObject {
      * Get every single URL of all added routes in this change.
      *
      * @return immutable list of all added URLs
+     * @since 3.1
      */
     public List<String> getAddedURLs() {
         return Collections.unmodifiableList(added.stream()
@@ -156,6 +163,7 @@ public class RoutesChangedEvent extends EventObject {
      * Get every single URL of all removed routes in this change.
      *
      * @return immutable list of all removed URLs
+     * @since 3.1
      */
     public List<String> getRemovedURLs() {
         return Collections.unmodifiableList(removed.stream()

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -423,6 +423,7 @@ public abstract class AbstractNavigationStateRenderer
      * @param path
      *            request path
      * @return List of parent layouts
+     * @since 24.5
      */
     protected List<Class<? extends RouterLayout>> getTargetParentLayouts(
             RouteTarget routeTarget, RouteRegistry registry, String path) {
@@ -511,6 +512,7 @@ public abstract class AbstractNavigationStateRenderer
      *
      * @return a list of parent {@link RouterLayout} types, not
      *         <code>null</code>
+     * @since 1.3
      */
     protected abstract List<Class<? extends RouterLayout>> getRouterLayoutTypes(
             Class<? extends Component> routeTargetType, Router router);
@@ -844,6 +846,7 @@ public abstract class AbstractNavigationStateRenderer
      *         observer or just move forward, otherwise the process will return
      *         immediately with the provided http code.
      * @see HttpStatusCode
+     * @since 4.0
      */
     protected Optional<Integer> handleTriggeredBeforeEvent(
             NavigationEvent event, BeforeEvent beforeEvent) {
@@ -1219,6 +1222,7 @@ public abstract class AbstractNavigationStateRenderer
      *            the inactive UI
      * @throws IllegalStateException
      *             if the UI is not in closing state
+     * @since 24.3.11
      */
     public static void purgeInactiveUIPreservedChainCache(UI inactiveUI) {
         if (!inactiveUI.isClosing()) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientRoutesProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientRoutesProvider.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
  *
  * @deprecated Provider is deprecated, use
  *             {@link FrontendUtils#getClientRoutes()} instead.
+ * @since 24.4
  */
 @Deprecated(forRemoval = true)
 public interface ClientRoutesProvider extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientTarget.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.component.Component;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 24.5
+ * @since 24.5.1
  */
 public class ClientTarget extends RouteTarget {
     private final String template;

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ConfigureRoutes.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ConfigureRoutes.java
@@ -155,6 +155,7 @@ public class ConfigureRoutes extends ConfiguredRoutes implements Serializable {
      *            navigation target to add
      * @param parentChain
      *            chain of parent layouts that should be used with this target
+     * @since 4.0
      */
     public void setRoute(String template,
             Class<? extends Component> navigationTarget,

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ConfiguredRoutes.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ConfiguredRoutes.java
@@ -142,6 +142,7 @@ public class ConfiguredRoutes implements Serializable {
      * @param template
      *            template to check
      * @return true if configuration contains route
+     * @since 4.0
      */
     public boolean hasTemplate(String template) {
         return getRoutesMap().containsKey(template);
@@ -183,6 +184,7 @@ public class ConfiguredRoutes implements Serializable {
      *         {@link RouteTarget} and {@link RouteParameters} extracted from
      *         the <code>url</code> argument according with the route
      *         configuration.
+     * @since 4.0
      */
     public NavigationRouteTarget getNavigationRouteTarget(String url) {
         return getRouteModel().getNavigationRouteTarget(url);
@@ -198,6 +200,7 @@ public class ConfiguredRoutes implements Serializable {
      *            parameter values that may be used with given target.
      * @return the {@link RouteTarget} instance matching the given target
      *         component and route parameters.
+     * @since 4.0
      */
     public RouteTarget getRouteTarget(Class<? extends Component> target,
             RouteParameters parameters) {
@@ -216,6 +219,7 @@ public class ConfiguredRoutes implements Serializable {
      * @param url
      *            string to get the route for
      * @return {@link Optional} containing the navigationTarget class if found
+     * @since 4.0
      */
     public Optional<Class<? extends Component>> getTarget(String url) {
         final NavigationRouteTarget result = getNavigationRouteTarget(url);
@@ -273,6 +277,7 @@ public class ConfiguredRoutes implements Serializable {
      * Make a copy of the target and route models mapping.
      *
      * @return a copy of the target and route models mapping.
+     * @since 4.0
      */
     protected final Map<Class<? extends Component>, RouteModel> copyTargetRouteModels(
             boolean mutable) {
@@ -300,6 +305,7 @@ public class ConfiguredRoutes implements Serializable {
      * @param navigationTarget
      *            navigationTarget to get registered route for
      * @return base route string if target class found
+     * @since 4.0
      */
     public String getTemplate(Class<? extends Component> navigationTarget) {
         return getTargetRoutes().get(navigationTarget);
@@ -318,6 +324,7 @@ public class ConfiguredRoutes implements Serializable {
      *            {@link RouteParameterFormatOption#REGEX} are provided, the
      *            unformatted template will be provided.
      * @return base route string if target class found
+     * @since 4.0
      */
     public String getTemplate(Class<? extends Component> navigationTarget,
             Set<RouteParameterFormatOption> format) {
@@ -335,6 +342,7 @@ public class ConfiguredRoutes implements Serializable {
      * @param navigationTarget
      *            navigationTarget to get registered route for
      * @return route string if target class found
+     * @since 4.0
      */
     public String getTargetUrl(Class<? extends Component> navigationTarget) {
         return iterateTemplates(navigationTarget, template -> {
@@ -362,6 +370,7 @@ public class ConfiguredRoutes implements Serializable {
      *            route parameters
      * @return url String populated with parameters for the given
      *         navigationTarget
+     * @since 4.0
      */
     public String getTargetUrl(Class<? extends Component> navigationTarget,
             RouteParameters parameters) {
@@ -402,6 +411,7 @@ public class ConfiguredRoutes implements Serializable {
      *            template to get parameters from.
      * @return map parameter names with
      *         {@link com.vaadin.flow.router.RouteParameterData}.
+     * @since 4.0
      */
     public Map<String, RouteParameterData> getParameters(String template) {
         return getRouteModel().getParameters(template);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/DefaultErrorHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/DefaultErrorHandler.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
  * Marks an HasErrorParameter view as Framework default handler so it can be
  * disregarded if there is a custom view for the same Exception.
  *
- * @since
+ * @since 6.0.10
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/DependencyTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/DependencyTrigger.java
@@ -19,6 +19,8 @@ import java.lang.annotation.Target;
  * Marks which classes should trigger loading of a chunk defined by a route.
  * <p>
  * This only exists only for internal use.
+ *
+ * @since 24.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ErrorStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ErrorStateRenderer.java
@@ -128,6 +128,7 @@ public class ErrorStateRenderer extends AbstractNavigationStateRenderer {
      *
      * @return a list of parent {@link RouterLayout} types, not
      *         <code>null</code>
+     * @since 1.3
      */
     @Override
     public List<Class<? extends RouterLayout>> getRouterLayoutTypes(

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/HasUrlParameterFormat.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/HasUrlParameterFormat.java
@@ -29,6 +29,8 @@ import com.vaadin.flow.router.WildcardParameter;
  * {@link HasUrlParameter} format into/from the template format.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 4.0
  */
 public class HasUrlParameterFormat implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationRouteTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationRouteTarget.java
@@ -22,6 +22,8 @@ import com.vaadin.flow.router.RouteParameters;
  * configuration.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 4.0
  */
 public class NavigationRouteTarget implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ParameterInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ParameterInfo.java
@@ -15,6 +15,8 @@ import java.util.Optional;
  * Define a route url parameter details.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.5
  */
 public class ParameterInfo implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/PathUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/PathUtil.java
@@ -23,6 +23,8 @@ import com.vaadin.flow.internal.UrlUtil;
  *
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 4.0
  */
 public class PathUtil implements Serializable {
 
@@ -65,6 +67,7 @@ public class PathUtil implements Serializable {
      *            start with a slash `/` but it may not contain the url
      *            protocol.
      * @return a List containing the decoded segments of the path.
+     * @since 24.9.12
      */
     public static List<String> getSegmentsListWithDecoding(String path) {
         path = path == null ? "" : trimSegmentsString(path);
@@ -142,6 +145,7 @@ public class PathUtil implements Serializable {
      *            url path to trim, not null
      * @return a String representing the input path without any leading and
      *         trailing whitespaces or trailing slash.
+     * @since 6.0.9
      */
     public static String trimSegmentsString(String path) {
         Objects.requireNonNull(path);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteTarget.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.router.RouterLayout;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 1.0
+ * @since 4.0
  */
 public class RouteTarget implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -84,6 +84,7 @@ public class RouteUtil {
      *            path used to get navigation target so we know which annotation
      *            to handle
      * @return parent layouts for target
+     * @since 9.0
      */
     public static List<Class<? extends RouterLayout>> getParentLayouts(
             VaadinContext context, Class<?> component, String path) {
@@ -123,6 +124,7 @@ public class RouteUtil {
      *            path used to get navigation target so we know which annotation
      *            to handle
      * @return parent layouts for target
+     * @since 24.5
      */
     public static List<Class<? extends RouterLayout>> getParentLayouts(
             RouteRegistry handledRegistry, Class<?> component, String path) {
@@ -160,6 +162,7 @@ public class RouteUtil {
      * @param component
      *            navigation target component to get route path for
      * @return actual path for given route target
+     * @since 9.0
      */
     public static String getRoutePath(VaadinContext context,
             Class<?> component) {
@@ -247,6 +250,7 @@ public class RouteUtil {
      *            the layout class for which the parent layouts are collected.
      * @return a list of all parent layout classes starting from the given
      *         layout and including all ancestors in the hierarchy.
+     * @since 24.5
      */
     public static List<Class<? extends RouterLayout>> collectRouteParentLayouts(
             Class<? extends RouterLayout> layout) {
@@ -295,6 +299,7 @@ public class RouteUtil {
      *            path used to get navigation target so we know which annotation
      *            to handle or null for error views.
      * @return top parent layout for target or null if none found
+     * @since 9.0
      */
     public static Class<? extends RouterLayout> getTopParentLayout(
             VaadinContext context, final Class<?> component,
@@ -347,6 +352,7 @@ public class RouteUtil {
      *            the component where the route points to
      * @return The value of the annotation or naming convention based value if
      *         no explicit value is given.
+     * @since 9.0
      */
     public static String resolve(VaadinContext context, Class<?> component) {
         RoutePathProvider provider = null;
@@ -387,6 +393,7 @@ public class RouteUtil {
      *            modified classes
      * @param deletedClasses
      *            deleted classes
+     * @since 3.1
      */
     public static void updateRouteRegistry(RouteRegistry registry,
             Set<Class<?>> addedClasses, Set<Class<?>> modifiedClasses,
@@ -564,6 +571,7 @@ public class RouteUtil {
      *            path to determine if we are targeting a {@link RouteAlias}
      *            instead of {@link Route}
      * @return {@code true} if auto layout can be used
+     * @since 24.5
      */
     public static boolean isAutolayoutEnabled(Class<?> target, String path) {
         if (target.isAnnotationPresent(RouteAlias.class)
@@ -605,6 +613,7 @@ public class RouteUtil {
      *            Flow routes to check against
      * @throws InvalidRouteConfigurationException
      *             if a collision is detected
+     * @since 24.5.1
      */
     public static void checkForClientRouteCollisions(VaadinService service,
             List<RouteData> flowRoutes)
@@ -626,6 +635,7 @@ public class RouteUtil {
      *            Flow routes to check against
      * @throws InvalidRouteConfigurationException
      *             if a collision is detected
+     * @since 24.5.1
      */
     public static void checkForClientRouteCollisions(VaadinService service,
             String... flowRouteTemplates)
@@ -666,6 +676,7 @@ public class RouteUtil {
      * @param registry
      *            the registry to check
      * @return {@code true} if the registry has any auto layouts
+     * @since 24.5
      */
     public static boolean hasAutoLayout(AbstractRouteRegistry registry) {
         return !registry.getLayouts().isEmpty();
@@ -678,6 +689,7 @@ public class RouteUtil {
      * @param configuration
      *            deployment configuration
      * @return {@code true} if any client route has auto layout
+     * @since 24.5
      */
     public static boolean hasClientRouteWithAutoLayout(
             AbstractConfiguration configuration) {
@@ -691,6 +703,7 @@ public class RouteUtil {
      * @param registry
      *            the registry to check
      * @return {@code true} if the registry has any auto layouts
+     * @since 24.5
      */
     public static boolean hasServerRouteWithAutoLayout(
             AbstractRouteRegistry registry) {
@@ -724,6 +737,7 @@ public class RouteUtil {
      *            instance of UI, not {@code null}
      * @return dynamic page title found in the routes chain, or empty optional
      *         if no implementor of {@link HasDynamicTitle} was found
+     * @since 24.5
      */
     public static Optional<String> getDynamicTitle(UI ui) {
         return Objects.requireNonNull(ui).getInternals()
@@ -742,6 +756,7 @@ public class RouteUtil {
      *
      * @return a {@link Optional} containing the template of the client route
      *         target or an empty {@link Optional}.
+     * @since 24.5.1
      */
     public static Optional<String> getClientNavigationRouteTargetTemplate(
             String url) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -24,7 +24,7 @@ import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DISABLE_XS
  * servlet level,...).
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public interface AbstractConfiguration extends Serializable {
@@ -41,6 +41,7 @@ public interface AbstractConfiguration extends Serializable {
      *
      * @return true if dev server should be used
      * @deprecated Use {@link #getMode()} instead
+     * @since 24.0
      */
     @Deprecated
     default boolean frontendHotdeploy() {
@@ -70,6 +71,7 @@ public interface AbstractConfiguration extends Serializable {
      *
      * @return custom production bundle, pre-compiled production bundle,
      *         development using livereload or development using bundle
+     * @since 24.0.1
      **/
     default Mode getMode() {
         if (isProductionMode()) {
@@ -139,6 +141,7 @@ public interface AbstractConfiguration extends Serializable {
      * Returns whether bun is enabled or not.
      *
      * @return {@code true} if enabled, {@code false} if not
+     * @since 24.3
      */
     default boolean isBunEnabled() {
         return getBooleanProperty(InitParameters.SERVLET_PARAMETER_ENABLE_BUN,
@@ -151,6 +154,7 @@ public interface AbstractConfiguration extends Serializable {
      *
      * @return {@code true} if globally installed pnpm is used, {@code false} if
      *         the default one is used.
+     * @since 9.0
      */
     default boolean isGlobalPnpm() {
         return getBooleanProperty(InitParameters.SERVLET_PARAMETER_GLOBAL_PNPM,
@@ -165,6 +169,7 @@ public interface AbstractConfiguration extends Serializable {
      *
      * @see #isProductionMode()
      * @return {@code true} if enabled, {@code false} if not collected.
+     * @since 9.0.2
      */
     default boolean isUsageStatisticsEnabled() {
         return !isProductionMode() && getBooleanProperty(
@@ -189,6 +194,7 @@ public interface AbstractConfiguration extends Serializable {
      * will set it to <code>build</code>.
      *
      * @return build folder name, default {@code target}
+     * @since 7.0
      */
     default String getBuildFolder() {
         return getStringProperty(InitParameters.BUILD_FOLDER, Constants.TARGET);
@@ -200,6 +206,7 @@ public interface AbstractConfiguration extends Serializable {
      * Only available in development mode.
      *
      * @return the project root folder, or {@code null} if unknown
+     * @since 24.0
      */
     default File getProjectFolder() {
         if (isProductionMode()) {
@@ -246,6 +253,7 @@ public interface AbstractConfiguration extends Serializable {
      *
      * @return the folder where resources are stored, typically
      *         {@code src/main/resources}.
+     * @since 9.0
      */
     default File getJavaResourceFolder() {
         File folder = new File(getStringProperty(
@@ -263,6 +271,7 @@ public interface AbstractConfiguration extends Serializable {
      *
      * @return the folder where source files are stored, typically
      *         {@code src/main/java}.
+     * @since 24.0
      */
     default File getJavaSourceFolder() {
         File folder = new File(getStringProperty(

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -29,6 +29,7 @@ public abstract class AbstractDeploymentConfiguration extends
      *
      * @param properties
      *            configuration properties
+     * @since 6.0
      */
     protected AbstractDeploymentConfiguration(Map<String, String> properties) {
         super(properties);

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractPropertyConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractPropertyConfiguration.java
@@ -19,7 +19,7 @@ import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
  * Provides a configuration based on string properties.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public abstract class AbstractPropertyConfiguration

--- a/flow-server/src/main/java/com/vaadin/flow/server/AmbiguousRouteConfigurationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AmbiguousRouteConfigurationException.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.component.Component;
  * target with the given path.
  *
  * @author Vaadin Ltd
- * @since 1.4
+ * @since 1.4.3
  */
 public class AmbiguousRouteConfigurationException
         extends InvalidRouteConfigurationException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -145,6 +145,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      *
      * @param pageBuilder
      *            Page builder to use.
+     * @since 2.0
      */
     protected BootstrapHandler(PageBuilder pageBuilder) {
         this.pageBuilder = pageBuilder;
@@ -154,6 +155,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * Returns the current page builder object.
      *
      * @return Page builder in charge of constructing the resulting page.
+     * @since 2.0
      */
     protected PageBuilder getPageBuilder() {
         return pageBuilder;
@@ -197,6 +199,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * @param contextCallback
          *            a callback that is invoked to resolve the context root
          *            from the request
+         * @since 2.0
          */
         protected BootstrapContext(VaadinRequest request,
                 VaadinResponse response, VaadinSession session, UI ui,
@@ -223,6 +226,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * @param routeCallback
          *            a callback that is invoked to resolve the route from the
          *            request
+         * @since 7.0
          */
         protected BootstrapContext(VaadinRequest request,
                 VaadinResponse response, VaadinSession session, UI ui,
@@ -261,6 +265,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Gets the Vaadin service.
          *
          * @return the Vaadin/HTTP service
+         * @since 7.0
          */
         public VaadinService getService() {
             return request.getService();
@@ -279,6 +284,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Should custom theme be initialized.
          *
          * @return true if theme should be initialized
+         * @since 23.0
          */
         public boolean isInitTheme() {
             return initTheme;
@@ -289,6 +295,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          *
          * @param initTheme
          *            enable or disable theme initialisation
+         * @since 23.0
          */
         public void setInitTheme(boolean initTheme) {
             this.initTheme = initTheme;
@@ -425,6 +432,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          *
          * @return an optional pwa registry instance, or an empty optional if no
          *         pwa registry available for the context
+         * @since 2.2
          */
         protected Optional<PwaRegistry> getPwaRegistry() {
             VaadinService vaadinService = getSession().getService();
@@ -439,6 +447,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * bootstrap request.
          *
          * @return the route to activate
+         * @since 7.0
          */
         public Location getRoute() {
             return route;
@@ -471,6 +480,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          *            context root
          * @param session
          *            the vaadin session
+         * @since 2.0
          */
         public BootstrapUriResolver(String contextRootRelatiePath,
                 VaadinSession session) {
@@ -537,6 +547,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      *            the request
      * @return {@code true} if the request is Vaadin internal, {@code false}
      *         otherwise
+     * @since 7.0
      */
     public static boolean isFrameworkInternalRequest(VaadinRequest request) {
         if (request instanceof VaadinServletRequest) {
@@ -564,6 +575,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      *            the request
      * @return {@code true} if the request is for /VAADIN/*, {@code false}
      *         otherwise
+     * @since 23.0
      */
     public static boolean isVaadinStaticFileRequest(VaadinRequest request) {
         return request.getPathInfo() != null && HandlerHelper
@@ -579,6 +591,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * @return {@code true} if the request is potentially for HTML,
      *         {@code false} if it is certain that it is a request for a script,
      *         image or something else
+     * @since 23.0.2
      */
     protected boolean isRequestForHtml(VaadinRequest request) {
         if (request.getHeader(BootstrapHandler.SERVICE_WORKER_HEADER) != null) {
@@ -622,6 +635,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      *         {@code false} if not (location was valid)
      * @throws IOException
      *             in case writing to response fails
+     * @since 8.0
      */
     protected boolean writeErrorCodeIfRequestLocationIsInvalid(
             VaadinRequest request, VaadinResponse response) throws IOException {
@@ -649,6 +663,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
     /**
      * Interface for objects capable of building the bootstrap page.
+     *
+     * @since 2.0
      */
     public interface PageBuilder extends Serializable {
         /**
@@ -665,6 +681,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * Builds bootstrap pages.
      *
      * Do not subclass this, unless you really know why you are doing it.
+     *
+     * @since 2.0
      */
     protected static class BootstrapPageBuilder implements PageBuilder {
 
@@ -935,6 +953,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * @param chunks
          *            in the stat file
          * @return
+         * @since 24.8
          */
         protected List<String> getChunkKeys(ObjectNode chunks) {
             // include all chunks but the one used for exported
@@ -1377,6 +1396,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * @param ui
      *            the UI object
      * @return a new bootstrap context instance
+     * @since 2.0
      */
     protected BootstrapContext createBootstrapContext(VaadinRequest request,
             VaadinResponse response, UI ui,
@@ -1453,6 +1473,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * @param ui
      *            the UI for which the UIDL should be generated
      * @return a JSON object with the initial UIDL message
+     * @since 2.6
      */
     protected static ObjectNode getInitialUidl(UI ui) {
         ObjectNode json = new UidlWriter().createUidl(ui, false);
@@ -1572,6 +1593,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * @return the collection of link tags to be added to the page
      * @throws IOException
      *             if theme name cannot be extracted from file
+     * @since 24.1
      */
     protected static Collection<Element> getStylesheetTags(
             VaadinContext context, String fileName) throws IOException {
@@ -1596,6 +1618,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * @param fileName
      *            the stylesheet file name to add a reference to
      * @return the collection of links to be added to the page
+     * @since 24.1
      */
     protected static Collection<String> getStylesheetLinks(
             VaadinContext context, String fileName) {
@@ -1618,6 +1641,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      *            the directory where project's frontend files are located.
      *
      * @return the collection of links to be added to the page
+     * @since 24.6.8
      */
     protected static Collection<String> getStylesheetLinks(
             VaadinContext context, String fileName, File frontendDirectory) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -25,6 +25,8 @@ public final class Constants implements Serializable {
 
     /**
      * The prefix used for System property parameters.
+     *
+     * @since 2.0
      */
     public static final String VAADIN_PREFIX = "vaadin.";
 
@@ -47,6 +49,8 @@ public final class Constants implements Serializable {
     /**
      * Default path for the frontend statistics json file. It can be modified by
      * setting the system property "statistics.file.path".
+     *
+     * @since 2.0
      */
     public static final String STATISTICS_JSON_DEFAULT = Constants.VAADIN_CONFIGURATION
             + "stats.json";
@@ -54,74 +58,102 @@ public final class Constants implements Serializable {
     /**
      * Default resource directory to place template sources in. This is used
      * used for Vite production mode instead of a stats.json file.
+     *
+     * @since 9.0
      */
     public static final String TEMPLATE_DIRECTORY = Constants.VAADIN_CONFIGURATION
             + "templates/";
 
     /**
      * Name of the <code>npm</code> main file.
+     *
+     * @since 2.0
      */
     public static final String PACKAGE_JSON = "package.json";
 
     /**
      * Name of the <code>npm</code> version locking file.
+     *
+     * @since 23.0
      */
     public static final String PACKAGE_LOCK_JSON = "package-lock.json";
 
     /**
      * Name of the <code>pnpm</code> version locking file.
+     *
+     * @since 24.1
      */
     public static final String PACKAGE_LOCK_YAML = "pnpm-lock.yaml";
 
     /**
      * Name of the <code>bun</code> version locking file.
+     *
+     * @since 24.3
      */
     public static final String PACKAGE_LOCK_BUN = "bun.lockb";
 
     /**
      * Name of the <code>bun</code> version locking file, starting from bun 1.2.
+     *
+     * @since 24.6.3
      */
     public static final String PACKAGE_LOCK_BUN_1_2 = "bun.lock";
 
     /**
      * Target folder constant.
+     *
+     * @since 7.0
      */
     public static final String TARGET = "target";
 
     /**
      * Location for the frontend resources in jar files for compatibility mode
      * (also obsolete but supported for npm mode).
+     *
+     * @since 2.0.11
      */
     public static final String COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT = "META-INF/resources/frontend";
 
     /**
      * Location for the frontend resources in jar files.
+     *
+     * @since 2.0
      */
     public static final String RESOURCES_FRONTEND_DEFAULT = "META-INF/frontend";
 
     /**
      * The name of the application theme root folder.
+     *
+     * @since 6.0
      */
     public static final String APPLICATION_THEME_ROOT = "themes";
 
     /**
      * Location for the resources in jar files.
+     *
+     * @since 6.0
      */
     public static final String RESOURCES_JAR_DEFAULT = "META-INF/resources/";
 
     /**
      * Location for the theme resources in jar files.
+     *
+     * @since 6.0
      */
     public static final String RESOURCES_THEME_JAR_DEFAULT = RESOURCES_JAR_DEFAULT
             + APPLICATION_THEME_ROOT + "/";
 
     /**
      * Constant for whether pnpm is default or not.
+     *
+     * @since 9.0
      */
     public static final boolean ENABLE_PNPM_DEFAULT = false;
 
     /**
      * Constant for whether bun is default or not.
+     *
+     * @since 24.3
      */
     public static final boolean ENABLE_BUN_DEFAULT = false;
 
@@ -129,101 +161,139 @@ public final class Constants implements Serializable {
      * Constant for setting the pinned supported version of pnpm to be used by
      * default (see
      * {@link com.vaadin.flow.server.frontend.FrontendTools#DEFAULT_PNPM_VERSION}).
+     *
+     * @since 9.0
      */
     public static final boolean GLOBAL_PNPM_DEFAULT = false;
 
     /**
      * The default value for {@link InitParameters#NODE_AUTO_UPDATE}.
+     *
+     * @since 9.0
      */
     public static final boolean DEFAULT_NODE_AUTO_UPDATE = true;
 
     /**
      * The default value for
      * {@link InitParameters#REQUIRE_HOME_NODE_EXECUTABLE}.
+     *
+     * @since 9.0
      */
     public static final boolean DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE = false;
 
     /**
      * The default value for whether usage statistics is enabled.
+     *
+     * @since 9.0.2
      */
     public static final boolean DEFAULT_DEVMODE_STATS = true;
 
     /**
      * Internal parameter which prevent validation for annotations which are
      * allowed on an AppShell class
+     *
+     * @since 4.0
      */
     public static final String ALLOW_APPSHELL_ANNOTATIONS = "allow.appshell.annotations";
 
     /**
      * The path used in the vaadin servlet for handling static resources.
+     *
+     * @since 2.0
      */
     public static final String META_INF = "META-INF/";
 
     /**
      * The path used in the vaadin servlet for handling static resources.
+     *
+     * @since 2.0
      */
     public static final String VAADIN_MAPPING = "VAADIN/";
 
     /**
      * The path used in the vaadin servlet for handling push.
+     *
+     * @since 23.3
      */
     public static final String PUSH_MAPPING = VAADIN_MAPPING + "push";
 
     /**
      * The static build resources folder.
+     *
+     * @since 2.0
      */
     public static final String VAADIN_BUILD = "build/";
 
     /**
      * The static configuration resources folder.
+     *
+     * @since 2.0
      */
     public static final String VAADIN_CONFIGURATION = "config/";
 
     /**
      * The static resources root folder.
+     *
+     * @since 6.0
      */
     public static final String VAADIN_WEBAPP = "webapp/";
 
     /**
      * The generated PWA icons folder.
+     *
+     * @since 24.6
      */
     public static final String VAADIN_PWA_ICONS = "pwa-icons/";
 
     /**
      * The path to meta-inf/VAADIN/ where static resources are put on the
      * servlet.
+     *
+     * @since 2.0
      */
     public static final String VAADIN_SERVLET_RESOURCES = META_INF
             + VAADIN_MAPPING;
 
     /**
      * The path to webapp/ public resources root.
+     *
+     * @since 6.0
      */
     public static final String VAADIN_WEBAPP_RESOURCES = VAADIN_SERVLET_RESOURCES
             + VAADIN_WEBAPP;
 
     /**
      * The prefix used for all internal static files, relative to context root.
+     *
+     * @since 2.0
      */
     public static final String VAADIN_BUILD_FILES_PATH = VAADIN_MAPPING
             + VAADIN_BUILD;
 
     /**
      * Default path for local frontend resources packaged for jar add-ons.
+     *
+     * @since 2.0.5
      */
     public static final String LOCAL_FRONTEND_RESOURCES_PATH = "src/main/resources/META-INF/resources/frontend";
 
     /**
      * Property boolean for marking stats.json to be fetched from external
      * location.
+     *
+     * @since 2.2
      */
     public static final String EXTERNAL_STATS_FILE = "external.stats.file";
     /**
      * Property String for external stats.json location url.
+     *
+     * @since 2.2
      */
     public static final String EXTERNAL_STATS_URL = "external.stats.url";
     /**
      * Default location to look for the external stats.json.
+     *
+     * @since 2.2
      */
     public static final String DEFAULT_EXTERNAL_STATS_URL = "/vaadin-static/VAADIN/config/stats.json";
 
@@ -231,6 +301,8 @@ public final class Constants implements Serializable {
      * A request parameter that can be given in browser to force the Vaadin
      * application to create a new UI and session instance, thus overriding
      * {@code @PreserveOnRefresh} annotation.
+     *
+     * @since 3.0
      */
     public static final String URL_PARAMETER_RESTART_APPLICATION = "restartApplication";
 
@@ -239,147 +311,201 @@ public final class Constants implements Serializable {
      * application to close an existing UI and session. Unlike
      * {@link #URL_PARAMETER_RESTART_APPLICATION}, this will not create a new
      * session.
+     *
+     * @since 3.0
      */
     public static final String URL_PARAMETER_CLOSE_APPLICATION = "closeApplication";
 
     /**
      * UsageEntry name for UsageStatistics BootstrapHandler.
+     *
+     * @since 3.0
      */
     public static final String STATISTIC_FLOW_BOOTSTRAPHANDLER = "flow/BootstrapHandler";
 
     /**
      * UsageEntry name for UsageStatistics Routing Server.
+     *
+     * @since 3.0
      */
     public static final String STATISTIC_ROUTING_SERVER = "routing/server";
 
     /**
      * UsageEntry name for UsageStatistics Routing Client.
+     *
+     * @since 3.0
      */
     public static final String STATISTIC_ROUTING_CLIENT = "routing/client";
 
     /**
      * UsageEntry name for UsageStatistics Hybrid.
+     *
+     * @since 3.0
      */
     public static final String STATISTIC_ROUTING_HYBRID = "routing/hybrid";
 
     /**
      * UsageEntry name for Flow routes definitions. Marked used, if
      * RouteRegistry is not empty.
+     *
+     * @since 24.4
      */
     public static final String STATISTIC_HAS_FLOW_ROUTE = "has-flow-route";
 
     /**
      * UsageEntry name for automatic layout. Marked used, if Layout annotation
      * is used or RouteRegistry#setLayout is used directly.
+     *
+     * @since 24.5
      */
     public static final String STATISTIC_HAS_AUTO_LAYOUT = "has-auto-layout";
 
     /**
      * UsageEntry name for client route using automatic layout. Marked used, if
      * AvailableViewInfo#flowLayout is true for any client route.
+     *
+     * @since 24.5
      */
     public static final String STATISTIC_HAS_CLIENT_ROUTE_WITH_AUTO_LAYOUT = "has-auto-layout/client";
 
     /**
      * UsageEntry name for server route using automatic layout. Marked used, if
      * any server route's layout matches Layout annotated layout.
+     *
+     * @since 24.5
      */
     public static final String STATISTIC_HAS_SERVER_ROUTE_WITH_AUTO_LAYOUT = "has-auto-layout/server";
 
     /**
      * UsageEntry name for exported web components. Marked used, if either
      * WebComponentExporter or WebComponentExporterFactory is found in a project
+     *
+     * @since 24.4
      */
     public static final String STATISTIC_HAS_EXPORTED_WC = "has-exported-wc";
 
     /**
      * UsageEntry for rendering a Flow route. Marked as used, if a user
      * navigates to a Flow route and navigation doesn't end up with an error.
+     *
+     * @since 24.4
      */
     public static final String STATISTICS_FLOW_ROUTER = "flow-router";
 
     /**
      * UsageEntry for rendering an exported web component. Marked as used, if an
      * exported web component is instantiated on the server.
+     *
+     * @since 24.4
      */
     public static final String STATISTICS_EXPORTED_WC = "exported-wc";
 
     /**
      * The name of platform core components and tools versions file.
+     *
+     * @since 23.1.3
      */
     public static final String VAADIN_CORE_VERSIONS_JSON = "vaadin-core-versions.json";
 
     /**
      * The name of platform commercial components and tools versions file.
+     *
+     * @since 2.2
      */
     public static final String VAADIN_VERSIONS_JSON = "vaadin-versions.json";
 
     /**
      * Default live reload port as defined in Spring Boot Dev Tools.
+     *
+     * @since 4.0
      */
     public static final int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;
 
     /**
      * The name of the default dev bundle for the Express Build mode.
+     *
+     * @since 24.0
      */
     public static final String DEV_BUNDLE_NAME = "vaadin-dev-bundle";
 
     /**
      * The name of the default production bundle.
+     *
+     * @since 24.1
      */
     public static final String PROD_BUNDLE_NAME = "vaadin-prod-bundle";
 
     /**
      * The folder in the project where Flow generates Express Build mode
      * application dev bundle.
+     *
+     * @since 24.0
      */
     public static final String DEV_BUNDLE_LOCATION = "dev-bundle";
 
     /**
      * The folder where the bundle zip files are stored.
+     *
+     * @since 24.3
      */
     public static final String BUNDLE_LOCATION = "src/main/bundles/";
 
     /**
      * The file name of the compressed development bundle.
+     *
+     * @since 24.3
      */
     public static final String DEV_BUNDLE_COMPRESSED_FILE = "dev.bundle";
 
     /**
      * Location of the compressed development bundle file.
+     *
+     * @since 24.3
      */
     public static final String DEV_BUNDLE_COMPRESSED_FILE_LOCATION = BUNDLE_LOCATION
             + DEV_BUNDLE_COMPRESSED_FILE;
 
     /**
      * The path part where dev-bundle is located inside the jar.
+     *
+     * @since 24.0
      */
     public static final String DEV_BUNDLE_JAR_PATH = DEV_BUNDLE_NAME + "/";
 
     /**
      * The path part where production bundle is located inside the jar.
+     *
+     * @since 24.1
      */
     public static final String PROD_BUNDLE_JAR_PATH = PROD_BUNDLE_NAME + "/";
 
     /**
      * The file name of the compressed production bundle.
+     *
+     * @since 24.3
      */
     public static final String PROD_BUNDLE_COMPRESSED_FILE = "prod.bundle";
 
     /**
      * Location of the compressed production bundle file.
+     *
+     * @since 24.3
      */
     public static final String PROD_BUNDLE_COMPRESSED_FILE_LOCATION = BUNDLE_LOCATION
             + PROD_BUNDLE_COMPRESSED_FILE;
 
     /**
      * The directory name inside dev bundle for the frontend assets.
+     *
+     * @since 24.0
      */
     public static final String ASSETS = "assets";
 
     /**
      * Name of the temporary file storing internal flag showing that Flow needs
      * to re-build the production bundle or not.
+     *
+     * @since 24.1
      */
     public static final String NEEDS_BUNDLE_BUILD_FILE = Constants.VAADIN_CONFIGURATION
             + "needs-build";
@@ -387,35 +513,47 @@ public final class Constants implements Serializable {
     /**
      * Key for storing the value of `alwaysExecutePrepareFrontend` flag of
      * Gradle builds in a build info (token) file.
+     *
+     * @since 24.2
      */
     public static final String DISABLE_PREPARE_FRONTEND_CACHE = "disable.prepare.frontend.cache";
 
     /**
      * Attribute used by HasSize to mark elements that have been set to full
      * width.
+     *
+     * @since 24.7
      */
     public static final String ATTRIBUTE_WIDTH_FULL = "data-width-full";
 
     /**
      * Attribute used by HasSize to mark elements that have been set to full
      * height.
+     *
+     * @since 24.7
      */
     public static final String ATTRIBUTE_HEIGHT_FULL = "data-height-full";
 
     /**
      * maximum allowed size of a complete request for multipart stream upload
      * requests.
+     *
+     * @since 24.8
      */
     public static final long DEFAULT_REQUEST_SIZE_MAX = -1;
 
     /**
      * maximum allowed size of a single uploaded file for multipart stream
      * upload requests.
+     *
+     * @since 24.8
      */
     public static final long DEFAULT_FILE_SIZE_MAX = -1;
 
     /**
      * maximum number of files allowed per multipart stream upload requests.
+     *
+     * @since 24.8
      */
     public static final long DEFAULT_FILE_COUNT_MAX = 10000;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -68,11 +68,15 @@ public class DefaultDeploymentConfiguration
 
     /**
      * Default value for {@link #getMaxMessageSuspendTimeout()} ()} = {@value} .
+     *
+     * @since 3.0.1
      */
     public static final int DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT = 5000;
 
     /**
      * Default value for {@link #getWebComponentDisconnect()} = {@value}.
+     *
+     * @since 2.0
      */
     public static final int DEFAULT_WEB_COMPONENT_DISCONNECT = 300;
 
@@ -117,6 +121,7 @@ public class DefaultDeploymentConfiguration
      * @param initParameters
      *            the init parameters that should make up the foundation for
      *            this configuration
+     * @since 6.0
      */
     public DefaultDeploymentConfiguration(ApplicationConfiguration parentConfig,
             Class<?> systemPropertyBaseClass, Properties initParameters) {
@@ -204,6 +209,8 @@ public class DefaultDeploymentConfiguration
      * {@inheritDoc}
      * <p>
      * The default max message suspension time is 5000 milliseconds.
+     *
+     * @since 3.0.1
      */
     @Override
     public int getMaxMessageSuspendTimeout() {
@@ -259,6 +266,8 @@ public class DefaultDeploymentConfiguration
      * {@inheritDoc}
      * <p>
      * The default mode is <code>""</code> which uses the service mapping.
+     *
+     * @since 23.3.5
      */
     @Override
     public String getPushServletMapping() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/DependencyFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DependencyFilter.java
@@ -38,6 +38,7 @@ public interface DependencyFilter extends Serializable {
      * @param service
      *            a Vaadin service
      * @return a list of dependencies to load
+     * @since 3.0
      */
     List<Dependency> filter(List<Dependency> dependencies,
             VaadinService service);

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -40,6 +40,7 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
      * @param vaadinConfig
      *            the config to get the rest of the properties from
      * @return {@link DeploymentConfiguration} instance
+     * @since 2.2
      */
     public DeploymentConfiguration createDeploymentConfiguration(
             Class<?> systemPropertyBaseClass, VaadinConfig vaadinConfig) {
@@ -59,6 +60,7 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
      * @param vaadinConfig
      *            the config to get the rest of the properties from
      * @return {@link DeploymentConfiguration} instance
+     * @since 2.2
      */
     public DeploymentConfiguration createPropertyDeploymentConfiguration(
             Class<?> systemPropertyBaseClass, VaadinConfig vaadinConfig) {
@@ -77,6 +79,7 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
      * @param vaadinConfig
      *            the config to get the rest of the properties from
      * @return {@link Properties} instance
+     * @since 2.2
      */
     protected Properties createInitParameters(Class<?> systemPropertyBaseClass,
             VaadinConfig vaadinConfig) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevToolsToken.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevToolsToken.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
  * refused after a server restart.
  *
  * For internal yse only.
+ *
+ * @since 24.3.4
  */
 public class DevToolsToken implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/ErrorEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ErrorEvent.java
@@ -45,6 +45,7 @@ public class ErrorEvent implements Serializable {
      *            the throwable to wrap
      * @param componentNode
      *            stateNode of for exception component.
+     * @since 24.3
      */
     public ErrorEvent(Throwable throwable, StateNode componentNode) {
         this.throwable = throwable;
@@ -65,6 +66,7 @@ public class ErrorEvent implements Serializable {
      * empty optional.
      *
      * @return Component that error happened for if available
+     * @since 24.3
      */
     public Optional<Component> getComponent() {
         return getElement().flatMap(Element::getComponent);
@@ -75,6 +77,7 @@ public class ErrorEvent implements Serializable {
      * optional.
      *
      * @return Element that error happened for if available
+     * @since 24.3
      */
     public Optional<Element> getElement() {
         if (componentNode != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/ErrorHandlerUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ErrorHandlerUtil.java
@@ -30,6 +30,8 @@ import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 /**
  * Utility class for use with ErrorHandler to show HasErrorParameter view when
  * an exception happens during a RPC call outside of navigation.
+ *
+ * @since 24.3
  */
 public final class ErrorHandlerUtil {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/ErrorRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ErrorRouteRegistry.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.router.internal.ErrorTargetEntry;
  * Interface class for RouteRegistries that can be used to request for error
  * navigation views for Exceptions.
  *
- * @since
+ * @since 6.0.10
  */
 public interface ErrorRouteRegistry extends Serializable {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/ExecutionFailedException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ExecutionFailedException.java
@@ -14,7 +14,7 @@ import com.vaadin.flow.server.frontend.FallibleCommand;
  * Thrown by {@link FallibleCommand} if it's unable to complete its execution.
  *
  * @author Vaadin Ltd
- * @since 2.0
+ * @since 2.0.5
  *
  */
 public class ExecutionFailedException extends Exception {

--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -37,7 +37,7 @@ import com.vaadin.flow.shared.ApplicationConstants;
  * Contains helper methods for {@link VaadinServlet} and generally for handling
  * {@link VaadinRequest VaadinRequests}.
  *
- * @since 1.0
+ * @since 2.2
  */
 public class HandlerHelper implements Serializable {
 
@@ -90,6 +90,8 @@ public class HandlerHelper implements Serializable {
 
         /**
          * INIT requests.
+         *
+         * @since 3.0
          */
         INIT(ApplicationConstants.REQUEST_TYPE_INIT),
 
@@ -100,6 +102,8 @@ public class HandlerHelper implements Serializable {
 
         /**
          * WebComponent resynchronization requests.
+         *
+         * @since 23.3.2
          */
         WEBCOMPONENT_RESYNC(
                 ApplicationConstants.REQUEST_TYPE_WEBCOMPONENT_RESYNC),
@@ -115,11 +119,15 @@ public class HandlerHelper implements Serializable {
 
         /**
          * Page showing that the browser is unsupported.
+         *
+         * @since 23.4
          */
         BROWSER_TOO_OLD("oldbrowser"),
 
         /**
          * Translation properties file requests.
+         *
+         * @since 24.4
          */
         TRANSLATION_FILE(ApplicationConstants.REQUEST_TYPE_TRANSLATION_FILE);
 
@@ -210,6 +218,7 @@ public class HandlerHelper implements Serializable {
      *            the servlet request
      * @return {@code true} if the request is Vaadin internal, {@code false}
      *         otherwise
+     * @since 7.0
      */
     public static boolean isFrameworkInternalRequest(String servletMappingPath,
             HttpServletRequest request) {
@@ -287,6 +296,7 @@ public class HandlerHelper implements Serializable {
      * @return an optional containing the path relative to the servlet if the
      *         request is inside the servlet mapping, an empty optional
      *         otherwise
+     * @since 8.0
      */
     public static Optional<String> getPathIfInsideServlet(
             String servletMappingPath, String requestedPath) {
@@ -377,6 +387,7 @@ public class HandlerHelper implements Serializable {
      *            the servlet request
      * @return the path inside the context root, not including the slash after
      *         the context root path
+     * @since 23.0.1
      */
     public static String getRequestPathInsideContext(
             HttpServletRequest request) {
@@ -488,6 +499,7 @@ public class HandlerHelper implements Serializable {
      *            the URL path to be verified.
      * @return {@code true}, if the given path has a directory change
      *         instruction, {@code false} otherwise.
+     * @since 5.0
      */
     public static boolean isPathUnsafe(String path) {
         // Check that the path does not have '/../', '\..\', %5C..%5C,
@@ -509,6 +521,8 @@ public class HandlerHelper implements Serializable {
      * Spring Security.
      * <p>
      * These paths are relative to a potential Vaadin mapping
+     *
+     * @since 7.0
      */
     public static String[] getPublicResources() {
         return publicResources;
@@ -521,6 +535,8 @@ public class HandlerHelper implements Serializable {
      * <p>
      * These URLs are always relative to the root path and independent of any
      * Vaadin mapping
+     *
+     * @since 24.0.2
      */
     public static String[] getPublicResourcesRoot() {
         return publicResourcesRoot;
@@ -536,6 +552,7 @@ public class HandlerHelper implements Serializable {
      * @param iconPath
      *            path of the base icon.
      * @return list of paths of icon variants.
+     * @since 24.3.3
      */
     public static List<String> getIconVariants(String iconPath) {
         return PwaRegistry.getIconTemplates(iconPath).stream()
@@ -546,6 +563,8 @@ public class HandlerHelper implements Serializable {
      * URLs matching these patterns should be publicly available for
      * applications to work but might require a security context, i.e.
      * authentication information.
+     *
+     * @since 7.0
      */
     public static String[] getPublicResourcesRequiringSecurityContext() {
         return new String[] { //
@@ -571,6 +590,7 @@ public class HandlerHelper implements Serializable {
      *            the HTTP servlet request to evaluate
      * @return {@code true} if the request is initiated by a non-HTML context;
      *         {@code false} otherwise
+     * @since 24.8
      */
     public static boolean isNonHtmlInitiatedRequest(
             HttpServletRequest request) {
@@ -592,6 +612,7 @@ public class HandlerHelper implements Serializable {
      *            the Vaadin request to evaluate
      * @return {@code true} if the request is initiated by a non-HTML context;
      *         {@code false} otherwise
+     * @since 24.8
      */
     public static boolean isNonHtmlInitiatedRequest(VaadinRequest request) {
         return isNonHtmlInitiatedRequest(request.getHeader(FETCH_DEST_HEADER));

--- a/flow-server/src/main/java/com/vaadin/flow/server/HttpStatusCode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HttpStatusCode.java
@@ -12,6 +12,8 @@ import java.util.stream.Stream;
 
 /**
  * HTTP status codes as defined in RFC 2068.
+ *
+ * @since 23.1
  */
 public enum HttpStatusCode {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.component.UI;
  * parameters here.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 4.0
  */
 public class InitParameters implements Serializable {
 
@@ -80,11 +80,15 @@ public class InitParameters implements Serializable {
     /**
      * Configuration name for the time waiting for the frontend build tool to
      * output a success or error pattern.
+     *
+     * @since 24.0
      */
     public static final String SERVLET_PARAMETER_DEVMODE_TIMEOUT = "devmode.output.pattern.timeout";
 
     /**
      * Configuration name for adding extra options to the vite.
+     *
+     * @since 9.0
      */
     public static final String SERVLET_PARAMETER_DEVMODE_VITE_OPTIONS = "devmode.vite.options";
 
@@ -99,6 +103,8 @@ public class InitParameters implements Serializable {
      * A comma separated list of IP addresses, potentially with wildcards, which
      * can connect to the dev tools. If not specified, only localhost
      * connections are allowed.
+     *
+     * @since 24.3
      */
     public static final String SERVLET_PARAMETER_DEVMODE_HOSTS_ALLOWED = "devmode.hostsAllowed";
 
@@ -108,18 +114,20 @@ public class InitParameters implements Serializable {
      * is supposed to contain a single address, and the HTTP request to have a
      * single occurrence of the header. If not specified, remote address are
      * read from the {@literal X-Forwarded-For} header.
+     *
+     * @since 24.4
      */
     public static final String SERVLET_PARAMETER_DEVMODE_REMOTE_ADDRESS_HEADER = "devmode.remoteAddressHeader";
 
     /**
      * Configuration parameter name for enabling pnpm.
-     *
-     * @since 2.2
      */
     public static final String SERVLET_PARAMETER_ENABLE_PNPM = "pnpm.enable";
 
     /**
      * Configuration parameter name for enabling bun.
+     *
+     * @since 24.3
      */
     public static final String SERVLET_PARAMETER_ENABLE_BUN = "bun.enable";
 
@@ -133,6 +141,8 @@ public class InitParameters implements Serializable {
     /**
      * Configuration parameter name for using globally installed pnpm or default
      * one.
+     *
+     * @since 9.0
      */
     public static final String SERVLET_PARAMETER_GLOBAL_PNPM = "pnpm.global";
 
@@ -142,15 +152,13 @@ public class InitParameters implements Serializable {
      * Note that if the dev tools are disabled
      * ({@link #SERVLET_PARAMETER_DEVMODE_ENABLE_DEV_TOOLS} is set to {@code
      * false}), the live reload will be disabled as well.
-     *
-     * @since
      */
     public static final String SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD = "devmode.liveReload.enabled";
 
     /**
      * Configuration parameter name for enabling dev tools.
      *
-     * @since 9.0
+     * @since 23.1
      */
     public static final String SERVLET_PARAMETER_DEVMODE_ENABLE_DEV_TOOLS = "devmode.devTools.enabled";
 
@@ -160,7 +168,7 @@ public class InitParameters implements Serializable {
      * {@link com.vaadin.flow.component.UI} instances will be serialized.
      * Otherwise, it won't be serialized.
      *
-     * @since
+     * @since 8.0
      */
     public static final String APPLICATION_PARAMETER_DEVMODE_ENABLE_SERIALIZE_SESSION = "devmode.sessionSerialization.enabled";
 
@@ -168,13 +176,15 @@ public class InitParameters implements Serializable {
      * Configuration parameter name for enabling component tracking in
      * development mode. If not set, tracking is enabled by default.
      *
-     * @since
+     * @since 24.4
      */
     public static final String APPLICATION_PARAMETER_DEVMODE_ENABLE_COMPONENT_TRACKER = "devmode.componentTracker.enabled";
 
     /**
      * Configuration parameter name for adding extra file extensions for stats
      * bundle to generate hashes for.
+     *
+     * @since 24.6
      */
     public static final String FRONTEND_EXTRA_EXTENSIONS = "devmode.frontendExtraFileExtensions";
 
@@ -185,6 +195,8 @@ public class InitParameters implements Serializable {
 
     /**
      * Menu access control property.
+     *
+     * @since 24.4
      */
     public static final String MENU_ACCESS_CONTROL = "menu.access.control";
 
@@ -197,8 +209,6 @@ public class InitParameters implements Serializable {
     /**
      * Configuration parameter name for requiring node executable installed in
      * home directory.
-     *
-     * @since
      */
     public static final String REQUIRE_HOME_NODE_EXECUTABLE = "require.home.node";
 
@@ -206,7 +216,7 @@ public class InitParameters implements Serializable {
      * Configuration parameter name for requiring node executable installed in
      * home directory.
      *
-     * @since
+     * @since 9.0
      */
     public static final String NODE_AUTO_UPDATE = "node.auto.update";
 
@@ -223,7 +233,7 @@ public class InitParameters implements Serializable {
     /**
      * Configuration name for the build folder.
      *
-     * @since
+     * @since 7.0
      */
     public static final String BUILD_FOLDER = "build.folder";
 
@@ -231,38 +241,50 @@ public class InitParameters implements Serializable {
      * Packages, in addition to the internally used ones, to run postinstall
      * scripts for.
      *
-     * @since
+     * @since 23.0
      */
     public static final String ADDITIONAL_POSTINSTALL_PACKAGES = "npm.postinstallPackages";
 
     /**
      * Configuration name for enabling development using the frontend
      * development server instead of using an application bundle.
+     *
+     * @since 24.0
      */
     public static final String FRONTEND_HOTDEPLOY = "frontend.hotdeploy";
 
     /**
      * Configuration name for adding dependencies on other projects when using
      * the frontend development server.
+     *
+     * @since 24.1
      */
     public static final String FRONTEND_HOTDEPLOY_DEPENDENCIES = "frontend.hotdeploy.dependencies";
 
     /**
      * Configuration name for enabling ci build for npm/pnpm.
+     *
+     * @since 24.1
      */
     public static final String CI_BUILD = "vaadin.ci.build";
 
     /**
      * Configuration name for disabling dev bundle rebuild.
+     *
+     * @since 24.1
      */
     public static final String SKIP_DEV_BUNDLE_REBUILD = "vaadin.skip.dev.bundle";
 
     /**
      * Configuration name for forcing optimized production bundle build.
+     *
+     * @since 24.1
      */
     public static final String FORCE_PRODUCTION_BUILD = "vaadin.force.production.build";
     /**
      * Configuration name for forcing optimized production bundle build.
+     *
+     * @since 24.3
      */
     public static final String COMPRESS_BUNDLE = "vaadin.compress.bundle";
 
@@ -270,11 +292,15 @@ public class InitParameters implements Serializable {
      * Configuration name to enable adding a commercial banner to the
      * application when commercial components are used without a valid license
      * key.
+     *
+     * @since 24.9
      */
     public static final String COMMERCIAL_WITH_BANNER = "commercialWithBanner";
 
     /**
      * Configuration name for cleaning or leaving frontend files in build.
+     *
+     * @since 24.4
      */
     public static final String CLEAN_BUILD_FRONTEND_FILES = "vaadin.clean.build.frontend.files";
 
@@ -283,16 +309,22 @@ public class InitParameters implements Serializable {
      * new tab for the application in development mode.
      *
      * Time is given in minutes.
+     *
+     * @since 24.4
      */
     public static final String LAUNCH_BROWSER_DELAY = "launch-browser-delay";
 
     /**
      * Configuration name for setting the application identifier.
+     *
+     * @since 24.5
      */
     public static final String APPLICATION_IDENTIFIER = "applicationIdentifier";
 
     /**
      * Configuration name for excluding npm packages for web components.
+     *
+     * @since 24.6
      */
     public static final String NPM_EXCLUDE_WEB_COMPONENTS = "npm.excludeWebComponents";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/InlineTargets.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InlineTargets.java
@@ -41,6 +41,7 @@ public class InlineTargets {
      *            inline dependency to add to bootstrap page
      * @param service
      *            the service that can find the dependency
+     * @since 7.0
      */
     public void addInlineDependency(Inline inline, VaadinService service) {
         Inline.Wrapping type;

--- a/flow-server/src/main/java/com/vaadin/flow/server/InvalidMenuAccessControlException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InvalidMenuAccessControlException.java
@@ -12,7 +12,7 @@ package com.vaadin.flow.server;
  * Exception indicating that the application's Menu access control has been
  * configured incorrectly.
  *
- * @since 1.0
+ * @since 24.4
  */
 public class InvalidMenuAccessControlException extends RuntimeException {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/LoadDependenciesOnStartup.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/LoadDependenciesOnStartup.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
  * This annotation must be added to the class implementing
  * {@link AppShellConfigurator}.
  *
+ * @since 24.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flow-server/src/main/java/com/vaadin/flow/server/Mode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Mode.java
@@ -12,6 +12,8 @@ package com.vaadin.flow.server;
  * The mode the application is running in.
  *
  * One of production, development using livereload or development using bundle
+ *
+ * @since 24.0.1
  */
 public enum Mode {
     PRODUCTION_CUSTOM("production", true),

--- a/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  * {@literal manifest.webmanifest}. Same applies for service worker and
  * generated icons.
  *
- * @since 1.2
+ * @since 1.1
  *
  * @see <a href=
  *      "https://developer.mozilla.org/en-US/Apps/Progressive">https://developer.mozilla.org/en-US/Apps/Progressive</a>
@@ -176,6 +176,7 @@ public @interface PWA {
      * </p>
      *
      * @return whether offline is enabled.
+     * @since 23.1
      */
     boolean offline() default true;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -74,6 +74,7 @@ public class Platform implements Serializable {
      *
      * @return Hilla version if Hilla is on the classpath; empty Optional if
      *         Hilla is not on the classpath.
+     * @since 24.1.8
      */
     public static Optional<String> getHillaVersion() {
         // thread-safe: in the worst case hillaVersion may be computed multiple

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -37,7 +37,7 @@ import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_SYNC_ID_CH
  * The property handling implementation of {@link DeploymentConfiguration} based
  * on a base class for resolving system properties and a set of init parameters.
  *
- * @since 1.2
+ * @since 1.2.1
  */
 public class PropertyDeploymentConfiguration
         extends AbstractDeploymentConfiguration {
@@ -62,6 +62,7 @@ public class PropertyDeploymentConfiguration
      * @param initParameters
      *            the init parameters that should make up the foundation for
      *            this configuration
+     * @since 6.0
      */
     public PropertyDeploymentConfiguration(
             ApplicationConfiguration parentConfig,
@@ -298,6 +299,7 @@ public class PropertyDeploymentConfiguration
      *            a property name
      * @return whether the {@code property} is explicitly set in the
      *         configuration
+     * @since 6.0
      */
     protected boolean isOwnProperty(String property) {
         return getApplicationProperty(getProperties()::get, property) != null;
@@ -307,6 +309,7 @@ public class PropertyDeploymentConfiguration
      * Returns parent application configuration.
      *
      * @return the parent config
+     * @since 6.0
      */
     protected ApplicationConfiguration getParentConfiguration() {
         return parentConfig;

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
@@ -19,7 +19,7 @@ import java.util.List;
  * Takes {@link PWA} in constructor to fill properties. Sanitizes the input and
  * falls back to default values if {@link PWA} is unavailable ({@code null}).
  *
- * @since 1.2
+ * @since 1.1
  */
 public class PwaConfiguration implements Serializable {
     public static final String DEFAULT_PATH = "manifest.webmanifest";
@@ -48,6 +48,8 @@ public class PwaConfiguration implements Serializable {
 
     /**
      * Creates the configuration using default PWA parameters.
+     *
+     * @since 6.0
      */
     public PwaConfiguration() {
         this(false, DEFAULT_NAME, "Flow PWA", "", DEFAULT_BACKGROUND_COLOR,
@@ -61,6 +63,7 @@ public class PwaConfiguration implements Serializable {
      *
      * @param pwa
      *            the annotation to use for configuration
+     * @since 6.0
      */
     public PwaConfiguration(PWA pwa) {
         this(true, pwa.name(), pwa.shortName(), pwa.description(),
@@ -98,6 +101,7 @@ public class PwaConfiguration implements Serializable {
      *            the list of files to add for pre-caching
      * @param offlineEnabled
      *            is offline enabled.
+     * @since 7.0
      */
     public PwaConfiguration(boolean enabled, String name, String shortName,
             String description, String backgroundColor, String themeColor,
@@ -260,6 +264,7 @@ public class PwaConfiguration implements Serializable {
      * Is offline enabled.
      *
      * @return is offline enabled.
+     * @since 23.1
      */
     public boolean isOfflineEnabled() {
         return offlineEnabled;
@@ -306,6 +311,7 @@ public class PwaConfiguration implements Serializable {
      * Set {@link PWA#offlinePath()} value in PWA annotation to enable.
      *
      * @return true when static offline HTML is used
+     * @since 6.0
      */
     public boolean isOfflinePathEnabled() {
         return !offlinePath.isEmpty();

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaIcon.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaIcon.java
@@ -40,7 +40,7 @@ import org.jsoup.nodes.Element;
  *
  * Icon caching is left to the browser if it's not cached with service worker.
  *
- * @since 1.2
+ * @since 1.1
  */
 public class PwaIcon implements Serializable {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
@@ -56,7 +56,7 @@ import elemental.json.JsonObject;
  * <li>Service worker
  * </ul>
  *
- * @since 1.2
+ * @since 1.1
  */
 public class PwaRegistry implements Serializable {
 
@@ -88,6 +88,7 @@ public class PwaRegistry implements Serializable {
      *            the context
      * @throws IOException
      *             when icon or offline resources are not found.
+     * @since 3.0
      */
     public PwaRegistry(PWA pwa, ServletContext servletContext)
             throws IOException {
@@ -424,6 +425,7 @@ public class PwaRegistry implements Serializable {
      * resources) as a String.
      *
      * @return contents of sw-runtime.js
+     * @since 6.0
      */
     public String getRuntimeServiceWorkerJs() {
         return runtimeServiceWorkerJs;
@@ -481,6 +483,7 @@ public class PwaRegistry implements Serializable {
      * @param baseName
      *            path of the base icon.
      * @return list of PWA icons variants.
+     * @since 24.6
      */
     public static List<PwaIcon> getIconTemplates(String baseName) {
         List<PwaIcon> icons = new ArrayList<>();

--- a/flow-server/src/main/java/com/vaadin/flow/server/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/RouteRegistry.java
@@ -120,6 +120,7 @@ public interface RouteRegistry extends Serializable {
      * @param accessControls
      *            the access controls to use for checking access
      * @return list of accessible menu routes available for this registry
+     * @since 24.4
      */
     List<RouteData> getRegisteredAccessibleMenuRoutes(
             VaadinRequest vaadinRequest,
@@ -135,6 +136,7 @@ public interface RouteRegistry extends Serializable {
      *         {@link RouteTarget} and {@link RouteParameters} extracted from
      *         the <code>url</code> argument according with the route
      *         configuration.
+     * @since 4.0
      */
     NavigationRouteTarget getNavigationRouteTarget(String url);
 
@@ -148,6 +150,7 @@ public interface RouteRegistry extends Serializable {
      *            parameter values that may be used with given target.
      * @return the {@link RouteTarget} instance matching the given target
      *         component and route parameters.
+     * @since 4.0
      */
     RouteTarget getRouteTarget(Class<? extends Component> target,
             RouteParameters parameters);
@@ -198,6 +201,7 @@ public interface RouteRegistry extends Serializable {
      *            parameters for the target url.
      * @return {@link Optional} navigation target url string or
      *         {@link Optional#empty()} if navigation target was not found
+     * @since 4.0
      */
     Optional<String> getTargetUrl(Class<? extends Component> navigationTarget,
             RouteParameters parameters);
@@ -214,6 +218,7 @@ public interface RouteRegistry extends Serializable {
      *            {@code null}
      * @return {@link Optional} navigation target template string or
      *         {@link Optional#empty()} if navigation target was not found
+     * @since 4.0
      */
     Optional<String> getTemplate(Class<? extends Component> navigationTarget);
 
@@ -249,6 +254,7 @@ public interface RouteRegistry extends Serializable {
      * Gets the Vaadin context which the registry belongs to.
      *
      * @return the Vaadin context
+     * @since 9.0
      */
     VaadinContext getContext();
 
@@ -260,6 +266,7 @@ public interface RouteRegistry extends Serializable {
      * @throws NotFoundException
      *             if given navigation target is not registered
      * @return {@code true} if parameters are required
+     * @since 9.0
      */
     boolean hasMandatoryParameter(Class<? extends Component> navigationTarget);
 
@@ -268,6 +275,7 @@ public interface RouteRegistry extends Serializable {
      *
      * @param layout
      *            {@link RouterLayout} class
+     * @since 24.5
      */
     void setLayout(Class<? extends RouterLayout> layout);
 
@@ -277,6 +285,7 @@ public interface RouteRegistry extends Serializable {
      * @param path
      *            current path
      * @return {@link RouterLayout} component or null
+     * @since 24.5
      */
     Class<? extends RouterLayout> getLayout(String path);
 
@@ -286,6 +295,7 @@ public interface RouteRegistry extends Serializable {
      * @param path
      *            current path
      * @return {@code true} if layout exists
+     * @since 24.5
      */
     boolean hasLayout(String path);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/ServiceContextUriResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ServiceContextUriResolver.java
@@ -29,6 +29,7 @@ public class ServiceContextUriResolver extends VaadinUriResolver
      * @param uri
      *            the URI to resolve
      * @return the URI resolved to be relative to the context root
+     * @since 3.0
      */
     public String resolveVaadinUri(String uri) {
         return super.resolveVaadinUri(uri, "/");

--- a/flow-server/src/main/java/com/vaadin/flow/server/ServiceInitEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ServiceInitEvent.java
@@ -68,6 +68,7 @@ public class ServiceInitEvent extends EventObject {
      *
      * @param indexHtmlRequestListener
      *            the Index HTML request listener to be added.
+     * @since 3.0
      */
     public void addIndexHtmlRequestListener(
             IndexHtmlRequestListener indexHtmlRequestListener) {
@@ -94,6 +95,7 @@ public class ServiceInitEvent extends EventObject {
      *
      * @param vaadinRequestInterceptor
      *            the request interceptor to add, not <code>null</code>
+     * @since 24.3
      */
     public void addVaadinRequestInterceptor(
             VaadinRequestInterceptor vaadinRequestInterceptor) {
@@ -119,6 +121,7 @@ public class ServiceInitEvent extends EventObject {
      *
      * @param executor
      *            the executor to set.
+     * @since 24.8
      */
     public void setExecutor(Executor executor) {
         this.executor = executor;
@@ -139,6 +142,7 @@ public class ServiceInitEvent extends EventObject {
      * for the service.
      *
      * @return the stream of added Index HTML request listeners
+     * @since 3.0
      */
     public Stream<IndexHtmlRequestListener> getAddedIndexHtmlRequestListeners() {
         return addedIndexHtmlRequestListeners.stream();
@@ -159,6 +163,7 @@ public class ServiceInitEvent extends EventObject {
      * the service.
      *
      * @return the stream of added request interceptors
+     * @since 24.3
      */
     public Stream<VaadinRequestInterceptor> getAddedVaadinRequestInterceptor() {
         return addedVaadinRequestInterceptors.stream();
@@ -170,6 +175,7 @@ public class ServiceInitEvent extends EventObject {
      *
      * @return an {@link Optional} containing the {@link Executor}, or an empty
      *         {@link Optional} if no executor is set.
+     * @since 24.8
      */
     public Optional<Executor> getExecutor() {
         return Optional.ofNullable(executor);

--- a/flow-server/src/main/java/com/vaadin/flow/server/SessionLockCheckStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SessionLockCheckStrategy.java
@@ -10,6 +10,8 @@ package com.vaadin.flow.server;
 
 /**
  * Available strategies for session lock checking.
+ *
+ * @since 24.4
  */
 public enum SessionLockCheckStrategy {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileHandlerFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileHandlerFactory.java
@@ -12,7 +12,7 @@ package com.vaadin.flow.server;
  * A factory to create a {@link StaticFileHandler}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0.2
  *
  */
 public interface StaticFileHandlerFactory {

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -91,6 +91,7 @@ public class StaticFileServer implements StaticFileHandler {
      *
      * @param vaadinService
      *            vaadin service for the deployment, not <code>null</code>
+     * @since 7.0
      */
     public StaticFileServer(VaadinService vaadinService) {
         this.vaadinService = vaadinService;
@@ -441,6 +442,7 @@ public class StaticFileServer implements StaticFileHandler {
      *         {@code null} if there is no resource at that path or it should
      *         not be exposed
      * @see VaadinService#getStaticResource(String)
+     * @since 6.0.2
      */
     protected URL getStaticResource(String path) {
         return vaadinService.getStaticResource(path);

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
@@ -238,6 +238,7 @@ public class StreamResource extends AbstractStreamResource {
      * @param value
      *            value of the header
      * @return this resource
+     * @since 9.0
      */
     public StreamResource setHeader(String name, String value) {
         if (headers == null) {
@@ -254,6 +255,7 @@ public class StreamResource extends AbstractStreamResource {
      *            name of header to get value for
      * @return an optional with header value, or an empty optional if it has not
      *         been set
+     * @since 9.0
      */
     public Optional<String> getHeader(String name) {
         if (headers != null) {
@@ -269,6 +271,7 @@ public class StreamResource extends AbstractStreamResource {
      * like {@link #setContentType(String)} and {@link #setCacheTime(long)}.
      *
      * @return a map of headers and their values
+     * @since 9.0
      */
     public Map<String, String> getHeaders() {
         if (headers == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResourceRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResourceRegistry.java
@@ -113,6 +113,7 @@ public class StreamResourceRegistry implements Serializable {
      *            element request handler to register
      *
      * @return registration handler
+     * @since 24.8
      */
     public StreamRegistration registerResource(
             ElementRequestHandler elementRequestHandler) {
@@ -137,6 +138,7 @@ public class StreamResourceRegistry implements Serializable {
      *            owner element this request handler is scoped to
      *
      * @return registration handler
+     * @since 24.8
      */
     public StreamRegistration registerResource(
             ElementRequestHandler elementRequestHandler, Element owner) {
@@ -150,6 +152,8 @@ public class StreamResourceRegistry implements Serializable {
      * instances as {@link AbstractStreamResource} compatible instances.
      *
      * For internal use only. May be renamed or removed in a future release.
+     *
+     * @since 24.8
      */
     public static class ElementStreamResource extends AbstractStreamResource {
         private final ElementRequestHandler elementRequestHandler;
@@ -209,6 +213,7 @@ public class StreamResourceRegistry implements Serializable {
      * @param resource
      *            stream resource
      * @return resource URI
+     * @since 2.2
      */
     public URI getTargetURI(AbstractStreamResource resource) {
         return StreamResourceRegistry.getURI(resource);

--- a/flow-server/src/main/java/com/vaadin/flow/server/SynchronizedRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SynchronizedRequestHandler.java
@@ -34,6 +34,8 @@ public abstract class SynchronizedRequestHandler implements RequestHandler {
      * The ResponseWriter will be executed by
      * {@link #handleRequest(VaadinSession, VaadinRequest, VaadinResponse)}
      * without holding Vaadin session lock.
+     *
+     * @since 24.5.6
      */
     @FunctionalInterface
     public interface ResponseWriter extends Serializable {
@@ -102,6 +104,7 @@ public abstract class SynchronizedRequestHandler implements RequestHandler {
      *         should be called. Returns {@literal false} if
      *         {@link #synchronizedHandleRequest(VaadinSession, VaadinRequest, VaadinResponse)}
      *         should be called.
+     * @since 24.5.6
      */
     public boolean isReadAndWriteOutsideSessionLock() {
         return false;
@@ -130,6 +133,7 @@ public abstract class SynchronizedRequestHandler implements RequestHandler {
      * @throws IOException
      *             If an IO error occurred
      * @see #handleRequest(VaadinSession, VaadinRequest, VaadinResponse)
+     * @since 24.5.6
      */
     public Optional<ResponseWriter> synchronizedHandleRequest(
             VaadinSession session, VaadinRequest request,

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
@@ -16,7 +16,7 @@ import java.util.Enumeration;
  * for Config objects for instance <code>ServletConfig</code> and
  * <code>PortletConfig</code>.
  *
- * @since
+ * @since 2.2
  */
 public interface VaadinConfig extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
@@ -19,7 +19,7 @@ import java.util.function.Supplier;
  * for context objects with properties e.g. <code>ServletContext</code> and
  * <code>PortletContext</code>
  *
- * @since 2.0.0
+ * @since 2.0
  */
 public interface VaadinContext extends Serializable {
 
@@ -62,7 +62,7 @@ public interface VaadinContext extends Serializable {
      * @param value
      *            the attribute value to set, or <code>null</code> to remove the
      *            current value
-     * @since
+     * @since 2.2
      */
     <T> void setAttribute(Class<T> clazz, T value);
 
@@ -74,6 +74,7 @@ public interface VaadinContext extends Serializable {
      * @param value
      *            attribute value, not {@code null}.
      * @see #removeAttribute(Class) for removing attributes.
+     * @since 2.2
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     default void setAttribute(Object value) {
@@ -100,6 +101,7 @@ public interface VaadinContext extends Serializable {
      * are o initialization parameters.
      *
      * @return initialization parameters as a <code>Enumeration</code>
+     * @since 2.2
      */
     Enumeration<String> getContextParameterNames();
 
@@ -111,6 +113,7 @@ public interface VaadinContext extends Serializable {
      *            name of the parameter whose value is requested
      * @return parameter value as <code>String</code> or <code>null</code> for
      *         no parameter
+     * @since 2.2
      */
     String getContextParameter(String name);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
@@ -72,6 +72,7 @@ public interface VaadinRequest {
      *
      * @return a long containing the length of the request body or -1L if the
      *         length is not known
+     * @since 6.0.5
      */
     default long getContentLengthLong() {
         return getContentLength();

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequestInterceptor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequestInterceptor.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  * Used to provide an around-like aspect option around request processing.
  *
  * @author Marcin Grzejszczak
- * @since 24.2
+ * @since 24.3
  */
 public interface VaadinRequestInterceptor extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
@@ -170,6 +170,7 @@ public interface VaadinResponse {
      * @param len
      *            a long specifying the length of the content being returned to
      *            the client
+     * @since 24.8
      */
     void setContentLengthLong(long len);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -473,6 +473,7 @@ public abstract class VaadinService implements Serializable {
      * @param request
      *            Request.
      * @return Relative context root path for that request.
+     * @since 2.0
      */
     public abstract String getContextRootRelativePath(VaadinRequest request);
 
@@ -516,6 +517,7 @@ public abstract class VaadinService implements Serializable {
      * @return The list of request handlers used by this service.
      * @throws ServiceException
      *             if a problem occurs when creating the request interceptors
+     * @since 24.3
      */
     protected List<VaadinRequestInterceptor> createVaadinRequestInterceptors()
             throws ServiceException {
@@ -631,6 +633,7 @@ public abstract class VaadinService implements Serializable {
      * @return a default executor instance to use, never {@literal null}.
      * @see VaadinServiceInitListener
      * @see ServiceInitEvent#setExecutor(Executor)
+     * @since 24.8
      */
     protected Executor createDefaultExecutor() {
         this.defaultExecutorInUse = true;
@@ -694,6 +697,7 @@ public abstract class VaadinService implements Serializable {
      * @return the Executor instance, never {@literal null}.
      * @see VaadinServiceInitListener
      * @see ServiceInitEvent#setExecutor(Executor)
+     * @since 24.8
      */
     public Executor getExecutor() {
         return executor;
@@ -706,6 +710,7 @@ public abstract class VaadinService implements Serializable {
      * Java time API objects.
      *
      * @return the configured {@link ObjectMapper} instance
+     * @since 24.8
      */
     protected ObjectMapper createDefaultObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
@@ -885,6 +890,7 @@ public abstract class VaadinService implements Serializable {
      * @param response
      *            The object containing all relevant info needed by listeners to
      *            change the Index HTML response.
+     * @since 3.0
      */
     public void modifyIndexHtmlResponse(IndexHtmlResponse response) {
         indexHtmlRequestListeners.forEach(
@@ -1104,6 +1110,7 @@ public abstract class VaadinService implements Serializable {
      *            The session to unlock
      * @param lock
      *            Lock instance to unlock
+     * @since 8.0.5
      */
     protected void unlockSession(WrappedSession wrappedSession, Lock lock) {
         assert ((ReentrantLock) lock).isHeldByCurrentThread()
@@ -1820,6 +1827,7 @@ public abstract class VaadinService implements Serializable {
      * @return a collection of request interceptors in the order they are
      *         invoked
      * @see #createVaadinRequestInterceptors()
+     * @since 24.3
      */
     public Iterable<VaadinRequestInterceptor> getVaadinRequestInterceptors() {
         return vaadinRequestInterceptors;
@@ -2095,6 +2103,7 @@ public abstract class VaadinService implements Serializable {
      *            shown. If the selector is {@code null}, the body element is
      *            used.
      * @return A JSON string to be sent to the client
+     * @since 2.2
      */
     public static String createCriticalNotificationJSON(String caption,
             String message, String details, String url, String querySelector) {
@@ -2136,6 +2145,7 @@ public abstract class VaadinService implements Serializable {
      *            or asynchronously.
      * @return the JSON used to inform the client about a session expiration, as
      *         a string
+     * @since 2.2
      */
     public static String createSessionExpiredJSON(boolean async) {
         ObjectNode json = JacksonUtils.createObjectNode();
@@ -2158,6 +2168,7 @@ public abstract class VaadinService implements Serializable {
      *            or asynchronously.
      * @return the JSON used to inform the client that the UI cannot be found,
      *         as a string
+     * @since 2.2
      */
     public static String createUINotFoundJSON(boolean async) {
         // Session Expired is technically not really the correct thing as
@@ -2275,6 +2286,7 @@ public abstract class VaadinService implements Serializable {
      *         disabled; <code>false</code> if protection is enabled and the
      *         token is invalid
      * @see DeploymentConfiguration#isXsrfProtectionEnabled()
+     * @since 2.0
      */
     public static boolean isCsrfTokenValid(UI ui, String requestToken) {
 
@@ -2610,6 +2622,7 @@ public abstract class VaadinService implements Serializable {
      *            the untranslated Vaadin URL for the resource
      * @return the resource located at the named path, or <code>null</code> if
      *         there is no resource at that path
+     * @since 3.0
      */
     public abstract URL getResource(String url);
 
@@ -2620,6 +2633,7 @@ public abstract class VaadinService implements Serializable {
      *            the untranslated Vaadin URL for the resource
      * @return a stream for the resource or <code>null</code> if no resource
      *         exists at the specified path
+     * @since 3.0
      */
     public abstract InputStream getResourceAsStream(String url);
 
@@ -2631,6 +2645,7 @@ public abstract class VaadinService implements Serializable {
      * @return <code>true</code> if a resource is found and can be read using
      *         {@link #getResourceAsStream(String)}, <code>false</code> if it is
      *         not found
+     * @since 3.0
      */
     public boolean isResourceAvailable(String url) {
         return getResource(url) != null;
@@ -2644,6 +2659,7 @@ public abstract class VaadinService implements Serializable {
      *            the resource to resolve, not <code>null</code>
      * @return the resolved URL or the same as the input url if no translation
      *         was performed
+     * @since 3.0
      */
     public abstract String resolveResource(String url);
 
@@ -2654,6 +2670,7 @@ public abstract class VaadinService implements Serializable {
      * {@link #getContext()}.
      *
      * @return Context. This may never be {@code null}.
+     * @since 2.0
      */
     protected abstract VaadinContext constructVaadinContext();
 
@@ -2661,6 +2678,7 @@ public abstract class VaadinService implements Serializable {
      * Returns {@link VaadinContext} for this service.
      *
      * @return A non-null context instance.
+     * @since 2.0
      */
     public VaadinContext getContext() {
         if (vaadinContext == null) {
@@ -2694,6 +2712,7 @@ public abstract class VaadinService implements Serializable {
      * in the case
      *
      * @return a non-null instance.
+     * @since 3.0
      */
     public BootstrapInitialPredicate getBootstrapInitialPredicate() {
         if (bootstrapInitialPredicate == null) {
@@ -2709,6 +2728,7 @@ public abstract class VaadinService implements Serializable {
      *
      * @param bootstrapInitialPredicate
      *            the predicate.
+     * @since 3.0
      */
     public void setBootstrapInitialPredicate(
             BootstrapInitialPredicate bootstrapInitialPredicate) {
@@ -2722,6 +2742,7 @@ public abstract class VaadinService implements Serializable {
      * By default it returns an instance that returns true for all requests.
      *
      * @return a non-null instance.
+     * @since 3.0
      */
     public BootstrapUrlPredicate getBootstrapUrlPredicate() {
         if (bootstrapUrlPredicate == null) {
@@ -2736,6 +2757,7 @@ public abstract class VaadinService implements Serializable {
      *
      * @param bootstrapUrlPredicate
      *            the predicate.
+     * @since 3.0
      */
     public void setBootstrapUrlPredicate(
             BootstrapUrlPredicate bootstrapUrlPredicate) {
@@ -2746,6 +2768,7 @@ public abstract class VaadinService implements Serializable {
      * Get the name of the CSRF Token attribute in HTTP session.
      *
      * @return the attribute name string
+     * @since 3.0
      */
     public static String getCsrfTokenAttributeName() {
         return VaadinSession.class.getName() + "."

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -235,6 +235,7 @@ public class VaadinServlet extends HttpServlet {
      *
      * @param runnable
      *            the runnable to run
+     * @since 24.0
      */
     public static void whenFrontendMappingAvailable(Runnable runnable) {
         synchronized (VaadinServlet.class) {
@@ -266,6 +267,7 @@ public class VaadinServlet extends HttpServlet {
      * @param vaadinService
      *            the vaadinService created at {@link #createServletService()}
      * @return the file server to be used by this servlet, not <code>null</code>
+     * @since 7.0
      */
     protected StaticFileHandler createStaticFileHandler(
             VaadinService vaadinService) {
@@ -673,6 +675,7 @@ public class VaadinServlet extends HttpServlet {
      * For internal use only.
      *
      * @return the vaadin servlet used for frontend files in development mode
+     * @since 23.2
      */
     public static String getFrontendMapping() {
         return frontendMapping;

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 /**
  * {@link VaadinConfig} implementation for Servlets.
  *
- * @since
+ * @since 2.2
  */
 public class VaadinServletConfig implements VaadinConfig {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
@@ -18,7 +18,7 @@ import com.vaadin.flow.di.Lookup;
 /**
  * {@link VaadinContext} that goes with {@link VaadinServletService}.
  *
- * @since 2.0.0
+ * @since 2.0
  */
 public class VaadinServletContext implements VaadinContext {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -257,6 +257,7 @@ public class VaadinServletService extends VaadinService {
      *            the path inside servlet context
      * @return a URL for the resource or <code>null</code> if no resource was
      *         found
+     * @since 3.0
      */
     public URL getResourceInServletContext(String path) {
         ServletContext servletContext = getServlet().getServletContext();

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -149,6 +149,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Creates the StreamResourceRegistry for this session.
      *
      * @return A StreamResourceRegistry instance
+     * @since 2.2
      */
     protected StreamResourceRegistry createStreamResourceRegistry() {
         return new StreamResourceRegistry(this);
@@ -231,6 +232,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      *
      * @param browser
      *            the web browser object
+     * @since 5.0
      */
     public void setBrowser(WebBrowser browser) {
         checkHasLock();
@@ -511,6 +513,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      *            the session destroy listener
      * @return a handle that can be used for removing the listener
      * @see VaadinService#addSessionDestroyListener
+     * @since 24.4.10
      */
     public Registration addSessionDestroyListener(
             SessionDestroyListener listener) {
@@ -1200,6 +1203,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * the current time and midnight, January 1, 1970 UTC.
      *
      * @return last lock operation timestamp.
+     * @since 23.2.6
      */
     public long getLastLocked() {
         return lastLocked;
@@ -1213,6 +1217,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * the current time and midnight, January 1, 1970 UTC.
      *
      * @return last unlock operation timestamp.
+     * @since 23.2.6
      */
     public long getLastUnlocked() {
         return lastUnlocked;
@@ -1232,6 +1237,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * @return the element instance
      * @throws IllegalArgumentException
      *             if the element was not found
+     * @since 24.0
      */
     public Element findElement(int uiId, int nodeId)
             throws IllegalArgumentException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/Version.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Version.java
@@ -148,6 +148,7 @@ public class Version implements Serializable {
      * and varies from build to build.
      *
      * @return version's build hash
+     * @since 24.1.14
      */
     public static String getBuildHash() {
         return VERSION_BUILD_HASH;

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -45,6 +45,8 @@ import com.vaadin.flow.server.VaadinServletRequest;
  * any of the roles mentioned in the annotation</li>
  * <li>{@link DenyAll} - denies access.</li>
  * </ul>
+ *
+ * @since 7.0
  */
 public class AccessAnnotationChecker implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckDecision.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckDecision.java
@@ -10,6 +10,8 @@ package com.vaadin.flow.server.auth;
 
 /**
  * Decision on navigation access.
+ *
+ * @since 24.3
  */
 public enum AccessCheckDecision {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckDecisionResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckDecisionResolver.java
@@ -19,6 +19,8 @@ import java.util.List;
  * The component is used by {@link NavigationAccessControl} to compute the final
  * decision, based on the results of all registered
  * {@link NavigationAccessChecker}s.
+ *
+ * @since 24.3
  */
 @FunctionalInterface
 public interface AccessCheckDecisionResolver extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckResult.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckResult.java
@@ -14,6 +14,8 @@ import java.util.Objects;
 /**
  * A representation of the access check result, potentially providing deny
  * reason.
+ *
+ * @since 24.3
  */
 public class AccessCheckResult implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessDeniedErrorRouter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessDeniedErrorRouter.java
@@ -59,6 +59,8 @@ import com.vaadin.flow.router.AccessDeniedException;
  *     }
  * }
  * </pre>
+ *
+ * @since 24.3
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE })

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessPathChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessPathChecker.java
@@ -28,6 +28,7 @@ import java.util.function.Predicate;
  * {@link RoutePathAccessChecker}.
  *
  * @see RoutePathAccessChecker
+ * @since 24.3
  */
 public interface AccessPathChecker extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AnnotatedViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AnnotatedViewAccessChecker.java
@@ -27,6 +27,8 @@ import com.vaadin.flow.server.RouteRegistry;
  * An instance of this class should be provided to a
  * {@link NavigationAccessControl} added as a {@link BeforeEnterListener} to the
  * {@link com.vaadin.flow.component.UI} of interest.
+ *
+ * @since 24.3
  */
 public class AnnotatedViewAccessChecker implements NavigationAccessChecker {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AnonymousAllowed.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AnonymousAllowed.java
@@ -35,6 +35,7 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * @see AccessAnnotationChecker for security rules check implementation
+ * @since 7.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultAccessCheckDecisionResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultAccessCheckDecisionResolver.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * {@link AnnotatedViewAccessChecker} is enabled because it computes only ALLOW
  * or DENY results.
  *
+ * @since 24.3
  */
 public class DefaultAccessCheckDecisionResolver
         implements AccessCheckDecisionResolver {

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultMenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultMenuAccessControl.java
@@ -10,6 +10,8 @@ package com.vaadin.flow.server.auth;
 
 /**
  * Default implementation of {@link MenuAccessControl}.
+ *
+ * @since 24.4
  */
 public class DefaultMenuAccessControl implements MenuAccessControl {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
@@ -19,6 +19,8 @@ import com.vaadin.flow.server.menu.AvailableViewInfo;
 /**
  * Interface for controlling access to routes in the application's menu
  * component.
+ *
+ * @since 24.4
  */
 public interface MenuAccessControl extends Serializable {
 
@@ -75,6 +77,7 @@ public interface MenuAccessControl extends Serializable {
      *            view info
      * @return true if the view is accessible, false if something is not
      *         authenticated.
+     * @since 24.5.1
      */
     default boolean canAccessView(AvailableViewInfo viewInfo) {
         VaadinRequest request = VaadinRequest.getCurrent();
@@ -98,6 +101,7 @@ public interface MenuAccessControl extends Serializable {
      * @param roleChecker
      *            function to authenticate if user has role
      * @return true if accessible, false if something is not authenticated
+     * @since 24.5.1
      */
     static boolean canAccessView(AvailableViewInfo viewInfo,
             Principal principal, Predicate<String> roleChecker) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessChecker.java
@@ -33,6 +33,8 @@ import java.io.Serializable;
  *
  * {@link NavigationContext} provides the methods to create the above
  * {@link AccessCheckResult}s.
+ *
+ * @since 24.3
  */
 @FunctionalInterface
 public interface NavigationAccessChecker extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
@@ -80,6 +80,7 @@ import com.vaadin.flow.server.WrappedSession;
  * @see AnnotatedViewAccessChecker
  * @see #setLoginView(String)
  * @see #setLoginView(Class)
+ * @since 24.3
  */
 public class NavigationAccessControl implements BeforeEnterListener {
 
@@ -417,6 +418,7 @@ public class NavigationAccessControl implements BeforeEnterListener {
      * Checks if an access checker of the given type is in use.
      *
      * @return {@code true} if a checker is in use, {@code false} otherwise
+     * @since 24.4
      */
     public boolean hasAccessChecker(
             Class<? extends NavigationAccessChecker> type) {
@@ -437,6 +439,7 @@ public class NavigationAccessControl implements BeforeEnterListener {
      * @param vaadinRequest
      *            the Vaadin request.
      * @return a new navigation context instance.
+     * @since 24.4
      */
     public NavigationContext createNavigationContext(Class<?> navigationTarget,
             String path, VaadinService vaadinService,

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationContext.java
@@ -43,6 +43,8 @@ import com.vaadin.flow.router.Router;
  * navigation checker to take a decision; for example, a configuration where the
  * path {@literal /my/view} is public, but {@literal /my/*} is protected.</li>
  * </ul>
+ *
+ * @since 24.3
  */
 public final class NavigationContext {
     private final Router router;

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/RoutePathAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/RoutePathAccessChecker.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see AccessPathChecker
  * @see NavigationAccessControl
+ * @since 24.3
  */
 public class RoutePathAccessChecker implements NavigationAccessChecker {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.server.VaadinServletRequest;
  * @deprecated for annotation based view security use
  *             {@link NavigationAccessControl} with
  *             {@link AnnotatedViewAccessChecker}.
+ * @since 8.0
  */
 @Deprecated(forRemoval = true, since = "24.3")
 public class ViewAccessChecker implements BeforeEnterListener {
@@ -72,6 +73,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
      * @param enabled
      *            {@code false} for disabling the access checker, {@code
      * true} for enabling the access checker.
+     * @since 9.0
      */
     public ViewAccessChecker(boolean enabled) {
         this(new AccessAnnotationChecker());
@@ -241,6 +243,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
      *            progress (e.g. in a background thread)
      * @return a function which takes a role name and returns {@code true} if
      *         the user is included in that role
+     * @since 23.1
      */
     protected Function<String, Boolean> getRolesChecker(VaadinRequest request) {
         if (request == null) {
@@ -259,6 +262,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
      * @return a representation of the currently logged in user or {@code null}
      *         if no user is currently logged in
      *
+     * @since 23.1
      */
     protected Principal getPrincipal(VaadinRequest request) {
         if (request == null) {
@@ -288,6 +292,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
      * @param context
      *            the navigation context
      * @return the result of the access check
+     * @since 24.4
      */
     public AccessCheckResult checkAccess(NavigationContext context) {
         if (!enabled) {
@@ -318,6 +323,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
      * @param vaadinRequest
      *            the Vaadin request.
      * @return a new navigation context instance.
+     * @since 24.4
      */
     public NavigationContext createNavigationContext(Class<?> navigationTarget,
             String path, VaadinService vaadinService,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -63,6 +63,8 @@ public class AtmospherePushConnection
          * <p>
          * Immediately reads the length of the message (up until
          * {@value PushConstants#MESSAGE_DELIMITER}) from the reader.
+         *
+         * @since 24.3.1
          */
         public FragmentedMessage() {
         }
@@ -255,6 +257,7 @@ public class AtmospherePushConnection
      *             if an IO error occurred
      * @return a Reader yielding the complete message, or {@code null} if the
      *         received message was a partial message
+     * @since 24.3.1
      */
     protected static Reader receiveMessage(AtmosphereResource resource,
             Reader reader, FragmentedMessageHolder holder) throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
@@ -14,6 +14,9 @@ import org.atmosphere.cpr.AtmosphereResource;
 
 import com.vaadin.flow.server.communication.AtmospherePushConnection.FragmentedMessage;
 
+/**
+ * @since 24.3.1
+ */
 public interface FragmentedMessageHolder extends Serializable {
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -74,6 +74,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * and inject baseHref as well as the bundle scripts into the template.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 3.0
  */
 public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
@@ -316,6 +318,8 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
     /**
      * Adds the needed overrides for the license checker to work when in
      * development mode.
+     *
+     * @since 23.2
      */
     public static void addLicenseChecker(Document indexDocument) {
         // maybeCheck is invoked by the WC license checker

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestListener.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.server.VaadinResponse;
  *
  * @see ServiceInitEvent#addIndexHtmlRequestListener(IndexHtmlRequestListener)
  * @see IndexHtmlRequestHandler
+ * @since 3.0
  */
 @FunctionalInterface
 public interface IndexHtmlRequestListener extends EventListener, Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlResponse.java
@@ -21,6 +21,7 @@ import java.util.Optional;
  * HTML response contains of the full DOM of the HTML document as well as the
  * HTTP headers that will be included in the corresponding HTTP response.
  *
+ * @since 3.0
  */
 public class IndexHtmlResponse {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -51,11 +51,14 @@ import com.vaadin.flow.shared.ApplicationConstants;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
+ * @since 3.0
  */
 public class JavaScriptBootstrapHandler extends BootstrapHandler {
 
     /**
      * Custom BootstrapContext for {@link JavaScriptBootstrapHandler}.
+     *
+     * @since 7.0
      */
     public static class JavaScriptBootstrapContext extends BootstrapContext {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/LongPollingCacheFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/LongPollingCacheFilter.java
@@ -33,6 +33,8 @@ import org.slf4j.LoggerFactory;
  * Messages already seen are discarded, whereas messages not yet sent to the
  * client are added again to the cache to preserve them until client confirms
  * reception by sending the last seen message identifier.
+ *
+ * @since 23.3.4
  */
 public class LongPollingCacheFilter
         implements PerRequestBroadcastFilter, Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
@@ -40,7 +40,7 @@ import com.vaadin.flow.server.VaadinSession;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 1.2
+ * @since 1.1
  */
 public class PwaHandler implements RequestHandler {
     public static final String SW_RUNTIME_PRECACHE_PATH = "/sw-runtime-resources-precache.js";
@@ -58,6 +58,7 @@ public class PwaHandler implements RequestHandler {
      * @param pwaRegistryGetter
      *            PWA registry getter
      *
+     * @since 6.0
      */
     public PwaHandler(SerializableSupplier<PwaRegistry> pwaRegistryGetter) {
         this.pwaRegistryGetter = pwaRegistryGetter;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -67,7 +67,6 @@ public class ServerRpcHandler implements Serializable {
      * side.
      *
      * @author Vaadin Ltd
-     * @since 1.0
      */
     public static class RpcRequest implements Serializable {
 
@@ -205,7 +204,6 @@ public class ServerRpcHandler implements Serializable {
      * the expected one.
      *
      * @author Vaadin Ltd
-     * @since 1.0
      */
     public static class InvalidUIDLSecurityKeyException
             extends GeneralSecurityException {
@@ -220,6 +218,8 @@ public class ServerRpcHandler implements Serializable {
 
     /**
      * Exception thrown then the client side resynchronization is required.
+     *
+     * @since 2.1
      */
     public static class ResynchronizationRequiredException
             extends RuntimeException {
@@ -234,6 +234,8 @@ public class ServerRpcHandler implements Serializable {
 
     /**
      * Exception thrown when the client side re-sends the same request.
+     *
+     * @since 24.7
      */
     public static class ClientResentPayloadException extends RuntimeException {
 
@@ -280,6 +282,7 @@ public class ServerRpcHandler implements Serializable {
      * @throws InvalidUIDLSecurityKeyException
      *             If the received security key does not match the one stored in
      *             the session.
+     * @since 24.5.6
      */
     public void handleRpc(UI ui, String message, VaadinRequest request)
             throws InvalidUIDLSecurityKeyException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -381,6 +381,7 @@ public class StreamReceiverHandler implements Serializable {
      * @return true if upload successful, else false
      * @throws UploadException
      *             Thrown for illegal target node state
+     * @since 5.0
      */
     protected boolean handleFileUploadValidationAndData(VaadinSession session,
             InputStream inputStream, StreamReceiver streamReceiver,
@@ -455,6 +456,7 @@ public class StreamReceiverHandler implements Serializable {
      *            response to write to
      * @throws IOException
      *             exception when writing to stream
+     * @since 5.0
      */
     protected void sendUploadResponse(VaadinResponse response, boolean success)
             throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -56,6 +56,8 @@ public class StreamRequestHandler implements RequestHandler {
 
     /**
      * Dynamic resource URI prefix.
+     *
+     * @since 4.0
      */
     public static final String DYN_RES_PREFIX = "VAADIN/dynamic/resource/";
 
@@ -287,6 +289,7 @@ public class StreamRequestHandler implements RequestHandler {
      * default. Defaults to -1 (no limit).
      *
      * @return maximum request size for upload
+     * @since 23.3.5
      */
     protected long getRequestSizeMax() {
         return DEFAULT_REQUEST_SIZE_MAX;
@@ -297,6 +300,7 @@ public class StreamRequestHandler implements RequestHandler {
      * default. Defaults to -1 (no limit).
      *
      * @return maximum file size for upload
+     * @since 23.3.5
      */
     protected long getFileSizeMax() {
         return DEFAULT_FILE_SIZE_MAX;
@@ -307,6 +311,7 @@ public class StreamRequestHandler implements RequestHandler {
      * default. Defaults to 10000.
      *
      * @return maximum file part count for upload
+     * @since 23.3.5
      */
     protected long getFileCountMax() {
         return DEFAULT_FILE_COUNT_MAX;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -90,6 +90,7 @@ public class UidlWriter implements Serializable {
          *            the service which is resolving
          * @param browser
          *            the browser
+         * @since 3.0
          */
         public ResolveContext(VaadinService service, WebBrowser browser) {
             this.service = Objects.requireNonNull(service);
@@ -127,6 +128,7 @@ public class UidlWriter implements Serializable {
      * @param resync
      *            True iff the client should be asked to resynchronize
      * @return JSON object containing the UIDL response
+     * @since 2.1
      */
     public ObjectNode createUidl(UI ui, boolean async, boolean resync) {
         ObjectNode response = JacksonUtils.createObjectNode();

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -535,6 +535,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
      * @param path
      *            original resource path
      * @return new resource path, relative to basePath
+     * @since 2.1
      */
     protected String modifyPath(String basePath, String path) {
         int vaadinIndex = path.indexOf(Constants.VAADIN_MAPPING);
@@ -587,6 +588,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
      * @param response
      *            the response object
      * @return Service url for the given request.
+     * @since 2.2
      */
     protected String getServiceUrl(VaadinRequest request,
             VaadinResponse response) {
@@ -615,6 +617,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
      * @param response
      *            the response object
      * @return true if request has been handled, false otherwise
+     * @since 23.3.2
      */
     protected boolean handleWebComponentResyncRequest(BootstrapContext context,
             VaadinRequest request, VaadinResponse response) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -150,6 +150,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
      * Enabled by default.
      *
      * @return true iff bootstrap fragment caching is enabled
+     * @since 2.2
      */
     public boolean isCacheEnabled() {
         return cache != null;
@@ -161,6 +162,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
      *
      * @param cacheEnabled
      *            whether bootstrap fragments should be cached per tag
+     * @since 2.2
      */
     public void setCacheEnabled(boolean cacheEnabled) {
         if (cacheEnabled) {
@@ -180,6 +182,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
      * @param response
      *            current VaadinResponse
      * @return npm response script
+     * @since 2.2
      */
     protected String generateNPMResponse(String tagName, VaadinRequest request,
             VaadinResponse response) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -206,6 +206,7 @@ public abstract class AbstractRpcInvocationHandler
      *            the JsonObject containing invocation properties.
      * @return a boolean indicating that the inert status should be ignored for
      *         the current invocation or not.
+     * @since 23.1
      */
     protected boolean allowInert(UI ui, JsonObject invocationJson) {
         return isValidPollInvocation(ui, invocationJson);

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptor.java
@@ -27,6 +27,8 @@ import com.vaadin.pro.licensechecker.dau.DauIntegration;
  * in-memory cache.
  *
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.5
  */
 public class DAUVaadinRequestInterceptor implements VaadinRequestInterceptor,
         VaadinServiceInitListener, ServiceDestroyListener {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractFileGeneratorFallibleCommand.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractFileGeneratorFallibleCommand.java
@@ -22,6 +22,8 @@ import java.util.List;
  * processes. In addition, it allows to avoid writes on disk of the file already
  * exists and has exactly the same generated content, preventing file system
  * watchers to trigger unnecessary events.
+ *
+ * @since 24.4
  */
 public abstract class AbstractFileGeneratorFallibleCommand
         implements FallibleCommand {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
@@ -32,6 +32,9 @@ import com.vaadin.flow.server.Constants;
 
 import static com.vaadin.flow.server.Constants.DEV_BUNDLE_JAR_PATH;
 
+/**
+ * @since 24.1
+ */
 public final class BundleUtils {
 
     private BundleUtils() {
@@ -141,6 +144,7 @@ public final class BundleUtils {
      * @param chunkLines
      *            content of the chunk, collection of string lines
      * @return chunk's hash
+     * @since 24.1.9
      */
     public static String getChunkHash(List<String> chunkLines) {
         List<String> sortedChunkLines = new ArrayList<>(chunkLines);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -69,6 +69,7 @@ public final class BundleValidationUtil {
      * @param mode
      *            Vaadin application mode
      * @return true if a new frontend bundle is needed, false otherwise
+     * @since 24.4
      */
     public static boolean needsBuild(Options options,
             FrontendDependenciesScanner frontendDependencies, Mode mode) {
@@ -306,6 +307,7 @@ public final class BundleValidationUtil {
      * @param frontendDependencies
      *            frontend dependency scanner
      * @return package.json content as JsonNode
+     * @since 24.4
      */
     public static JsonNode getPackageJson(Options options,
             FrontendDependenciesScanner frontendDependencies) {
@@ -436,6 +438,7 @@ public final class BundleValidationUtil {
      * @param npmPackages
      *            npm packages map
      * @return {@code true} if up to date
+     * @since 24.7
      */
     public static boolean hashAndBundleModulesEqual(JsonNode statsJson,
             JsonNode packageJson, Map<String, String> npmPackages) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
@@ -32,6 +32,8 @@ import com.vaadin.flow.internal.JacksonUtils;
  * <p>
  * </p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.1
  */
 public class CssBundler {
 
@@ -127,6 +129,7 @@ public class CssBundler {
      *         rewritten URLs.
      * @throws IOException
      *             if filesystem resources can not be read.
+     * @since 24.7
      */
     public static String inlineImports(File themeFolder, File cssFile,
             JsonNode themeJson) throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/DevBundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/DevBundleUtils.java
@@ -23,6 +23,8 @@ import com.vaadin.flow.server.Constants;
  * Helpers related to the development bundle.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.1
  */
 public class DevBundleUtils {
 
@@ -42,6 +44,7 @@ public class DevBundleUtils {
      *            the file name inside the bundle
      * @return a URL referring to the file inside the bundle or {@code null} if
      *         the file was not found
+     * @since 24.3
      */
     public static URL findBundleFile(File projectDir, String buildFolder,
             String filename) throws IOException {
@@ -65,6 +68,7 @@ public class DevBundleUtils {
      * @param buildFolder
      *            the project build folder name
      * @return the bundle directory
+     * @since 24.3
      */
     public static File getDevBundleFolder(File projectDir, String buildFolder) {
         return new File(new File(projectDir, buildFolder),
@@ -81,6 +85,7 @@ public class DevBundleUtils {
      * @return stats.json content or {@code null} if not found
      * @throws IOException
      *             if an I/O exception occurs.
+     * @since 24.3
      */
     public static String findBundleStatsJson(File projectDir,
             String buildFolder) throws IOException {
@@ -106,6 +111,7 @@ public class DevBundleUtils {
      *            current project root directory
      * @param devBundleFolder
      *            dev bundle location
+     * @since 24.3
      */
     public static void compressBundle(File projectDir, File devBundleFolder) {
         File bundleFile = new File(projectDir,
@@ -126,6 +132,7 @@ public class DevBundleUtils {
      *            current project root directory
      * @param devBundleFolder
      *            unpacked dev bundle location
+     * @since 24.3
      */
     public static void unpackBundle(File projectDir, File devBundleFolder) {
         File bundleFile = new File(projectDir,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/EndpointGeneratorTaskFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/EndpointGeneratorTaskFactory.java
@@ -24,6 +24,7 @@ public interface EndpointGeneratorTaskFactory {
      * @param options
      *            the task options
      * @return an endpoint tasks for generating TypeScript files for endpoints.
+     * @since 24.0
      */
     TaskGenerateEndpoint createTaskGenerateEndpoint(Options options);
 
@@ -33,6 +34,7 @@ public interface EndpointGeneratorTaskFactory {
      * @param options
      *            the task options
      * @return an endpoint task that generates open api json file.
+     * @since 24.0
      */
     TaskGenerateOpenAPI createTaskGenerateOpenAPI(Options options);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -28,6 +28,8 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 /**
  * Excludes dependencies listed in an "exclusions" array of
  * vaadin-*versions.json file from a package.json.
+ *
+ * @since 24.4
  */
 public class ExclusionFilter implements Serializable {
 
@@ -58,6 +60,7 @@ public class ExclusionFilter implements Serializable {
      *            whether React is enabled
      * @param excludeWebComponentNpmPackages
      *            whether to exclude web component npm packages
+     * @since 24.6
      */
     public ExclusionFilter(ClassFinder finder, boolean reactEnabled,
             boolean excludeWebComponentNpmPackages) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FallibleCommand.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FallibleCommand.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.server.ExecutionFailedException;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 2.2
  */
 public interface FallibleCommand {
 
@@ -41,6 +41,7 @@ public interface FallibleCommand {
      *
      * @param support
      *            the generated file support utility to use.
+     * @since 24.4
      */
     default void setGeneratedFileSupport(GeneratedFilesSupport support) {
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FileIOUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FileIOUtils.java
@@ -30,6 +30,9 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @since 24.0.5
+ */
 public class FileIOUtils {
 
     private FileIOUtils() {
@@ -47,6 +50,7 @@ public class FileIOUtils {
      * @return true if the content was written to the file, false otherwise
      * @throws IOException
      *             if something went wrong
+     * @since 24.1
      */
     public static boolean writeIfChanged(File file, List<String> content)
             throws IOException {
@@ -65,6 +69,7 @@ public class FileIOUtils {
      * @return true if the content was written to the file, false otherwise
      * @throws IOException
      *             if something went wrong
+     * @since 24.1
      */
     public static boolean writeIfChanged(File file, String content)
             throws IOException {
@@ -132,6 +137,7 @@ public class FileIOUtils {
      * @param file
      *            the file to check
      * @return true if the file is likely a temporary file, false otherwise
+     * @since 24.1
      */
     public static boolean isProbablyTemporaryFile(File file) {
         return file.getName().endsWith("~");
@@ -148,6 +154,7 @@ public class FileIOUtils {
      * @throws IOException
      *             if an I/O error is thrown while walking through the tree in
      *             base directory
+     * @since 24.4
      */
     public static List<Path> getFilesByPattern(Path baseDir, String pattern)
             throws IOException {
@@ -187,6 +194,7 @@ public class FileIOUtils {
      * @param compareFn
      *            a function to compare the normalized strings
      * @return true if the normalized strings are equal, false otherwise
+     * @since 24.4
      */
     public static boolean compareIgnoringIndentationAndEOL(String content1,
             String content2, BiPredicate<String, String> compareFn) {
@@ -206,6 +214,7 @@ public class FileIOUtils {
      * @param compareFn
      *            a function to compare the normalized strings
      * @return true if the normalized strings are equal, false otherwise
+     * @since 24.4
      */
     public static boolean compareIgnoringIndentationEOLAndWhiteSpace(
             String content1, String content2,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -49,6 +49,7 @@ import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
  *
  * @author Vaadin Ltd
  *
+ * @since 3.1
  */
 public class FrontendTools {
 
@@ -56,10 +57,14 @@ public class FrontendTools {
      * This is the version that is installed if there is no node installed or
      * the installed version is older than {@link #SUPPORTED_NODE_VERSION}, i.e.
      * {@value #SUPPORTED_NODE_MAJOR_VERSION}.{@value #SUPPORTED_NODE_MINOR_VERSION}.
+     *
+     * @since 4.0
      */
     public static final String DEFAULT_NODE_VERSION = "v22.23.1";
     /**
      * This is the version shipped with the default Node version.
+     *
+     * @since 9.0
      */
     public static final String DEFAULT_NPM_VERSION = "10.9.7";
 
@@ -183,6 +188,7 @@ public class FrontendTools {
      *
      * @param settings
      *            tooling settings to use
+     * @since 9.0
      */
     public FrontendTools(FrontendToolsSettings settings) {
         this.baseDir = Objects.requireNonNull(settings.getBaseDir());
@@ -204,6 +210,7 @@ public class FrontendTools {
      *            the project root directory
      * @param applicationConfiguration
      *            the configuration for the application
+     * @since 23.0
      */
     public FrontendTools(ApplicationConfiguration applicationConfiguration,
             File projectRoot) {
@@ -231,6 +238,7 @@ public class FrontendTools {
      *             {@link FrontendTools#FrontendTools(FrontendToolsSettings)}
      *             instead, as it simplifies configuring the frontend tools and
      *             gives the default values to configuration parameters.
+     * @since 6.0.8
      */
     @Deprecated
     public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
@@ -268,6 +276,7 @@ public class FrontendTools {
      *             {@link FrontendTools#FrontendTools(FrontendToolsSettings)}
      *             instead, as it simplifies configuring the frontend tools and
      *             gives the default values to configuration parameters.
+     * @since 4.0
      */
     @Deprecated
     public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
@@ -309,6 +318,7 @@ public class FrontendTools {
      *             {@link FrontendTools#FrontendTools(FrontendToolsSettings)}
      *             instead, as it simplifies configuring the frontend tools and
      *             gives the default values to configuration parameters.
+     * @since 9.0
      */
     @Deprecated
     public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
@@ -355,6 +365,7 @@ public class FrontendTools {
      *             {@link FrontendTools#FrontendTools(FrontendToolsSettings)}
      *             instead, as it simplifies configuring the frontend tools and
      *             gives the default values to configuration parameters.
+     * @since 9.0
      */
     @Deprecated
     public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
@@ -597,6 +608,7 @@ public class FrontendTools {
      *
      * @return the list of all commands in sequence that need to be executed to
      *         have bun running
+     * @since 24.3
      */
     public List<String> getBunExecutable() {
         List<String> bunCommand = getSuitableBun();
@@ -649,6 +661,8 @@ public class FrontendTools {
 
     /**
      * Gets the version of the node executable.
+     *
+     * @since 8.0.5
      */
     public FrontendVersion getNodeVersion() throws UnknownVersionException {
         return getNodeVersionAndExecutable().getFirst();
@@ -785,6 +799,7 @@ public class FrontendTools {
      * @return the version of npm.
      * @throws UnknownVersionException
      *             if the npm command fails or returns unexpected output.
+     * @since 9.0
      */
     public FrontendVersion getNpmVersion() throws UnknownVersionException {
         List<String> npmVersionCommand = new ArrayList<>(
@@ -806,6 +821,7 @@ public class FrontendTools {
      * @return the path to the executable.
      * @throws CommandExecutionException
      *             if the node resolution fails.
+     * @since 24.8
      */
     public Path getNpmPackageExecutable(String packageName, String binName,
             File cwd) throws CommandExecutionException {
@@ -831,6 +847,7 @@ public class FrontendTools {
      * @return the flags
      * @deprecated Webpack is not used anymore, this method is obsolete and have
      *             no replacements.
+     * @since 9.0.4
      */
     @Deprecated(forRemoval = true, since = "24.8")
     public Map<String, String> getWebpackNodeEnvironment() {
@@ -1091,6 +1108,7 @@ public class FrontendTools {
      * part of a process builder command.
      *
      * @return the path to the node binary
+     * @since 23.0
      */
     public String getNodeBinary() {
         if (forceAlternativeNode) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.internal.Pair;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 1.2
+ * @since 2.0
  */
 public class FrontendToolsLocator implements Serializable {
     private static final String FAILED_WITH_EXIT_CODE_MSG = "Command '{}' failed with exit code '{}'";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
@@ -25,6 +25,8 @@ import static com.vaadin.flow.server.frontend.FrontendTools.DEFAULT_NODE_VERSION
  * <p>
  * This can be modified, but the choices will be locked in {@link FrontendTools}
  * when it is initialized. Until then any settings can be changed.
+ *
+ * @since 9.0
  */
 public class FrontendToolsSettings implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -100,6 +100,8 @@ public class FrontendUtils {
     /**
      * Default folder for client-side generated files inside the project root
      * frontend folder.
+     *
+     * @since 6.0
      */
     public static final String GENERATED = "generated/";
 
@@ -118,47 +120,63 @@ public class FrontendUtils {
      *
      * By default the old folder is <code>/frontend</code> in the project
      * folder.
+     *
+     * @since 24.4
      */
     public static final String LEGACY_FRONTEND_DIR = DEFAULT_NODE_DIR
             + FRONTEND;
 
     /**
      * The name of the vite configuration file.
+     *
+     * @since 9.0
      */
     public static final String VITE_CONFIG = "vite.config.ts";
 
     /**
      * The name of the generated vite configuration file.
+     *
+     * @since 9.0
      */
     public static final String VITE_GENERATED_CONFIG = "vite.generated.ts";
 
     /**
      * The name of the service worker source file for InjectManifest method of
      * the workbox plugin.
+     *
+     * @since 6.0
      */
     public static final String SERVICE_WORKER_SRC = "sw.ts";
 
     /**
      * The JavaScript version of the service worker file, for checking if a user
      * has a JavaScript version of a custom service worker file already.
+     *
+     * @since 6.0
      */
     public static final String SERVICE_WORKER_SRC_JS = "sw.js";
 
     /**
      * The folder inside the 'generated' folder where frontend resources from
      * jars are copied.
+     *
+     * @since 23.3
      */
     public static final String JAR_RESOURCES_FOLDER = "jar-resources";
 
     /**
      * The location where javascript files present in jar resources are copied
      * and can be imported from.
+     *
+     * @since 23.3
      */
     public static final String JAR_RESOURCES_IMPORT = "Frontend/generated/"
             + JAR_RESOURCES_FOLDER + "/";
     /**
      * The location where javascript files present in jar resources are copied
      * and can be imported from, relative to the frontend folder.
+     *
+     * @since 23.3
      */
     public static final String JAR_RESOURCES_IMPORT_FRONTEND_RELATIVE = JAR_RESOURCES_IMPORT
             .replace("Frontend/", "./");
@@ -172,12 +190,16 @@ public class FrontendUtils {
     /**
      * The TypeScript definitions for the {@link FrontendUtils#IMPORTS_NAME}
      * file.
+     *
+     * @since 3.0
      */
     public static final String IMPORTS_D_TS_NAME = "generated-flow-imports.d.ts";
 
     /**
      * Name of the file that contains application imports, javascript, theme and
      * style annotations used when embedding Flow as web-component.
+     *
+     * @since 24.3.10
      */
     public static final String IMPORTS_WEB_COMPONENT_NAME = "generated-flow-webcomponent-imports.js";
 
@@ -188,6 +210,8 @@ public class FrontendUtils {
      * File name of the bootstrap file that is generated in frontend
      * {@link #GENERATED} folder. The bootstrap file is always executed in a
      * Vaadin app.
+     *
+     * @since 6.0
      */
     public static final String BOOTSTRAP_FILE_NAME = "vaadin.ts";
 
@@ -195,6 +219,8 @@ public class FrontendUtils {
      * File name of the web component bootstrap file that is generated in
      * frontend {@link #GENERATED} folder. The bootstrap file is always executed
      * in an exported web component.
+     *
+     * @since 23.1
      */
     public static final String WEB_COMPONENT_BOOTSTRAP_FILE_NAME = "vaadin-web-component.ts";
 
@@ -203,36 +229,50 @@ public class FrontendUtils {
      * {@link #GENERATED} folder. The feature flags file contains code to define
      * feature flags as globals that might be used by Vaadin web components or
      * application code.
+     *
+     * @since 23.0
      */
     public static final String FEATURE_FLAGS_FILE_NAME = "vaadin-featureflags.js";
 
     /**
      * File name of the index.html in client side.
+     *
+     * @since 3.0
      */
     public static final String INDEX_HTML = "index.html";
 
     /**
      * File name of the web-component.html in client side.
+     *
+     * @since 23.0.13
      */
     public static final String WEB_COMPONENT_HTML = "web-component.html";
 
     /**
      * File name of the index.ts in client side.
+     *
+     * @since 3.0
      */
     public static final String INDEX_TS = "index.ts";
 
     /**
      * File name of the index.js in client side.
+     *
+     * @since 3.0
      */
     public static final String INDEX_JS = "index.js";
 
     /**
      * File name of the index.tsx in client side.
+     *
+     * @since 24.0
      */
     public static final String INDEX_TSX = "index.tsx";
 
     /**
      * File name of Vite helper used in development mode.
+     *
+     * @since 9.0
      */
     public static final String VITE_DEVMODE_TS = "vite-devmode.ts";
 
@@ -248,6 +288,8 @@ public class FrontendUtils {
 
     /**
      * Default generated path for generated frontend files.
+     *
+     * @since 6.0
      */
     public static final String DEFAULT_PROJECT_FRONTEND_GENERATED_DIR = DEFAULT_FRONTEND_DIR
             + GENERATED;
@@ -268,11 +310,15 @@ public class FrontendUtils {
      * {@link FrontendUtils#DEFAULT_FRONTEND_DIR}. e.g.
      * <code>import 'Frontend/foo.js';</code> references the
      * file<code>frontend/foo.js</code>.
+     *
+     * @since 23.3
      */
     public static final String FRONTEND_FOLDER_ALIAS = "Frontend/";
 
     /**
      * The prefix used to import files generated by Flow.
+     *
+     * @since 24.1
      */
     public static final String FRONTEND_GENERATED_FLOW_IMPORT_PATH = FRONTEND_FOLDER_ALIAS
             + "generated/flow/";
@@ -280,6 +326,8 @@ public class FrontendUtils {
     /**
      * The default directory in frontend directory, where Hilla views are
      * located.
+     *
+     * @since 24.4
      */
     public static final String HILLA_VIEWS_PATH = "views";
 
@@ -291,21 +339,29 @@ public class FrontendUtils {
 
     /**
      * A key in a Json object for chunks list.
+     *
+     * @since 2.1
      */
     public static final String CHUNKS = "chunks";
 
     /**
      * The entry-point key used for the exported bundle.
+     *
+     * @since 3.0.1
      */
     public static final String EXPORT_CHUNK = "export";
 
     /**
      * A key in a Json object for css imports data.
+     *
+     * @since 2.1
      */
     public static final String CSS_IMPORTS = "cssImports";
 
     /**
      * A key in a Json object for js modules data.
+     *
+     * @since 2.1
      */
     public static final String JS_MODULES = "jsModules";
 
@@ -438,6 +494,7 @@ public class FrontendUtils {
      *            the function to make changes to the created instance of
      *            ProcessBuilder, not {@literal null}.
      * @return a configured process builder
+     * @since 24.8
      */
     public static ProcessBuilder createProcessBuilder(List<String> command,
             UnaryOperator<ProcessBuilder> configureProcessBuilder) {
@@ -496,6 +553,7 @@ public class FrontendUtils {
      * @throws IOException
      *             on error when reading file
      *
+     * @since 3.0
      */
     public static String getIndexHtmlContent(VaadinService service)
             throws IOException {
@@ -519,6 +577,7 @@ public class FrontendUtils {
      * @throws IOException
      *             on error when reading file
      *
+     * @since 23.0.13
      */
     public static String getWebComponentHtmlContent(VaadinService service)
             throws IOException {
@@ -604,6 +663,7 @@ public class FrontendUtils {
      *            the file path.
      * @return an input stream for reading the file contents; null if there is
      *         no such file or the dev server is not running.
+     * @since 9.0
      */
     public static InputStream getFrontendFileFromDevModeHandler(
             VaadinService service, String path) {
@@ -635,6 +695,7 @@ public class FrontendUtils {
      * @param path
      *            the file path.
      * @return an existing {@link File} , or null if the file doesn't exist.
+     * @since 24.4
      */
     public static File resolveFrontendPath(File projectRoot,
             DeploymentConfiguration deploymentConfiguration, String path) {
@@ -650,6 +711,7 @@ public class FrontendUtils {
      * @param frontendDir
      *            the frontend directory location from project's configuration
      * @return correct folder or legacy folder if not user defined
+     * @since 24.4
      */
     public static File getLegacyFrontendFolderIfExists(File projectRoot,
             File frontendDir) {
@@ -676,6 +738,7 @@ public class FrontendUtils {
      * @param frontendDirectory
      *            the frontend directory.
      * @return an existing {@link File} , or null if the file doesn't exist.
+     * @since 23.2.2
      */
     public static File resolveFrontendPath(File projectRoot, String path,
             File frontendDirectory) {
@@ -695,6 +758,7 @@ public class FrontendUtils {
      * @param jarImport
      *            jar file to get (no resource folder should be added)
      * @return resource as String or {@code null} if not found
+     * @since 24.1
      */
     public static String getJarResourceString(String jarImport,
             ClassFinder finder) {
@@ -722,6 +786,7 @@ public class FrontendUtils {
      * @param frontendDirectory
      *            project's frontend directory
      * @return a {@link File} representing a folder with copied resources
+     * @since 24.0
      */
     public static File getJarResourcesFolder(File frontendDirectory) {
         return new File(getFrontendGeneratedFolder(frontendDirectory),
@@ -746,6 +811,7 @@ public class FrontendUtils {
      *
      * @return {@link #DEFAULT_FRONTEND_DIR} or value of
      *         {@link #PARAM_FRONTEND_DIR} if it is set.
+     * @since 24.1
      */
     public static File getProjectFrontendDir(
             AbstractConfiguration configuration) {
@@ -761,6 +827,7 @@ public class FrontendUtils {
      * @param target
      *            the target path
      * @return unix relative path from source to target
+     * @since 2.2
      */
     public static String getUnixRelativePath(Path source, Path target) {
         return getUnixPath(source.relativize(target));
@@ -772,6 +839,7 @@ public class FrontendUtils {
      * @param source
      *            path to get
      * @return path as a String in Unix form.
+     * @since 2.2
      */
     public static String getUnixPath(Path source) {
         return source.toString().replaceAll("\\\\", "/");
@@ -826,6 +894,8 @@ public class FrontendUtils {
 
     /**
      * Thrown when the command execution fails.
+     *
+     * @since 9.0
      */
     public static class CommandExecutionException extends Exception {
         /**
@@ -849,6 +919,7 @@ public class FrontendUtils {
          *            the output from the command
          * @param errorOutput
          *            the error output from the command
+         * @since 23.2.7
          */
         public CommandExecutionException(int processExitCode, String output,
                 String errorOutput) {
@@ -897,6 +968,7 @@ public class FrontendUtils {
      * @return process output string.
      * @throws CommandExecutionException
      *             if the process completes exceptionally.
+     * @since 9.0
      */
     public static String executeCommand(List<String> command)
             throws CommandExecutionException {
@@ -914,6 +986,7 @@ public class FrontendUtils {
      * @return process output string.
      * @throws CommandExecutionException
      *             if the process completes exceptionally.
+     * @since 24.8
      */
     public static String executeCommand(List<String> command,
             UnaryOperator<ProcessBuilder> configureProcessBuilder)
@@ -962,6 +1035,7 @@ public class FrontendUtils {
      * @return a {@link CompletableFuture} that return the string contents of
      *         the process input and error streams when both are consumed,
      *         wrapped into a {@link Pair}.
+     * @since 24.1
      */
     public static CompletableFuture<Pair<String, String>> consumeProcessStreams(
             Process process) {
@@ -984,6 +1058,7 @@ public class FrontendUtils {
      * @return FrontendVersion of versionString
      * @throws IOException
      *             if parsing fails
+     * @since 3.1
      */
     public static FrontendVersion parseFrontendVersion(String versionString)
             throws IOException {
@@ -997,6 +1072,7 @@ public class FrontendUtils {
      * The directory is created if it's doesn't exist.
      *
      * @return a vaadin home directory
+     * @since 3.1
      */
     public static File getVaadinHomeDirectory() {
         File home = FileUtils.getUserDirectory();
@@ -1062,6 +1138,7 @@ public class FrontendUtils {
      * @param command
      *            the command and it's arguments
      * @return the string for printing in logs
+     * @since 2.2
      */
     public static String commandToString(String baseDir, List<String> command) {
         StringBuilder retval = new StringBuilder("\n");
@@ -1092,6 +1169,7 @@ public class FrontendUtils {
      * @param versionOrigin
      *            origin of the version (like a file), used in error message
      * @return the frontend version the package or {@code null}
+     * @since 24.7
      */
     public static FrontendVersion getPackageVersionFromJson(JsonNode sourceJson,
             String pkg, String versionOrigin) {
@@ -1123,6 +1201,7 @@ public class FrontendUtils {
      *            outlet for the message
      * @param message
      *            the string to show
+     * @since 2.2
      */
     @SuppressWarnings("squid:S106")
     public static void console(String format, Object message) {
@@ -1140,6 +1219,7 @@ public class FrontendUtils {
      * @throws IOException
      *             on failure to delete any one file, or if the directory name
      *             is not {@code node_modules}
+     * @since 9.0.5
      */
     public static void deleteNodeModules(File nodeModules) throws IOException {
         if (!nodeModules.exists()) {
@@ -1165,6 +1245,7 @@ public class FrontendUtils {
      *            directory to delete
      * @throws IOException
      *             on failure to delete or read any one file
+     * @since 23.1.5
      */
     public static void deleteDirectory(File directory) throws IOException {
         if (!directory.exists() || !directory.isDirectory()) {
@@ -1253,6 +1334,7 @@ public class FrontendUtils {
      * @return the path to the servlet used for the frontend bundle. Empty for a
      *         /* mapping, otherwise always starts with a slash but never ends
      *         with a slash
+     * @since 23.2
      */
     public static String getFrontendServletPath(ServletContext servletContext) {
         String mapping = VaadinServlet.getFrontendMapping();
@@ -1269,6 +1351,7 @@ public class FrontendUtils {
      * @param frontendFolder
      *            the project frontend folder
      * @return the folder for Flow generated files
+     * @since 24.1
      */
     public static File getFlowGeneratedFolder(File frontendFolder) {
         return new File(getFrontendGeneratedFolder(frontendFolder), "flow");
@@ -1281,6 +1364,7 @@ public class FrontendUtils {
      * @param frontendFolder
      *            the project frontend folder
      * @return the location of the generated import JS file
+     * @since 24.1
      */
     public static File getFlowGeneratedImports(File frontendFolder) {
         return new File(getFlowGeneratedFolder(frontendFolder), IMPORTS_NAME);
@@ -1294,6 +1378,7 @@ public class FrontendUtils {
      *            the project frontend folder
      * @return the location of the generated import JS file for exported web
      *         components
+     * @since 24.3.10
      */
     public static File getFlowGeneratedWebComponentsImports(
             File frontendFolder) {
@@ -1307,6 +1392,7 @@ public class FrontendUtils {
      * @param frontendFolder
      *            the project frontend folder
      * @return the exported web components folder
+     * @since 24.1
      */
     public static File getFlowGeneratedWebComponentsFolder(
             File frontendFolder) {
@@ -1321,6 +1407,7 @@ public class FrontendUtils {
      * @param frontendDirectory
      *            path to the frontend folder in a project.
      * @return {@code false} if vaadin-router is used, {@code true} otherwise.
+     * @since 24.4
      */
     public static boolean isReactRouterRequired(File frontendDirectory) {
         Objects.requireNonNull(frontendDirectory);
@@ -1354,6 +1441,7 @@ public class FrontendUtils {
      * @param frontendDirectory
      *            Target frontend directory.
      * @return {@code true} if hilla views are used, {@code false} otherwise.
+     * @since 24.4
      */
     public static boolean isHillaViewsUsed(File frontendDirectory) {
         Objects.requireNonNull(frontendDirectory);
@@ -1415,6 +1503,7 @@ public class FrontendUtils {
      *
      * @return {@code true} if Hilla is available and Hilla views are used,
      *         {@code false} otherwise
+     * @since 24.4
      */
     public static boolean isHillaUsed(File frontendDirectory) {
         return EndpointRequestUtil.isHillaAvailable()
@@ -1432,6 +1521,7 @@ public class FrontendUtils {
      *            class finder to check the presence of Hilla endpoint class
      * @return {@code true} if Hilla is available and Hilla views are used,
      *         {@code false} otherwise
+     * @since 24.4
      */
     public static boolean isHillaUsed(File frontendDirectory,
             ClassFinder classFinder) {
@@ -1493,6 +1583,7 @@ public class FrontendUtils {
      * Is the React module available in the classpath.
      *
      * @return true if the React module is available, false otherwise
+     * @since 24.4
      */
     public static boolean isReactModuleAvailable(Options options) {
         try {
@@ -1508,6 +1599,7 @@ public class FrontendUtils {
      * Get all available client routes in a distinct list of route paths.
      *
      * @return a list of available client routes
+     * @since 24.4
      */
     public static List<String> getClientRoutes() {
         return MenuRegistry.getClientRoutes(false,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 2.1
  */
 public class FrontendVersion
         implements Serializable, Comparable<FrontendVersion> {
@@ -132,6 +132,7 @@ public class FrontendVersion
      *            in error message to help discover the issue
      * @param version
      *            version string as "major.minor.revision[.build]"
+     * @since 7.0
      */
     public FrontendVersion(String name, String version) {
         Objects.requireNonNull(version);
@@ -235,6 +236,7 @@ public class FrontendVersion
      * @param otherVersion
      *            version to check against
      * @return true if this is older than otherVersion
+     * @since 2.2
      */
     public boolean isOlderThan(FrontendVersion otherVersion) {
         return compareTo(otherVersion) < 0;
@@ -247,6 +249,7 @@ public class FrontendVersion
      * @param otherVersion
      *            version to check against
      * @return true if this is newer than otherVersion
+     * @since 2.2
      */
     public boolean isNewerThan(FrontendVersion otherVersion) {
         return compareTo(otherVersion) > 0;
@@ -259,6 +262,7 @@ public class FrontendVersion
      * @param otherVersion
      *            version to check against
      * @return true if this is newer than or equal to otherVersion
+     * @since 24.3
      */
     public boolean isEqualOrNewer(FrontendVersion otherVersion) {
         return compareTo(otherVersion) >= 0;
@@ -270,6 +274,7 @@ public class FrontendVersion
      * @param otherVersion
      *            version to test equals with
      * @return true if parsed version parts are exactly the same
+     * @since 2.2
      */
     public boolean isEqualTo(FrontendVersion otherVersion) {
         return compareTo(otherVersion) == 0;
@@ -308,6 +313,7 @@ public class FrontendVersion
      * @param other
      *            version to compare against this version
      * @return -1 this is older, 0 versions equal, 1 this is newer
+     * @since 2.2
      */
     @Override
     public int compareTo(FrontendVersion other) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
@@ -71,6 +71,7 @@ public class FrontendWebComponentGenerator implements Serializable {
      * @return generated files
      * @throws java.lang.IllegalStateException
      *             if {@code finder} cannot locate required classes
+     * @since 6.0
      */
     public Set<File> generateWebComponents(File outputDirectory,
             ThemeDefinition theme) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
@@ -30,6 +30,8 @@ import com.vaadin.flow.server.frontend.scanner.CssData;
  * a dev server.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.0
  */
 public class GenerateMainImports extends AbstractUpdateImports {
     private JsonNode statsJson;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/GeneratedFilesSupport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/GeneratedFilesSupport.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
  * <p>
  * </p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.4
  */
 public final class GeneratedFilesSupport {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/JarContentsManager.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/JarContentsManager.java
@@ -33,7 +33,7 @@ import org.apache.commons.io.IOUtils;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since 1.0.
+ * @since 2.0.2
  */
 public class JarContentsManager {
     private static final String JAR_PATH_SEPARATOR = "/";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -96,6 +96,7 @@ public class NodeTasks implements FallibleCommand {
      *
      * @param options
      *            the options
+     * @since 23.3
      */
     public NodeTasks(Options options) {
         FrontendDependenciesScanner frontendDependencies = options
@@ -431,6 +432,9 @@ public class NodeTasks implements FallibleCommand {
         }
     }
 
+    /**
+     * @since 24.3
+     */
     public record NodeTasksLockInfo(long pid,
             String commandLine) implements Serializable {
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -98,6 +98,7 @@ public abstract class NodeUpdater implements FallibleCommand {
      *
      * @param options
      *            the task options
+     * @since 24.10.3
      */
     protected NodeUpdater(Options options) {
         this.finder = options.getClassFinder();
@@ -587,6 +588,7 @@ public abstract class NodeUpdater implements FallibleCommand {
      *            the package json content
      * @throws IOException
      *             when file IO fails
+     * @since 24.7
      */
     protected void generateVersionsJson(ObjectNode packageJson)
             throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -31,6 +31,8 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 /**
  * Build a <code>NodeExecutor</code> instance.
+ *
+ * @since 23.3.1
  */
 public class Options implements Serializable {
 
@@ -162,6 +164,7 @@ public class Options implements Serializable {
      *            a {@link Lookup} to discover services used by Flow (SPI)
      * @param npmFolder
      *            a project's base folder
+     * @since 24.0
      */
     public Options(Lookup lookup, File npmFolder) {
         this(lookup, new ClassFinder.CachedClassFinder(
@@ -177,6 +180,7 @@ public class Options implements Serializable {
      *            a class finder to use in node tasks
      * @param npmFolder
      *            a project's base folder
+     * @since 24.4
      */
     public Options(Lookup lookup, ClassFinder classFinder, File npmFolder) {
         this.lookup = lookup;
@@ -192,6 +196,7 @@ public class Options implements Serializable {
      *            the application configuration to be applied
      * @return the updated {@code Options} instance with the specified
      *         application configuration
+     * @since 24.10.5
      */
     public Options withApplicationConfiguration(
             ApplicationConfiguration applicationConfiguration) {
@@ -205,6 +210,7 @@ public class Options implements Serializable {
      * @param frontendDirectory
      *            a directory with project's frontend files
      * @return this
+     * @since 24.0
      */
     public Options withFrontendDirectory(File frontendDirectory) {
         this.frontendDirectory = frontendDirectory.isAbsolute()
@@ -221,6 +227,7 @@ public class Options implements Serializable {
      *            project build directory
      *
      * @return this builder
+     * @since 24.0
      */
     public Options withBuildDirectory(String buildDirectory) {
         this.buildDirectoryName = buildDirectory;
@@ -238,6 +245,7 @@ public class Options implements Serializable {
      *            as the "config/stats.json" stats file, and the
      *            "config/flow-build-info.json" token file.
      * @return this builder
+     * @since 24.4
      */
     public Options withBuildResultFolders(File webappResourcesDirectory,
             File resourceOutputDirectory) {
@@ -293,6 +301,7 @@ public class Options implements Serializable {
      *            <code>true</code> to clean npm files always, otherwise
      *            <code>false</code>
      * @return this builder
+     * @since 24.0
      */
     @Deprecated
     public Options enableNpmFileCleaning(boolean forceClean) {
@@ -323,6 +332,7 @@ public class Options implements Serializable {
      * @param runNpmInstall
      *            run npm install. Default is <code>false</code>
      * @return the builder
+     * @since 24.0
      */
     public Options withRunNpmInstall(boolean runNpmInstall) {
         this.runNpmInstall = runNpmInstall;
@@ -368,6 +378,7 @@ public class Options implements Serializable {
      *            whether to copy templates
      *
      * @return the builder
+     * @since 24.0
      */
     public Options withCopyTemplates(boolean copyTemplates) {
         this.copyTemplates = copyTemplates;
@@ -428,6 +439,7 @@ public class Options implements Serializable {
      * Gets the folder where frontend files should be generated.
      *
      * @return folder to generate frontend files in
+     * @since 24.0
      */
     public File getFrontendGeneratedFolder() {
         if (frontendGeneratedFolder == null) {
@@ -457,6 +469,7 @@ public class Options implements Serializable {
      * @param object
      *            the object to fill with token file data
      * @return the builder, for chaining
+     * @since 24.7
      */
     public Options populateTokenFileData(JsonNode object) {
         tokenFileData = object;
@@ -483,6 +496,7 @@ public class Options implements Serializable {
      * @param enable
      *            enables pnpm.
      * @return the builder, for chaining
+     * @since 24.0
      */
     public Options withEnablePnpm(boolean enable) {
         enablePnpm = enable;
@@ -497,6 +511,7 @@ public class Options implements Serializable {
      * @param enable
      *            enables bun.
      * @return the builder, for chaining
+     * @since 24.3
      */
     public Options withEnableBun(boolean enable) {
         enableBun = enable;
@@ -512,6 +527,7 @@ public class Options implements Serializable {
      * @param ciBuild
      *            true to enable ci build
      * @return the builder, for chaining
+     * @since 24.1
      */
     public Options withCiBuild(boolean ciBuild) {
         this.ciBuild = ciBuild;
@@ -521,6 +537,8 @@ public class Options implements Serializable {
     /**
      * Setting this to {@code true} will force a build of the production build
      * even if there is a default production bundle that could be used.
+     *
+     * @since 24.1
      */
     public Options withForceProductionBuild(boolean forceProductionBuild) {
         this.forceProductionBuild = forceProductionBuild;
@@ -600,6 +618,7 @@ public class Options implements Serializable {
      *            true to run with a dev server, false to run in development
      *            bundle mode
      * @return this builder
+     * @since 24.0
      */
     public Options withFrontendHotdeploy(boolean frontendHotdeploy) {
         this.frontendHotdeploy = frontendHotdeploy;
@@ -612,6 +631,7 @@ public class Options implements Serializable {
      *
      * @param frontendIgnoreVersionChecks
      *            {@code true} to ignore node/npm tool version checks
+     * @since 24.8
      */
     public Options withFrontendIgnoreVersionChecks(
             boolean frontendIgnoreVersionChecks) {
@@ -624,6 +644,7 @@ public class Options implements Serializable {
      *
      * @return true to run with a dev server, false to run in development bundle
      *         mode
+     * @since 24.0
      */
     public boolean isFrontendHotdeploy() {
         return frontendHotdeploy;
@@ -633,6 +654,7 @@ public class Options implements Serializable {
      * Check if a dev mode bundle build should run.
      *
      * @return true to run the build, false otherwise
+     * @since 24.0
      */
     public boolean isDevBundleBuild() {
         return !isProductionMode() && isBundleBuild();
@@ -645,6 +667,7 @@ public class Options implements Serializable {
      * @param bundleBuild
      *            true to run a bundle build
      * @return this builder
+     * @since 24.1
      */
     public Options withBundleBuild(boolean bundleBuild) {
         this.bundleBuild = bundleBuild;
@@ -655,6 +678,7 @@ public class Options implements Serializable {
      * Check if a bundle build should run.
      *
      * @return true to run the build, false otherwise
+     * @since 24.1
      */
     public boolean isBundleBuild() {
         return bundleBuild;
@@ -742,6 +766,7 @@ public class Options implements Serializable {
      * gradle.
      *
      * @return The name of the build directory
+     * @since 24.0
      */
     public String getBuildDirectoryName() {
         return buildDirectoryName;
@@ -820,6 +845,7 @@ public class Options implements Serializable {
 
     /**
      * @deprecated use {@link #isEnableConfigUpdate()}
+     * @since 24.0
      */
     @Deprecated(since = "24.4", forRemoval = true)
     public boolean isEnableWebpackConfigUpdate() {
@@ -902,6 +928,7 @@ public class Options implements Serializable {
      * Gets the lookup instance to use for internal lookups.
      *
      * @return the lookup instance
+     * @since 24.0
      */
     public Lookup getLookup() {
         return lookup;
@@ -912,6 +939,7 @@ public class Options implements Serializable {
      *
      * @return <code>true</code> if production mode is enabled, otherwise
      *         <code>false</code>
+     * @since 24.0
      */
     public boolean isProductionMode() {
         return productionMode;
@@ -922,6 +950,7 @@ public class Options implements Serializable {
      * {@literal src/main/resources} in a Maven project.
      *
      * @return the java resource folder
+     * @since 24.0
      */
     public File getJavaResourceFolder() {
         return javaResourceFolder;
@@ -939,6 +968,7 @@ public class Options implements Serializable {
      * @param skip
      *            {@code true} to skip rebuild of dev bundle
      * @return this builder
+     * @since 24.1
      */
     public Options skipDevBundleBuild(boolean skip) {
         skipDevBundle = skip;
@@ -950,6 +980,7 @@ public class Options implements Serializable {
      *
      * @return {@code true} to skip dev bundle checks, {@code false} to run
      *         normally. Default is {@code false}
+     * @since 24.1
      */
     public boolean isSkipDevBundle() {
         return skipDevBundle;
@@ -961,6 +992,7 @@ public class Options implements Serializable {
      * @param compressBundle
      *            {@code false} to not compress frontend bundles
      * @return this builder
+     * @since 24.3
      */
     public Options withCompressBundle(boolean compressBundle) {
         this.compressBundle = compressBundle;
@@ -971,6 +1003,7 @@ public class Options implements Serializable {
      * Get if frontend bundle should be compressed or not.
      *
      * @return true to copress, false to skip compression
+     * @since 24.3
      */
     public boolean isCompressBundle() {
         return compressBundle;
@@ -1003,6 +1036,7 @@ public class Options implements Serializable {
      *            {@literal false} if they should be preserved.
      *
      * @return this builder
+     * @since 24.4
      */
     public Options withCleanOldGeneratedFiles(boolean clean) {
         this.cleanOldGeneratedFiles = clean;
@@ -1015,6 +1049,7 @@ public class Options implements Serializable {
      *
      * @return {@literal true} if old generated files should be removed,
      *         otherwise {@literal false}.
+     * @since 24.4
      */
     public boolean isCleanOldGeneratedFiles() {
         return cleanOldGeneratedFiles;
@@ -1026,6 +1061,7 @@ public class Options implements Serializable {
      * @param frontendExtraFileExtensions
      *            the file extensions to add for the project
      * @return this builder
+     * @since 24.6
      */
     public Options withFrontendExtraFileExtensions(
             List<String> frontendExtraFileExtensions) {
@@ -1037,6 +1073,7 @@ public class Options implements Serializable {
      * Gets the project file extensions.
      *
      * @return the project file extensions
+     * @since 24.6
      */
     public List<String> getFrontendExtraFileExtensions() {
         return frontendExtraFileExtensions;
@@ -1046,6 +1083,7 @@ public class Options implements Serializable {
      * Sets whether to exclude web component npm packages in packages.json.
      *
      * @return this builder
+     * @since 24.6
      */
     public boolean isNpmExcludeWebComponents() {
         return npmExcludeWebComponents;
@@ -1057,6 +1095,7 @@ public class Options implements Serializable {
      * @param exclude
      *            whether to exclude web component npm packages
      * @return this builder
+     * @since 24.6
      */
     public Options withNpmExcludeWebComponents(boolean exclude) {
         this.npmExcludeWebComponents = exclude;
@@ -1067,6 +1106,7 @@ public class Options implements Serializable {
      * Whether to ignore node/npm tool version checks or not.
      *
      * @return {@code true} to ignore node/npm tool version checks
+     * @since 24.8
      */
     public boolean isFrontendIgnoreVersionChecks() {
         return frontendIgnoreVersionChecks;
@@ -1078,6 +1118,7 @@ public class Options implements Serializable {
      * @param frontendDependenciesScanner
      *            frontend dependencies scanner
      * @return this builder
+     * @since 24.8
      */
     public Options withFrontendDependenciesScanner(
             FrontendDependenciesScanner frontendDependenciesScanner) {
@@ -1090,6 +1131,7 @@ public class Options implements Serializable {
      *
      * @return {@code true} if the commercial banner is enabled, {@code false}
      *         otherwise
+     * @since 24.9
      */
     public boolean isCommercialBannerEnabled() {
         return commercialBannerEnabled;
@@ -1103,6 +1145,7 @@ public class Options implements Serializable {
      *            a boolean value indicating whether the built application could
      *            add a commercial banner.
      * @return this builder
+     * @since 24.9
      */
     public Options withCommercialBanner(boolean enableCommercialBanner) {
         this.commercialBannerEnabled = enableCommercialBanner;
@@ -1114,6 +1157,7 @@ public class Options implements Serializable {
      * this initializes a new one based on the Options set.
      *
      * @return frontend dependencies scanner
+     * @since 24.8
      */
     public FrontendDependenciesScanner getFrontendDependenciesScanner() {
         if (frontendDependenciesScanner == null) {
@@ -1133,6 +1177,7 @@ public class Options implements Serializable {
      * @param copyAssets
      *            boolean value indicating if npm assets should be copied.
      * @return this builder
+     * @since 24.9
      */
     public Options setCopyAssets(boolean copyAssets) {
         this.copyAssets = copyAssets;
@@ -1145,6 +1190,7 @@ public class Options implements Serializable {
      * NOTE! For a devBundleBuild copy assets will always be true!
      *
      * @return {@code false} to skip copying except for devBundleBuild.
+     * @since 24.9
      */
     public boolean copyAssets() {
         if (isDevBundleBuild()) {
@@ -1165,6 +1211,7 @@ public class Options implements Serializable {
      * @param defaultValue
      *            the value to return if the property is not set
      * @return the property value, or empty if configuration is unavailable
+     * @since 24.10.5
      */
     public Optional<String> getApplicationStringProperty(String name,
             String defaultValue) {
@@ -1184,6 +1231,7 @@ public class Options implements Serializable {
      * @param defaultValue
      *            the value to return if the property is not set
      * @return the property value, or empty if configuration is unavailable
+     * @since 24.10.5
      */
     public Optional<Boolean> getApplicationBooleanProperty(String name,
             boolean defaultValue) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ProdBundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ProdBundleUtils.java
@@ -24,6 +24,8 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
  * Helpers related to the production bundle.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.3
  */
 public class ProdBundleUtils {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ProxyFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ProxyFactory.java
@@ -21,6 +21,9 @@ import org.apache.commons.io.FileUtils;
 
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
 
+/**
+ * @since 24.5
+ */
 public class ProxyFactory {
 
     static final String NPMRC_NOPROXY_PROPERTY_KEY = "noproxy";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 24.1
  */
 public class TaskCleanFrontendFiles implements FallibleCommand {
 
@@ -57,6 +57,7 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
      *
      * @param options
      *            options containing file paths and classfinder
+     * @since 24.7.1
      */
     public TaskCleanFrontendFiles(Options options) {
         this.projectRoot = options.getNpmFolder();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
@@ -33,7 +33,7 @@ import static com.vaadin.flow.server.Constants.RESOURCES_JAR_DEFAULT;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 2.0.3
  */
 public class TaskCopyFrontendFiles
         extends AbstractFileGeneratorFallibleCommand {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 2.0.5
  */
 public class TaskCopyLocalFrontendFiles
         extends AbstractFileGeneratorFallibleCommand {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyNpmAssetsFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyNpmAssetsFiles.java
@@ -35,7 +35,7 @@ import static com.vaadin.flow.shared.ApplicationConstants.VAADIN_STATIC_FILES_PA
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 24.9
  */
 public class TaskCopyNpmAssetsFiles
         extends AbstractFileGeneratorFallibleCommand {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyTemplateFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyTemplateFiles.java
@@ -30,6 +30,8 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
  * at runtime in production mode.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 9.0
  */
 public class TaskCopyTemplateFiles implements FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -33,6 +33,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TSX;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
+ * @since 6.0
  */
 public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateEndpoint.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateEndpoint.java
@@ -12,6 +12,8 @@ package com.vaadin.flow.server.frontend;
  * Generate the TS files for endpoints, and the Client API file.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 23.0
  */
 public interface TaskGenerateEndpoint extends FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
@@ -24,6 +24,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
+ * @since 23.0
  */
 public class TaskGenerateFeatureFlags extends AbstractTaskClientGenerator {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateOpenAPI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateOpenAPI.java
@@ -12,6 +12,8 @@ package com.vaadin.flow.server.frontend;
  * Generate OpenAPI json file for Vaadin Endpoints.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 8.0
  */
 public interface TaskGenerateOpenAPI extends FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
@@ -39,6 +39,8 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
  * Generates necessary PWA icons.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.6
  */
 public class TaskGeneratePWAIcons implements FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 3.0
  */
 public class TaskGeneratePackageJson extends NodeUpdater {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -48,7 +48,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 3.0
+ * @since 24.3
  */
 public class TaskGenerateReactFiles
         extends AbstractFileGeneratorFallibleCommand {
@@ -215,6 +215,7 @@ public class TaskGenerateReactFiles
      *            the task options
      * @param layoutsClasses
      *            {@link Layout} annotated classes.
+     * @since 24.5
      */
     public static void writeLayouts(Options options,
             Collection<Class<?>> layoutsClasses) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateServiceWorker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateServiceWorker.java
@@ -23,7 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 3.0
+ * @since 6.0
  */
 public class TaskGenerateServiceWorker extends AbstractTaskClientGenerator {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -36,6 +36,8 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
     /**
      * Keeps track of whether a warning update has already been logged. This is
      * used to avoid spamming the log with the same message.
+     *
+     * @since 24.4
      */
     protected static boolean warningEmitted = false;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -28,7 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 3.0
+ * @since 3.1
  */
 public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
 
@@ -62,6 +62,8 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
     /**
      * Keeps track of whether a warning update has already been logged. This is
      * used to avoid spamming the log with the same message.
+     *
+     * @since 24.4
      */
     protected static boolean warningEmitted = false;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateViteDevMode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateViteDevMode.java
@@ -22,7 +22,7 @@ import org.apache.commons.io.IOUtils;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 9.0
  */
 public class TaskGenerateViteDevMode extends AbstractTaskClientGenerator {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentBootstrap.java
@@ -24,6 +24,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEB_COMPONENT_BOOTST
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
+ * @since 23.1
  */
 public class TaskGenerateWebComponentBootstrap
         extends AbstractTaskClientGenerator {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentHtml.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentHtml.java
@@ -22,7 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 3.0
+ * @since 23.1
  */
 public class TaskGenerateWebComponentHtml extends AbstractTaskClientGenerator {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPlugins.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPlugins.java
@@ -33,7 +33,7 @@ import static com.vaadin.flow.server.frontend.FrontendPluginsUtil.PLUGIN_TARGET;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 24.0
  */
 public class TaskInstallFrontendBuildPlugins implements FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.server.ExecutionFailedException;
  *
  * @see NodeTasks
  * @see GeneratedFilesSupport
+ * @since 24.4
  */
 public class TaskRemoveOldFrontendGeneratedFiles implements FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -32,6 +32,8 @@ import com.vaadin.flow.shared.util.SharedUtil;
  * Only used when running in dev mode without a dev server.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.0
  */
 public class TaskRunDevBundleBuild implements FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateOldIndexTs.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateOldIndexTs.java
@@ -27,6 +27,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Updated <code>index.ts</code> if it imports Flow from an old location.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.1
  */
 public class TaskUpdateOldIndexTs implements FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
@@ -34,6 +34,8 @@ import static elemental.json.impl.JsonUtil.stringify;
  * configuration.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 9.0
  */
 public class TaskUpdateSettingsFile implements FallibleCommand, Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -34,7 +34,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.THEME_IMPORTS_NAME;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 6.0
  */
 public class TaskUpdateThemeImport
         extends AbstractFileGeneratorFallibleCommand {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
@@ -31,6 +31,8 @@ import com.vaadin.flow.server.PwaConfiguration;
  * Updates the Vite configuration files according with current project settings.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 9.0
  */
 public class TaskUpdateVite implements FallibleCommand, Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeUtils.java
@@ -43,6 +43,8 @@ import static com.vaadin.flow.shared.ApplicationConstants.VAADIN_STATIC_FILES_PA
  * Helpers related to theme handling.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.1
  */
 public class ThemeUtils {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeValidationUtil.java
@@ -143,6 +143,7 @@ public class ThemeValidationUtil {
      * @return {@literal true} if the theme has legacy Shadow DOM stylesheets,
      *         and they are not included on the application bundle, otherwise
      *         {@literal false}.
+     * @since 24.7
      */
     public static boolean themeShadowDOMStylesheetsChanged(Options options,
             JsonNode statsJson,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -16,6 +16,8 @@ import com.vaadin.flow.theme.ThemeDefinition;
 
 /**
  * Implemented by classes that want to modify the bootstrap typescript.
+ *
+ * @since 24.3
  */
 public interface TypeScriptBootstrapModifier extends Serializable {
 
@@ -43,6 +45,7 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            true if building for production, false otherwise
      * @param themeDefinition
      *            the theme used by the application
+     * @since 24.3.3
      */
     @Deprecated
     default void modify(List<String> bootstrapTypeScript,
@@ -59,6 +62,7 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            options used by the build
      * @param frontendDependenciesScanner
      *            the frontend dependencies scanner
+     * @since 24.4
      */
     default void modify(List<String> bootstrapTypeScript, Options options,
             FrontendDependenciesScanner frontendDependenciesScanner) {
@@ -73,6 +77,7 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            the input typescript split into lines
      * @param options
      *            options used by the build
+     * @since 24.10.5
      */
     default void modify(List<String> bootstrapTypeScript, Options options) {
         modify(bootstrapTypeScript, options,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/UnknownTaskException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/UnknownTaskException.java
@@ -13,6 +13,8 @@ package com.vaadin.flow.server.frontend;
  * encountered.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 6.0
  */
 public class UnknownTaskException extends RuntimeException {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ArchiveExtractionException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ArchiveExtractionException.java
@@ -15,7 +15,7 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 3.1
  */
 public class ArchiveExtractionException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultArchiveExtractor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultArchiveExtractor.java
@@ -33,7 +33,7 @@ import org.apache.commons.io.IOUtils;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 3.1
  */
 public final class DefaultArchiveExtractor implements ArchiveExtractor {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 3.1
  */
 public final class DefaultFileDownloader implements FileDownloader {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DownloadException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DownloadException.java
@@ -15,7 +15,7 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 24.5
  */
 public final class DownloadException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/FileDownloader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/FileDownloader.java
@@ -18,7 +18,7 @@ import java.net.URI;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 24.5
  */
 public interface FileDownloader {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/InstallationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/InstallationException.java
@@ -15,7 +15,7 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 3.1
  */
 public class InstallationException extends Exception {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -39,7 +39,7 @@ import com.vaadin.flow.server.frontend.FrontendVersion;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 3.1
  */
 public class NodeInstaller {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/Platform.java
@@ -24,7 +24,7 @@ import static com.vaadin.flow.server.frontend.installer.NodeInstaller.UNOFFICIAL
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 3.1
  */
 public class Platform {
 
@@ -205,6 +205,7 @@ public class Platform {
      * Check if platform is linux.
      *
      * @return true if linux
+     * @since 23.0.5
      */
     public boolean isLinux() {
         return os == OS.LINUX;
@@ -234,6 +235,7 @@ public class Platform {
      * @param nodeVersion
      *            node version to get classifier for
      * @return platform node classifier
+     * @since 6.0.10
      */
     public String getNodeClassifier(FrontendVersion nodeVersion) {
         String result = getCodename() + "-"
@@ -245,6 +247,7 @@ public class Platform {
      * Gets the platform dependent download root.
      *
      * @return platform download root
+     * @since 23.1.5
      */
     public String getNodeDownloadRoot() {
         return nodeDownloadRoot;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 3.1
  */
 public class ProxyConfig {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
@@ -13,7 +13,7 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
+ * @since 24.7
  */
 public final class VerificationException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ChunkInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ChunkInfo.java
@@ -23,6 +23,8 @@ import java.util.Objects;
  * which is used for gathering all data that relates to internal entry points.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.1
  **/
 public class ChunkInfo {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassFinder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassFinder.java
@@ -26,7 +26,7 @@ import com.googlecode.gentyref.GenericTypeReflector;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 2.0.3
  */
 public interface ClassFinder extends Serializable {
 
@@ -228,6 +228,7 @@ public interface ClassFinder extends Serializable {
      * Get class loader which is used to find classes.
      *
      * @return the class loader which is used to find classes..
+     * @since 3.0
      */
     ClassLoader getClassLoader();
 
@@ -261,6 +262,7 @@ public interface ClassFinder extends Serializable {
      *            the fully qualified name of the class
      * @return {@code true} if the class should be inspected, otherwise
      *         {@code false}
+     * @since 24.8
      */
     default boolean shouldInspectClass(String className) {
         return true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
@@ -14,6 +14,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * @since 24.1
+ */
 public class ClassInfo {
     String className;
     final LinkedHashSet<String> modules = new LinkedHashSet<>();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssData.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 2.0.3
  */
 public final class CssData implements Serializable {
     private String value;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.router.Route;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 24.1
  */
 public final class EntryPointData implements Serializable {
     private final EntryPointType type;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointType.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointType.java
@@ -15,6 +15,8 @@ package com.vaadin.flow.server.frontend.scanner;
  * to those, there are a bunch of internal entry points that are also scanned.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.1
  */
 public enum EntryPointType {
     ROUTE, WEB_COMPONENT, INTERNAL;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -68,7 +68,7 @@ import static com.vaadin.flow.server.frontend.scanner.FrontendClassVisitor.VERSI
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 2.0
+ * @since 2.0.3
  */
 public class FrontendDependencies extends AbstractDependenciesScanner {
 
@@ -151,6 +151,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * @deprecated Use
      *             {@link FrontendDependencies#FrontendDependencies(ClassFinder, boolean, FeatureFlags, boolean)}
      *             instead.
+     * @since 24.0
      */
     @Deprecated
     public FrontendDependencies(ClassFinder finder,
@@ -332,6 +333,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * Get the PWA configuration of the application.
      *
      * @return the PWA configuration
+     * @since 6.0
      */
     @Override
     public PwaConfiguration getPwaConfiguration() {
@@ -357,6 +359,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * Get all JS modules needed in development mode.
      *
      * @return list of JS modules
+     * @since 24.2
      */
     @Override
     public Map<ChunkInfo, List<String>> getModulesDevelopment() {
@@ -395,6 +398,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * Get all the JS files needed in development mode.
      *
      * @return the set of JS files
+     * @since 24.2
      */
     @Override
     public Map<ChunkInfo, List<String>> getScriptsDevelopment() {
@@ -435,6 +439,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * Get all entryPoints in the application.
      *
      * @return the set of JS files
+     * @since 24.1
      */
     public Collection<EntryPointData> getEntryPoints() {
         return entryPoints.values();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.theme.ThemeDefinition;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 2.1
  */
 public interface FrontendDependenciesScanner extends Serializable {
 
@@ -161,6 +161,7 @@ public interface FrontendDependenciesScanner extends Serializable {
      * Get all npm packages needed only for development.
      *
      * @return the `devDependencies` packages
+     * @since 24.3
      */
     Map<String, String> getDevPackages();
 
@@ -168,6 +169,7 @@ public interface FrontendDependenciesScanner extends Serializable {
      * Get all npm package assets for the application.
      *
      * @return the npm packages assets
+     * @since 24.9
      */
     Map<String, List<String>> getAssets();
 
@@ -175,6 +177,7 @@ public interface FrontendDependenciesScanner extends Serializable {
      * Get all npm packages assets needed only for development.
      *
      * @return the `dev` npm package assets
+     * @since 24.9
      */
     Map<String, List<String>> getDevAssets();
 
@@ -191,6 +194,7 @@ public interface FrontendDependenciesScanner extends Serializable {
      * theme dependencies are guaranteed to precede other modules in the result.
      *
      * @return the JS modules
+     * @since 24.2
      */
     Map<ChunkInfo, List<String>> getModulesDevelopment();
 
@@ -205,6 +209,7 @@ public interface FrontendDependenciesScanner extends Serializable {
      * Get all the JS files needed only in development mode.
      *
      * @return the JS files
+     * @since 24.2
      */
     Map<ChunkInfo, List<String>> getScriptsDevelopment();
 
@@ -240,6 +245,7 @@ public interface FrontendDependenciesScanner extends Serializable {
      * Get the {@link PwaConfiguration} of the application.
      *
      * @return the PWA configuration
+     * @since 6.0
      */
     PwaConfiguration getPwaConfiguration();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/AvailableViewInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/AvailableViewInfo.java
@@ -55,6 +55,7 @@ import com.vaadin.flow.router.MenuData;
  * @param detail
  *            additional information to be used in the menu, encoded in JSON
  *            format
+ * @since 24.5
  */
 public record AvailableViewInfo(String title, String[] rolesAllowed,
         boolean loginRequired, String route, boolean lazy, boolean register,
@@ -113,6 +114,9 @@ public record AvailableViewInfo(String title, String[] rolesAllowed,
                 + routeParameters + ", detail=" + detail + '}';
     }
 
+    /**
+     * @since 24.8
+     */
     public static class DetailDeserializer extends JsonDeserializer<String> {
         @Override
         public String deserialize(JsonParser p, DeserializationContext ctxt)
@@ -125,6 +129,9 @@ public record AvailableViewInfo(String title, String[] rolesAllowed,
         }
     }
 
+    /**
+     * @since 24.8
+     */
     public static class DetailSerializer extends JsonSerializer<String> {
         @Override
         public void serialize(String value, JsonGenerator gen,

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuEntry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuEntry.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.Component;
  *            the source class with {@link com.vaadin.flow.router.Menu}
  *            annotation or null if not available. Always null for
  *            Hilla/TypeScript client views.
+ * @since 24.5
  */
 public record MenuEntry(String path, String title, Double order, String icon,
         Class<? extends Component> menuClass) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/RouteParamType.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/RouteParamType.java
@@ -12,6 +12,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.vaadin.flow.router.internal.ParameterInfo;
 
+/**
+ * @since 24.5
+ */
 public enum RouteParamType {
     // @formatter:off
     @JsonProperty("req") REQUIRED,

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractAnnotationValidator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractAnnotationValidator.java
@@ -85,6 +85,7 @@ public abstract class AbstractAnnotationValidator implements Serializable {
      * @param clazz
      *            class to validate annotations
      * @return an optional error message or empty if there is no error
+     * @since 2.0
      */
     protected Optional<String> handleNonRouterLayout(Class<?> clazz) {
         return Optional.of(String.format(NON_ROUTER_LAYOUT, clazz.getName(),
@@ -95,6 +96,7 @@ public abstract class AbstractAnnotationValidator implements Serializable {
      * Returns a hint for the discovered validation errors.
      *
      * @return the error hint
+     * @since 2.0
      */
     protected String getErrorHint() {
         return ERROR_MESSAGE_BEGINNING;
@@ -107,6 +109,7 @@ public abstract class AbstractAnnotationValidator implements Serializable {
      *            the type to get validation annotations
      * @return comma separated list of validation annotation declared for the
      *         {@code clazz}
+     * @since 2.0
      */
     protected String getClassAnnotations(Class<?> clazz) {
         return getClassAnnotations(clazz, getAnnotations());
@@ -120,6 +123,7 @@ public abstract class AbstractAnnotationValidator implements Serializable {
      * @param annotations
      *            the annotation list
      * @return a comma separated string with the annotation names
+     * @since 3.0
      */
     @SuppressWarnings("unchecked")
     public static String getClassAnnotations(Class<?> clazz,
@@ -179,6 +183,7 @@ public abstract class AbstractAnnotationValidator implements Serializable {
      *            the object with a @HandlesTypes annotation
      *
      * @return a filtered set of classes
+     * @since 23.1
      */
     public static Set<Class<?>> removeHandleTypesSelfReferences(
             Set<Class<?>> classSet, Object handlesTypesAnnotated) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -57,7 +57,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.PROJECT_BASEDIR;
  * A configuration factory base logic which reads the token file.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public class AbstractConfigurationFactory implements Serializable {
@@ -71,6 +71,7 @@ public class AbstractConfigurationFactory implements Serializable {
      * @param buildInfo
      *            the token file data
      * @return the config parameters
+     * @since 24.8
      */
     protected Map<String, String> getConfigParametersUsingTokenData(
             JsonNode buildInfo) {
@@ -214,6 +215,7 @@ public class AbstractConfigurationFactory implements Serializable {
      *            the configuration parameters to set dev mode properties to
      * @param buildInfo
      *            the token file data
+     * @since 24.8
      */
     protected void setDevModePropertiesUsingTokenData(
             Map<String, String> params, JsonNode buildInfo) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -52,6 +52,7 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
      * @param routeClasses
      *            potential route classes
      * @return a resulting set of the route component classes
+     * @since 9.0
      */
     @SuppressWarnings("unchecked")
     protected Set<Class<? extends Component>> validateRouteClasses(
@@ -258,6 +259,7 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
      * @param routeClasses
      *            potential route classes
      * @return a PWA -annotated class, or null if none exist.
+     * @since 9.0
      */
     @SuppressWarnings("unchecked")
     protected Class<?> validatePwaClass(VaadinContext context,

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AppShellPredicate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AppShellPredicate.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
  * for the web application.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.server.VaadinContext;
  * container level configuration (e.g. Servlet).
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public interface ApplicationConfiguration extends AbstractConfiguration {
@@ -88,6 +88,7 @@ public interface ApplicationConfiguration extends AbstractConfiguration {
      *
      * @return {@code true} if dev mode session serialization is enabled,
      *         {@code false} otherwise
+     * @since 8.0
      */
     boolean isDevModeSessionSerializationEnabled();
 
@@ -102,6 +103,7 @@ public interface ApplicationConfiguration extends AbstractConfiguration {
      *
      * @return {@code true} if Flow should not automatically register servlets
      * @see com.vaadin.flow.server.startup.ServletDeployer
+     * @since 9.0
      */
     default boolean disableAutomaticServletRegistration() {
         return getBooleanProperty(

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfigurationFactory.java
@@ -14,7 +14,7 @@ import com.vaadin.flow.server.VaadinContext;
  * A factory for {@link ApplicationConfiguration}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 public interface ApplicationConfigurationFactory {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -51,6 +51,8 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry
 
     /**
      * Creates a new uninitialized route registry.
+     *
+     * @since 9.0
      */
     protected ApplicationRouteRegistry(VaadinContext context) {
         this.context = context;
@@ -60,6 +62,8 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry
 
     /**
      * RouteRegistry wrapper class for storing the ApplicationRouteRegistry.
+     *
+     * @since 2.2
      */
     protected static class ApplicationRouteRegistryWrapper
             implements Serializable {
@@ -95,6 +99,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry
      *            the vaadin context for which to get a route registry, not
      *            <code>null</code>
      * @return a registry instance for the given context, not <code>null</code>
+     * @since 2.2
      */
     public static ApplicationRouteRegistry getInstance(VaadinContext context) {
         assert context != null;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListener.java
@@ -53,6 +53,7 @@ import com.vaadin.pro.licensechecker.MissingLicenseKeyException;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @see VaadinServiceInitListener
+ * @since 24.9
  */
 public abstract class BaseLicenseCheckerServiceInitListener
         implements VaadinServiceInitListener {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.server.VaadinServletContext;
  *
  * @author Vaadin Ltd
  *
+ * @since 3.0.3
  */
 public interface ClassLoaderAwareServletContainerInitializer
         extends ServletContainerInitializer {
@@ -119,6 +120,7 @@ public interface ClassLoaderAwareServletContainerInitializer
      * Whether this initializer requires lookup or not.
      *
      * @return whether this initializer requires lookup
+     * @since 6.0
      */
     default boolean requiresLookup() {
         return true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
@@ -40,7 +40,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
  * Default implementation of {@link ApplicationConfigurationFactory}.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 @Component(service = ApplicationConfigurationFactory.class, property = Constants.SERVICE_RANKING
@@ -117,6 +117,7 @@ public class DefaultApplicationConfigurationFactory
      * @param properties
      *            the context parameters, not {@code null}
      * @return a new application configuration instance
+     * @since 24.1
      */
     protected ApplicationConfigurationImpl doCreate(VaadinContext context,
             Map<String, String> properties) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/LookupServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/LookupServletContainerInitializer.java
@@ -43,7 +43,7 @@ import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
+ * @since 6.0
  *
  */
 @HandlesTypes({ ResourceProvider.class, InstantiatorFactory.class,

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
@@ -98,6 +98,7 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
      * @throws InvalidRouteLayoutConfigurationException
      *             Thrown if any {@link Layout} annotations are found on non
      *             {@link RouterLayout} classes
+     * @since 24.5
      */
     public static void validateLayoutAnnotations(Set<Class<?>> routesSet)
             throws InvalidRouteLayoutConfigurationException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletContextListeners.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletContextListeners.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.server.communication.JSR356WebsocketInitializer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since 1.0
+ * @since 1.0.5
  */
 @WebListener
 public class ServletContextListeners implements ServletContextListener {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
@@ -78,6 +78,7 @@ public class VaadinAppShellInitializer
      *            this class.
      * @param context
      *            the {@link VaadinContext}.
+     * @since 6.0
      */
     @SuppressWarnings("unchecked")
     public static void init(Set<Class<?>> classes, VaadinContext context) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
@@ -23,7 +23,7 @@ import java.util.Set;
  * {@link ClassLoaderAwareServletContainerInitializer#onStartup(Set, ServletContext)})</li>
  * </ul>
  *
- * @since
+ * @since 6.0
  *
  * @see ClassLoaderAwareServletContainerInitializer
  * @see VaadinServletContextStartupInitializer

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
@@ -11,7 +11,7 @@ package com.vaadin.flow.server.startup;
 /**
  * Indicates an issue during Vaadin initialization.
  *
- * @since
+ * @since 6.0
  */
 public class VaadinInitializerException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinServletContextStartupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinServletContextStartupInitializer.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * and perform any required programmatic registration of servlets, filters, and
  * listeners in response to it.
  *
- * @since
+ * @since 6.0
  *
  * @see ClassLoaderAwareServletContainerInitializer
  */

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -120,6 +120,7 @@ public interface DownloadHandler extends ElementRequestHandler {
      * @return a {@link DownloadHandler} that is served regardless of the
      *         owner's enabled state, or {@code this} if the disabled mode is
      *         already {@link DisabledUpdateMode#ALWAYS}
+     * @since 24.10.5
      */
     default DownloadHandler allowDisabled() {
         if (getDisabledUpdateMode() == DisabledUpdateMode.ALWAYS) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadResponse.java
@@ -122,6 +122,7 @@ public class DownloadResponse implements Serializable {
      * @param exception
      *            exception that caused the error
      * @return DownloadResponse for request
+     * @since 24.9
      */
     public static DownloadResponse error(int statusCode, Exception exception) {
         DownloadResponse downloadResponse = new DownloadResponse(null, null,
@@ -156,6 +157,7 @@ public class DownloadResponse implements Serializable {
      * @param exception
      *            exception that caused the error
      * @return DownloadResponse for request
+     * @since 24.9
      */
     public static DownloadResponse error(int statusCode, String message,
             Exception exception) {
@@ -187,6 +189,7 @@ public class DownloadResponse implements Serializable {
      * @param exception
      *            exception that caused the error
      * @return DownloadResponse for request
+     * @since 24.9
      */
     public static DownloadResponse error(HttpStatusCode statusCode,
             Exception exception) {
@@ -223,6 +226,7 @@ public class DownloadResponse implements Serializable {
      * @param exception
      *            exception that caused the error
      * @return DownloadResponse for request
+     * @since 24.9
      */
     public static DownloadResponse error(HttpStatusCode statusCode,
             String message, Exception exception) {
@@ -258,6 +262,7 @@ public class DownloadResponse implements Serializable {
      *            error code
      * @param exception
      *            exception that caused the error
+     * @since 24.9
      */
     public void setError(int error, Exception exception) {
         this.error = error;
@@ -286,6 +291,7 @@ public class DownloadResponse implements Serializable {
      *            error message
      * @param exception
      *            exception that caused the error
+     * @since 24.9
      */
     public void setError(int error, String errorMessage, Exception exception) {
         setError(error, errorMessage);
@@ -309,6 +315,7 @@ public class DownloadResponse implements Serializable {
      *            error code
      * @param exception
      *            exception that caused the error
+     * @since 24.9
      */
     public void setError(HttpStatusCode error, Exception exception) {
         this.error = error.getCode();
@@ -337,6 +344,7 @@ public class DownloadResponse implements Serializable {
      *            error message
      * @param exception
      *            exception that caused the error
+     * @since 24.9
      */
     public void setError(HttpStatusCode error, String errorMessage,
             Exception exception) {
@@ -370,6 +378,7 @@ public class DownloadResponse implements Serializable {
      *
      * @return the exception or null if no exception occurred
      * @see TransferContext#exception()
+     * @since 24.9
      */
     public Exception getException() {
         return exception;

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ElementRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ElementRequestHandler.java
@@ -20,6 +20,8 @@ import com.vaadin.flow.server.VaadinSession;
 /**
  * Request handler callback for handing client-server or server-client data
  * transfer scoped to a specific (owner) element.
+ *
+ * @since 24.8
  */
 @FunctionalInterface
 public interface ElementRequestHandler extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferContext.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.server.VaadinSession;
  * @param exception
  *            An exception that occurred during the transfer, or
  *            <code>null</code>.
+ * @since 24.8
  */
 public record TransferContext(VaadinRequest request, VaadinResponse response,
         VaadinSession session, String fileName, Element owningElement,
@@ -65,6 +66,7 @@ public record TransferContext(VaadinRequest request, VaadinResponse response,
      *            the total number of bytes to be transferred or <code>-1</code>
      *            if total number is unknown in advance, e.g. when reading from
      *            an input stream
+     * @since 24.9
      */
     public TransferContext(VaadinRequest request, VaadinResponse response,
             VaadinSession session, String fileName, Element owningElement,

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.shared.Registration;
  * @param <R>
  *            type of the subclass implementing this abstract class, needed for
  *            revealing a proper type when you chain the methods
+ * @since 24.8
  */
 public abstract class TransferProgressAwareHandler<T, R extends TransferProgressAwareHandler>
         implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferUtil.java
@@ -43,6 +43,8 @@ import com.vaadin.flow.server.VaadinSession;
 /**
  * Utility class with methods for handling transfer of upload and download
  * requests.
+ *
+ * @since 24.8
  */
 public final class TransferUtil {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadMetadata.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadMetadata.java
@@ -12,6 +12,8 @@ package com.vaadin.flow.server.streams;
  * Metadata for successful upload.
  * <p>
  * The fileName and contentType will only be available for multipart uploads.
+ *
+ * @since 24.8
  */
 public record UploadMetadata(String fileName, String contentType,
         long contentLength) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentBinding.java
@@ -141,6 +141,7 @@ public final class WebComponentBinding<C extends Component>
      * @throws IllegalArgumentException
      *             if the {@code jsonValue} cannot be converted to the type of
      *             the property identified by {@code propertyName}.
+     * @since 24.8
      */
     public void updateProperty(String propertyName, BaseJsonNode jsonValue) {
         Objects.requireNonNull(propertyName,
@@ -210,6 +211,7 @@ public final class WebComponentBinding<C extends Component>
      *            {@link PropertyData}
      * @throws NullPointerException
      *             if {@code propertyConfiguration} is {@code null}
+     * @since 24.8
      */
     public void bindProperty(
             PropertyConfigurationImpl<C, ? extends Serializable> propertyConfiguration,
@@ -234,6 +236,7 @@ public final class WebComponentBinding<C extends Component>
      *            have any effect
      * @throws NullPointerException
      *             if {@code propertyConfiguration} is {@code null}
+     * @since 24.8
      */
     public void bindProperty(
             PropertyConfigurationImpl<C, ? extends Serializable> propertyConfiguration,

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistry.java
@@ -221,6 +221,7 @@ public class WebComponentConfigurationRegistry implements Serializable {
      *
      * @param elements
      *            list of shadow dom elements
+     * @since 2.2
      */
     public void setShadowDomElements(List<Element> elements) {
         lock();
@@ -236,6 +237,7 @@ public class WebComponentConfigurationRegistry implements Serializable {
      * the embedded web component.
      *
      * @return copy of shadow dom elements
+     * @since 2.2
      */
     public List<Element> getShadowDomElements() {
         lock();

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentExporterUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentExporterUtils.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.internal.ReflectTools;
  *
  * @author Vaadin Ltd
  *
+ * @since 2.2
  */
 public final class WebComponentExporterUtils {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
@@ -84,6 +84,7 @@ public class WebComponentGenerator {
      *            the theme defined using {@link Theme} or {@code null} if not
      *            defined
      * @return generated web component html/JS to be served to the client
+     * @since 24.1
      */
     public static String generateModule(
             WebComponentExporterFactory<? extends Component> factory,
@@ -108,6 +109,7 @@ public class WebComponentGenerator {
      *            the theme defined using {@link Theme} or {@code null} if not
      *            defined
      * @return generated web component html/JS to be served to the client
+     * @since 24.1
      */
     public static String generateModule(
             WebComponentConfiguration<? extends Component> webComponentConfiguration,

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
@@ -186,6 +186,7 @@ public final class WebComponentModulesWriter implements Serializable {
          *             if reflective method invocation fails
          * @see #writeWebComponentsToDirectory(java.util.Set, java.io.File,
          *      java.lang.String)
+         * @since 24.1
          */
         @SuppressWarnings("unchecked")
         public static Set<File> generateWebComponentsToDirectory(

--- a/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
@@ -45,11 +45,15 @@ public class ApplicationConstants implements Serializable {
 
     /**
      * The URL which should be used to connect server-side VaadinService.
+     *
+     * @since 2.0
      */
     public static final String SERVICE_URL = "serviceUrl";
 
     /**
      * Whether the application is run in as a exported Web Component.
+     *
+     * @since 2.0.6
      */
     public static final String APP_WC_MODE = "webComponentMode";
 
@@ -109,6 +113,8 @@ public class ApplicationConstants implements Serializable {
     /**
      * The name of the parameter used to transmit the id of UI used in given
      * request.
+     *
+     * @since 23.3.2
      */
     public static final String UI_ID = "uiId";
 
@@ -130,6 +136,8 @@ public class ApplicationConstants implements Serializable {
     /**
      * Content type to use for text/javascript responses (should always be
      * UTF-8).
+     *
+     * @since 2.0
      */
     public static final String CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8 = "text/javascript; charset=utf-8";
 
@@ -148,10 +156,14 @@ public class ApplicationConstants implements Serializable {
      * Parameter for the initial router location when JavaScript bootstrapping.
      * It is optional when {@link ApplicationConstants#REQUEST_TYPE_PARAMETER}
      * has the {@link ApplicationConstants#REQUEST_TYPE_INIT} value
+     *
+     * @since 3.0
      */
     public static final String REQUEST_LOCATION_PARAMETER = "location";
     /**
      * Parameter for the initial query string when JavaScript bootstrapping.
+     *
+     * @since 23.3.1
      */
     public static final String REQUEST_QUERY_PARAMETER = "query";
 
@@ -162,6 +174,8 @@ public class ApplicationConstants implements Serializable {
 
     /**
      * Request type parameter value indicating an init request.
+     *
+     * @since 3.0
      */
     public static final String REQUEST_TYPE_INIT = "init";
 
@@ -183,12 +197,16 @@ public class ApplicationConstants implements Serializable {
     /**
      * Request type parameter value indicating a WebComponent resynchronization
      * request.
+     *
+     * @since 23.3.2
      */
     public static final String REQUEST_TYPE_WEBCOMPONENT_RESYNC = "webcomponent-resync";
 
     /**
      * Request type parameter value indicating a translation properties file
      * request.
+     *
+     * @since 24.4
      */
     public static final String REQUEST_TYPE_TRANSLATION_FILE = "i18n";
 
@@ -205,17 +223,23 @@ public class ApplicationConstants implements Serializable {
     /**
      * Web socket parameter which identifies connection as live reload
      * connection.
+     *
+     * @since 9.0
      */
     public static final String DEBUG_WINDOW_CONNECTION = "debug_window";
 
     /**
      * Boolean client configuration parameter enabling the development tools.
+     *
+     * @since 23.1
      */
     public static final String DEV_TOOLS_ENABLED = "devToolsEnabled";
 
     /**
      * The name of the parameter used for notifying the server that user closed
      * the tab/window or navigated away.
+     *
+     * @since 24.1
      */
     public static final String UNLOAD_BEACON = "UNLOAD";
 

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -666,6 +666,7 @@ public class BrowserDetails implements Serializable {
      * Tests if the browser is run on iPad.
      *
      * @return true if run on iPad, false otherwise
+     * @since 24.6
      */
     public boolean isIPad() {
         return isIPad;

--- a/flow-server/src/main/java/com/vaadin/flow/shared/GwtIncompatible.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/GwtIncompatible.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Target;
  * <code>gwt-shared</code>. See the documentation for
  * <code>com.google.gwt.core.shared.GwtIncompatible</code> for more information.
  *
- * @since
+ * @since 3.1
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR,

--- a/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
@@ -210,12 +210,16 @@ public class JsonConstants implements Serializable {
 
     /**
      * Key used to hold the promise id for a server side method call.
+     *
+     * @since 2.2
      */
     public static final String RPC_TEMPLATE_EVENT_PROMISE = "promise";
 
     /**
      * Name of the $server property that is used to track pending promises. The
      * name is chosen to avoid conflicts with genuine $server method names.
+     *
+     * @since 2.2
      */
     public static final String RPC_PROMISE_CALLBACK_NAME = "}p";
 
@@ -274,6 +278,8 @@ public class JsonConstants implements Serializable {
 
     /**
      * Key used when the message is sent asynchronously via push channel.
+     *
+     * @since 2.1.1
      */
     public static final String META_ASYNC = "async";
 
@@ -305,6 +311,8 @@ public class JsonConstants implements Serializable {
      * should be synchronized. The token is chosen to avoid collisions with
      * regular event data expressions by using a character that cannot be the
      * start of a valid JS expression.
+     *
+     * @since 1.3
      */
     public static final String SYNCHRONIZE_PROPERTY_TOKEN = "}";
 
@@ -324,16 +332,22 @@ public class JsonConstants implements Serializable {
 
     /**
      * RPC type value used for return channel messages.
+     *
+     * @since 2.0
      */
     public static final String RPC_TYPE_CHANNEL = "channel";
 
     /**
      * Key for the channel id in return channel messages.
+     *
+     * @since 2.0
      */
     public static final String RPC_CHANNEL = "channel";
 
     /**
      * Key for the arguments array in return channel messages.
+     *
+     * @since 2.0
      */
     public static final String RPC_CHANNEL_ARGUMENTS = "args";
 

--- a/flow-server/src/main/java/com/vaadin/flow/shared/Registration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/Registration.java
@@ -43,7 +43,7 @@ public interface Registration extends Serializable {
      *            not <code>null</code>
      * @return a registration that will invoke the command once, not
      *         <code>null</code>
-     * @since
+     * @since 3.1
      */
     @GwtIncompatible("Command is not in a package available to GWT")
     static Registration once(Command command) {
@@ -68,7 +68,7 @@ public interface Registration extends Serializable {
      *            the registrations to remove, not <code>null</code>
      * @return a registration that removes all provided registrations, not
      *         <code>null</code>
-     * @since
+     * @since 3.1
      */
     static Registration combine(Registration... registrations) {
         Objects.requireNonNull(registrations);
@@ -92,7 +92,7 @@ public interface Registration extends Serializable {
      *            the item to add and remove
      * @return a registration that will remove the item from the collection, not
      *         <code>null</code>
-     * @since
+     * @since 3.1
      */
     static <T> Registration addAndRemove(Collection<T> collection, T item) {
         collection.add(item);

--- a/flow-server/src/main/java/com/vaadin/flow/shared/VaadinUriResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/VaadinUriResolver.java
@@ -41,6 +41,7 @@ public abstract class VaadinUriResolver implements Serializable {
      *            the relative path from the servlet path (used as base path in
      *            the client) to the context root
      * @return the resolved URI
+     * @since 3.0
      */
     protected String resolveVaadinUri(String uri, String servletToContextRoot) {
         if (uri == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/shared/ui/Dependency.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/ui/Dependency.java
@@ -87,6 +87,7 @@ public class Dependency implements Serializable {
      *            the type of the dependency, not {@code null}
      * @param expression
      *            the JS expression to load the dependency, not {@code null}
+     * @since 2.1
      */
     public Dependency(Type type, String expression) {
         // It's important that the load mode of the dependency is Lazy because

--- a/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
@@ -317,6 +317,7 @@ public class SharedUtil implements Serializable {
      * @param upperCamelCaseString
      *            The input string in UpperCamelCase format
      * @return A dash separated lowercase version of the input
+     * @since 24.1.1
      */
     public static String upperCamelCaseToDashSeparatedLowerCase(
             String upperCamelCaseString) {

--- a/flow-server/src/main/java/com/vaadin/flow/theme/AbstractTheme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/AbstractTheme.java
@@ -69,6 +69,7 @@ public interface AbstractTheme extends Serializable {
      * @return a Map with the attributes (keys and values) that should be set in
      *         the body, or an empty Map if nothing should be set for the given
      *         variant.
+     * @since 2.0
      */
     default Map<String, String> getHtmlAttributes(String variant) {
         return Collections.emptyMap();

--- a/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
@@ -81,6 +81,7 @@ public @interface Theme {
      * Defaults to Lumo, If not specified.
      *
      * @return theme handler
+     * @since 6.0
      */
     Class<? extends AbstractTheme> themeClass() default AbstractTheme.class;
 

--- a/flow-server/src/main/java/com/vaadin/flow/theme/ThemeDefinition.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/ThemeDefinition.java
@@ -34,6 +34,7 @@ public class ThemeDefinition implements Serializable {
      *            the variant of the theme, not <code>null</code>
      * @param name
      *            name of the theme, not <code>null</code>
+     * @since 6.0
      */
     public ThemeDefinition(Class<? extends AbstractTheme> theme, String variant,
             String name) {
@@ -81,6 +82,7 @@ public class ThemeDefinition implements Serializable {
      * Gets the name of the theme.
      *
      * @return name of the theme
+     * @since 6.0
      */
     public String getName() {
         return name;

--- a/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPush.java
+++ b/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPush.java
@@ -100,6 +100,7 @@ public class WebPush {
      *            <code>title</code> and <code>body</code>
      * @throws WebPushException
      *             if sending a notification fails
+     * @since 24.6
      */
     public void sendNotification(WebPushSubscription subscription,
             WebPushMessage message) throws WebPushException {

--- a/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushKeys.java
+++ b/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushKeys.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
  * @see <a href=
  *      "https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription/getKey">PushSubscription
  *      Keys mdn web docs</a>
+ * @since 24.6
  */
 public record WebPushKeys(String p256dh, String auth) implements Serializable {
 }

--- a/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushMessage.java
+++ b/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushMessage.java
@@ -36,6 +36,7 @@ public record WebPushMessage(String title,
      * @see <a href=
      *      "https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#parameters">
      *      showNotification parameters</a>
+     * @since 24.6
      */
     public WebPushMessage(String title, Serializable options) {
         this(title, objectMapper.convertValue(options, ObjectNode.class));
@@ -48,6 +49,7 @@ public record WebPushMessage(String title,
      *            notification title
      * @param body
      *            notification body
+     * @since 24.6
      */
     public WebPushMessage(String title, String body) {
         this(title, getBodyOption(body));
@@ -58,6 +60,7 @@ public record WebPushMessage(String title,
      *
      * @param title
      *            notification title
+     * @since 24.6
      */
     public WebPushMessage(String title) {
         this(title, (ObjectNode) null);

--- a/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushSubscription.java
+++ b/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushSubscription.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
  * @see <a href=
  *      "https://developer.mozilla.org/en-US/docs/Web/API/PushManager">PushManager
  *      mdn web docs</a>
+ * @since 24.6
  */
 public record WebPushSubscription(String endpoint,
         WebPushKeys keys) implements Serializable {

--- a/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushSubscriptionResponse.java
+++ b/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPushSubscriptionResponse.java
@@ -23,6 +23,7 @@ public interface WebPushSubscriptionResponse extends Serializable {
      *
      * @param subscription
      *            web push subscription object
+     * @since 24.6
      */
     void subscription(WebPushSubscription subscription);
 }


### PR DESCRIPTION
Add missing @since tags, correct wrong ones, create a minimal @since javadoc for undocumented types, and remove redundant member/constructor/enum-constant tags that merely repeat the enclosing type's version. Each value is the earliest version from which the element is continuously present up to the 24.10 line.
