### PR TITLE
fix: allow UI polling while a modal component is open (cp 24.10) (#24834)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/PollNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/PollNotifier.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component;
 
 import java.io.Serializable;
 
+import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -28,6 +29,12 @@ public interface PollNotifier extends Serializable {
      * <p>
      * The listener is called whenever the client polls the server for
      * asynchronous UI updates.
+     * <p>
+     * Poll listeners are registered as "inert" tolerant, which means that they
+     * keep being invoked even while a modal component (such as a modal dialog)
+     * is open. Polling is a UI-level "global" feature that isn't tied to any
+     * specific component and doesn't pass any user-controlled data to the
+     * server, so it should not be blocked by a modality curtain.
      *
      * @see UI#setPollInterval(int)
      * @param listener
@@ -38,7 +45,7 @@ public interface PollNotifier extends Serializable {
             ComponentEventListener<PollEvent> listener) {
         if (this instanceof Component) {
             return ComponentUtil.addListener((Component) this, PollEvent.class,
-                    listener);
+                    listener, DomListenerRegistration::allowInert);
         } else {
             throw new IllegalStateException(String.format(
                     "The class '%s' doesn't extend '%s'. "

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import elemental.json.Json;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -38,6 +39,7 @@ import org.slf4j.Logger;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.History.HistoryStateChangeEvent;
+import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementDetachEvent;
 import com.vaadin.flow.dom.Node;
@@ -47,7 +49,9 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.CurrentInstance;
+
 import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationListener;
 import com.vaadin.flow.router.BeforeEnterEvent;
@@ -1280,6 +1284,28 @@ public class UITest {
         verifyInert(fixture.ui, true);
         verifyInert(fixture.routingComponent, true);
         verifyInert(fixture.modalComponent, false);
+    }
+
+    @Test
+    public void pollListener_uiInertDueToModalComponent_listenerStillInvoked() {
+        final TestFixture fixture = new TestFixture();
+        fixture.collectUiChanges(); // the modal add makes the UI inert
+        verifyInert(fixture.ui, true);
+
+        AtomicInteger count = new AtomicInteger();
+        fixture.ui.addPollListener(event -> count.incrementAndGet());
+
+        firePollEvent(fixture.ui);
+
+        assertEquals("Poll listener should be invoked even while the UI is inert "
+                        + "because of an open modal component", 1, count.get());
+    }
+
+    private void firePollEvent(UI ui) {
+        DomEvent pollEvent = new DomEvent(ui.getElement(),
+                PollEvent.DOM_EVENT_NAME, Json.createObject());
+        ui.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(pollEvent);
     }
 
     @Test


### PR DESCRIPTION
## What changed

Poll listeners registered through `PollNotifier.addPollListener` are now registered with `DomListenerRegistration::allowInert`, so they continue to fire even when a modal component makes the UI inert.

A unit test in `UITest` verifies that the `ui-poll` listener keeps being invoked while a modal curtain is active.

## Why

UI polling is a global, UI-level feature. It is not tied to any specific component and does not send user-controlled data to the server, so it should not be blocked by a modality curtain. Previously, opening a modal dialog caused poll events to be dropped with an `"Ignored listener invocation for ui-poll event ... inert"` message, effectively stopping polling for the duration the modal was open.

Fixes #20917
