### PR TITLE
fix: keep dev mode running when a pre-trial is expired

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListener.java
@@ -34,6 +34,8 @@ import com.vaadin.pro.licensechecker.Capabilities;
 import com.vaadin.pro.licensechecker.Capability;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 import com.vaadin.pro.licensechecker.MissingLicenseKeyException;
+import com.vaadin.pro.licensechecker.PreTrial;
+import com.vaadin.pro.licensechecker.PreTrialLicenseValidationException;
 
 /**
  * Abstract base class implementing the {@link VaadinServiceInitListener} for
@@ -104,6 +106,21 @@ public abstract class BaseLicenseCheckerServiceInitListener
                     // instruct dev tools to check license at runtime
                     CheckProductLicense.register(event, productName,
                             productVersion);
+                } catch (PreTrialLicenseValidationException ex) {
+                    // An expired pre-trial must not abort startup in dev mode:
+                    // delegate to dev tools so the splash screen can offer
+                    // signing in or extending the trial. Any other pre-trial
+                    // state is rethrown to preserve the previous behavior.
+                    if (ex.getPreTrial()
+                            .getTrialState() == PreTrial.PreTrialState.EXPIRED) {
+                        LOGGER.debug(
+                                "Expired pre-trial for {} {} will be handled by Vaadin Dev Server",
+                                productName, productVersion);
+                        CheckProductLicense.register(event, productName,
+                                productVersion);
+                    } else {
+                        throw ex;
+                    }
                 }
             } else {
                 // Fallback to online validation waiting for license key

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListenerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListenerTest.java
@@ -287,8 +287,8 @@ class BaseLicenseCheckerServiceInitListenerTest {
         try (MockedStatic<LicenseChecker> licenseChecker = Mockito
                 .mockStatic(LicenseChecker.class)) {
             PreTrialLicenseValidationException checkerException = new PreTrialLicenseValidationException(
-                    new PreTrial(PRODUCT_NAME, PreTrial.PreTrialState.RUNNING,
-                            7, 0));
+                    new PreTrial(PRODUCT_NAME,
+                            PreTrial.PreTrialState.ACCESS_DENIED, 7, 0));
             licenseChecker
                     .when(() -> LicenseChecker.checkLicense(eq(PRODUCT_NAME),
                             eq(PRODUCT_VERSION), isNull(BuildType.class),

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListenerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListenerTest.java
@@ -33,6 +33,8 @@ import com.vaadin.pro.licensechecker.BuildType;
 import com.vaadin.pro.licensechecker.Capabilities;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 import com.vaadin.pro.licensechecker.LicenseException;
+import com.vaadin.pro.licensechecker.PreTrial;
+import com.vaadin.pro.licensechecker.PreTrialLicenseValidationException;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -234,6 +236,71 @@ class BaseLicenseCheckerServiceInitListenerTest {
                             eq(PRODUCT_VERSION), any(Capabilities.class),
                             isNull(BuildType.class)), never());
 
+        }
+    }
+
+    @Test
+    void serviceInit_devToolsEnabled_expiredPreTrial_delegateHandlingToDevTools() {
+        config.setProductionMode(false);
+        config.setDevToolsEnabled(true);
+        try (MockedStatic<LicenseChecker> licenseChecker = Mockito
+                .mockStatic(LicenseChecker.class)) {
+            licenseChecker
+                    .when(() -> LicenseChecker.checkLicense(eq(PRODUCT_NAME),
+                            eq(PRODUCT_VERSION), isNull(BuildType.class),
+                            any(Consumer.class), eq(0),
+                            any(Capabilities.class)))
+                    .thenThrow(new PreTrialLicenseValidationException(
+                            new PreTrial(PRODUCT_NAME,
+                                    PreTrial.PreTrialState.EXPIRED, 0, 5)));
+
+            listener.serviceInit(event);
+            licenseChecker
+                    .verify(() -> LicenseChecker.checkLicense(eq(PRODUCT_NAME),
+                            eq(PRODUCT_VERSION), any(Capabilities.class),
+                            isNull(BuildType.class)), never());
+
+            var indexHtmlRequestListeners = event
+                    .getAddedIndexHtmlRequestListeners().toList();
+            assertEquals(1, indexHtmlRequestListeners.size(),
+                    "Expected index html request listener to be installed, but was not");
+            Document document = Jsoup
+                    .parse("<html><head></head><body></body></html>");
+            IndexHtmlResponse indexHtmlResponse = new IndexHtmlResponse(
+                    Mockito.mock(VaadinRequest.class),
+                    Mockito.mock(VaadinResponse.class), document);
+            indexHtmlRequestListeners.get(0)
+                    .modifyIndexHtmlResponse(indexHtmlResponse);
+
+            String headHTML = document.head().html();
+            assertTrue(headHTML.contains(
+                    "window.Vaadin.devTools.createdCvdlElements.push(product);"));
+            assertTrue(headHTML.contains("registerProduct('%s','%s');"
+                    .formatted(PRODUCT_NAME, PRODUCT_VERSION)));
+        }
+    }
+
+    @Test
+    void serviceInit_devToolsEnabled_nonExpiredPreTrial_throws() {
+        config.setProductionMode(false);
+        config.setDevToolsEnabled(true);
+        try (MockedStatic<LicenseChecker> licenseChecker = Mockito
+                .mockStatic(LicenseChecker.class)) {
+            PreTrialLicenseValidationException checkerException = new PreTrialLicenseValidationException(
+                    new PreTrial(PRODUCT_NAME, PreTrial.PreTrialState.RUNNING,
+                            7, 0));
+            licenseChecker
+                    .when(() -> LicenseChecker.checkLicense(eq(PRODUCT_NAME),
+                            eq(PRODUCT_VERSION), isNull(BuildType.class),
+                            any(Consumer.class), eq(0),
+                            any(Capabilities.class)))
+                    .thenThrow(checkerException);
+
+            PreTrialLicenseValidationException exception = assertThrows(
+                    PreTrialLicenseValidationException.class,
+                    () -> listener.serviceInit(event));
+            assertSame(checkerException, exception);
+            assertEquals(0, event.getAddedIndexHtmlRequestListeners().count());
         }
     }
 


### PR DESCRIPTION
## Summary

In dev mode with dev tools enabled, an expired pre-trial threw
PreTrialLicenseValidationException, which aborted server startup so the splash
screen was no longer shown. Catch it for the expired state and delegate to dev
tools like a missing key; other states are rethrown.