### PR TITLE
docs: add @since javadoc for undocumented types and enum constants

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataProvider.java
@@ -41,6 +41,9 @@ import com.vaadin.flow.function.SerializableFunction;
  * @since 1.1
  */
 public interface HierarchicalDataProvider<T, F> extends DataProvider<T, F> {
+    /**
+     * @since 25.0
+     */
     public enum HierarchyFormat {
         /**
          * The nested hierarchy format refers to a data provider implementation
@@ -213,8 +216,6 @@ public interface HierarchicalDataProvider<T, F> extends DataProvider<T, F> {
          * example, the use of recursive CTEs (Common Table Expressions) to
          * retrieve all descendants of an item in a single SQL query.
          * </ul>
-         *
-         * @since 25.0
          */
         FLATTENED,
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/value/ValueChangeMode.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/value/ValueChangeMode.java
@@ -39,12 +39,16 @@ public enum ValueChangeMode {
      * <p>
      * The recommended default timeout for input fields is
      * {@link HasValueChangeMode#DEFAULT_CHANGE_TIMEOUT}.
+     * 
+     * @since 2.0
      */
     LAZY,
 
     /**
      * Syncs the value at defined intervals as long as the value changes from
      * one event to the next.
+     * 
+     * @since 2.0
      */
     TIMEOUT,
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyLocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyLocation.java
@@ -40,6 +40,8 @@ public enum KeyLocation {
 
     /**
      * Right key location.
+     * 
+     * @since 1.3
      */
     RIGHT(2),
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyModifier.java
@@ -42,6 +42,8 @@ public enum KeyModifier implements Key {
 
     /**
      * KeyModifier for "{@code Alt Graph}" key.
+     * 
+     * @since 1.3
      */
     ALT_GRAPH(Key.ALT_GRAPH),
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1894,6 +1894,9 @@ public class UI extends Component
         return forwardToClientUrl;
     }
 
+    /**
+     * @since 24.4
+     */
     @DomEvent(BrowserLeaveNavigationEvent.EVENT_NAME)
     public static class BrowserLeaveNavigationEvent extends ComponentEvent<UI> {
         public static final String EVENT_NAME = "ui-leave-navigation";
@@ -1922,6 +1925,9 @@ public class UI extends Component
         }
     }
 
+    /**
+     * @since 24.4
+     */
     @DomEvent(BrowserNavigateEvent.EVENT_NAME)
     public static class BrowserNavigateEvent extends ComponentEvent<UI> {
         public static final String EVENT_NAME = "ui-navigate";

--- a/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
@@ -43,18 +43,26 @@ public enum Unit {
     EM("em"),
     /**
      * Unit code representing the viewport's width.
+     * 
+     * @since 7.0
      */
     VW("vw"),
     /**
      * Unit code representing the viewport's height.
+     * 
+     * @since 7.0
      */
     VH("vh"),
     /**
      * Unit code representing the viewport's smaller dimension.
+     * 
+     * @since 7.0
      */
     VMIN("vmin"),
     /**
      * Unit code representing the viewport's larger dimension.
+     * 
+     * @since 7.0
      */
     VMAX("vmax"),
     /**
@@ -75,6 +83,8 @@ public enum Unit {
     MM("mm"),
     /**
      * Unit code representing the width of the "0" (zero).
+     * 
+     * @since 7.0
      */
     CH("ch"),
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -532,7 +532,7 @@ public class ExtendedClientDetails implements Serializable {
      *            resolves a browser-detail key to its raw string value, or
      *            {@code null} if not present
      * @return the parsed details
-     * @since 25.3
+     * @since 25.2.1
      */
     public static ExtendedClientDetails updateFromValues(UI ui,
             UnaryOperator<String> getStringElseNull) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
@@ -174,7 +174,7 @@ public abstract class Trigger implements Serializable {
      * @param action
      *            supplies the action to wire once {@code attachTarget} is
      *            attached, not {@code null}
-     * @since 25.3
+     * @since 25.2.1
      */
     public final void triggers(Component attachTarget,
             SerializableSupplier<Action> action) {

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
@@ -368,6 +368,9 @@ public interface Style extends Serializable {
         return set(STYLE_BORDER_RADIUS, value);
     }
 
+    /**
+     * @since 24.1
+     */
     public enum BoxSizing {
         CONTENT_BOX, BORDER_BOX, INITIAL, INHERIT
     }
@@ -490,6 +493,9 @@ public interface Style extends Serializable {
         return applyOrErase(STYLE_FILTER, value);
     }
 
+    /**
+     * @since 24.1
+     */
     public enum Display {
         INLINE,
         BLOCK,
@@ -734,6 +740,9 @@ public interface Style extends Serializable {
         return set(STYLE_OPACITY, value);
     }
 
+    /**
+     * @since 24.1
+     */
     public enum Overflow {
         VISIBLE, HIDDEN, CLIP, SCROLL, AUTO, INITIAL, INHERIT
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/FrontendUtils.java
@@ -255,6 +255,8 @@ public class FrontendUtils {
      * not regenerate dev-server only files such as {@link #INDEX_TSX} or
      * {@link #VITE_DEVMODE_TS}, recognize them as generated instead of deleting
      * them as stale.
+     * 
+     * @since 25.2
      */
     public static final String GENERATED_FILES_LIST_NAME = "generated-flow-files.txt";
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeMap.java
@@ -154,6 +154,9 @@ public abstract class NodeMap extends NodeFeature {
         }
     }
 
+    /**
+     * @since 25.1
+     */
     public record InternalSignalBinding(Signal<?> signal, Serializable value,
             SerializableConsumer<?> writeCallback) implements Serializable {
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
@@ -55,22 +55,30 @@ public enum NavigationTrigger {
     /**
      * Navigation was triggered via
      * {@link UI#navigate(String, QueryParameters)}. It's for internal use only.
+     * 
+     * @since 4.0
      */
     UI_NAVIGATE,
 
     /**
      * Navigation was triggered by client-side.
+     * 
+     * @since 3.0
      */
     CLIENT_SIDE,
 
     /**
      * Navigation is for a reload event on a preserveOnRefresh route.
+     * 
+     * @since 23.2.8
      */
     REFRESH,
 
     /**
      * Navigation was triggered via {@link UI#refreshCurrentRoute(boolean)}.
      * It's for internal use only.
+     * 
+     * @since 24.5.8
      */
     REFRESH_ROUTE,
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
@@ -80,6 +80,7 @@ public record RouterState(Location location, RouteParameters routeParameters,
      *
      * @return {@code true} before the first navigation completes, otherwise
      *         {@code false}
+     * @since 25.2.1
      */
     public boolean isNavigationPending() {
         return navigationTarget == null;

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -143,8 +143,6 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
     /**
      * Creates an instance of the handler with default {@link PageBuilder}.
-     * 
-     * @since 2.0
      */
     public BootstrapHandler() {
         this(new BootstrapPageBuilder());

--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -97,6 +97,8 @@ public class HandlerHelper implements Serializable {
 
         /**
          * INIT requests.
+         * 
+         * @since 3.0
          */
         INIT(ApplicationConstants.REQUEST_TYPE_INIT),
 
@@ -107,6 +109,8 @@ public class HandlerHelper implements Serializable {
 
         /**
          * WebComponent resynchronization requests.
+         * 
+         * @since 23.3.2
          */
         WEBCOMPONENT_RESYNC(
                 ApplicationConstants.REQUEST_TYPE_WEBCOMPONENT_RESYNC),
@@ -122,11 +126,15 @@ public class HandlerHelper implements Serializable {
 
         /**
          * Page showing that the browser is unsupported.
+         * 
+         * @since 23.4
          */
         BROWSER_TOO_OLD("oldbrowser"),
 
         /**
          * Translation properties file requests.
+         * 
+         * @since 24.4
          */
         TRANSLATION_FILE(ApplicationConstants.REQUEST_TYPE_TRANSLATION_FILE);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -74,8 +74,6 @@ public class StreamRequestHandler implements RequestHandler {
     /**
      * Create a new stream request handler with the default
      * StreamReceiverHandler.
-     * 
-     * @since 2.2
      */
     public StreamRequestHandler() {
         this(new StreamReceiverHandler());

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/AvailableViewInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/AvailableViewInfo.java
@@ -111,6 +111,9 @@ public record AvailableViewInfo(String title, String[] rolesAllowed,
                 + routeParameters + ", detail=" + detail + '}';
     }
 
+    /**
+     * @since 24.8
+     */
     public static class DetailDeserializer extends ValueDeserializer<String> {
         @Override
         public String deserialize(JsonParser p, DeserializationContext ctxt) {
@@ -122,6 +125,9 @@ public record AvailableViewInfo(String title, String[] rolesAllowed,
         }
     }
 
+    /**
+     * @since 24.8
+     */
     public static class DetailSerializer extends ValueSerializer<String> {
         @Override
         public void serialize(String value, JsonGenerator gen,

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -42,10 +42,16 @@ public class BrowserDetails implements Serializable {
         UNKNOWN, WINDOWS, MACOSX, LINUX, IOS, ANDROID, CHROMEOS
     }
 
+    /**
+     * @since 25.0
+     */
     public enum BrowserName {
         UNKNOWN, SAFARI, CHROME, FIREFOX, OPERA, IE, EDGE
     }
 
+    /**
+     * @since 25.0
+     */
     public enum BrowserEngine {
         UNKNOWN, GECKO, WEBKIT, PRESTO, TRIDENT
     }


### PR DESCRIPTION
Create a minimal @since javadoc for public/protected types that had none, add @since to enum constants introduced later than their enum, and drop redundant tags whose version merely repeats the enclosing type's (enum constants and no-arg constructors that have been available since the type's origin).
