### PR TITLE
 feat: add configurable max request body size

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -71,9 +71,7 @@ public interface DeploymentConfiguration
     /**
      * Returns the maximum size, in characters, that Flow reads from a
      * client-to-server UIDL/RPC or push request body before rejecting the
-     * request with HTTP 413 (Request Entity Too Large). This guards against
-     * denial-of-service attacks that stream arbitrarily large payloads to
-     * exhaust server memory.
+     * request with HTTP 413 (Request Entity Too Large).
      * <p>
      * The limit does not apply to file uploads, which are streamed in chunks
      * and have their own separate size limits.

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -69,6 +69,21 @@ public interface DeploymentConfiguration
     int getHeartbeatInterval();
 
     /**
+     * Returns the maximum size, in characters, that Flow reads from a
+     * client-to-server UIDL/RPC or push request body before rejecting the
+     * request with HTTP 413 (Request Entity Too Large). This guards against
+     * denial-of-service attacks that stream arbitrarily large payloads to
+     * exhaust server memory.
+     * <p>
+     * The limit does not apply to file uploads, which are streamed in chunks
+     * and have their own separate size limits.
+     *
+     * @return the maximum request body size in characters, or a negative number
+     *         if the limit is disabled
+     */
+    long getMaxRequestBodySize();
+
+    /**
      * In certain cases, such as when combining XmlHttpRequests and push over
      * low bandwidth connections, messages may be received out of order by the
      * client. This property specifies the maximum time (in milliseconds) that

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import com.vaadin.flow.server.AbstractConfiguration;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.DefaultDeploymentConfiguration;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.SessionLockCheckStrategy;
 import com.vaadin.flow.server.WrappedSession;
@@ -79,7 +80,12 @@ public interface DeploymentConfiguration
      * @return the maximum request body size in characters, or a negative number
      *         if the limit is disabled
      */
-    long getMaxRequestBodySize();
+    default long getMaxRequestBodySize() {
+        return getApplicationOrSystemProperty(
+                InitParameters.SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE,
+                DefaultDeploymentConfiguration.DEFAULT_MAX_REQUEST_BODY_SIZE,
+                Long::parseLong);
+    }
 
     /**
      * In certain cases, such as when combining XmlHttpRequests and push over

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -79,6 +79,12 @@ public class DefaultDeploymentConfiguration
     public static final int DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT = 5000;
 
     /**
+     * Default value for {@link #getMaxRequestBodySize()} = {@value} characters
+     * (10&nbsp;MB).
+     */
+    public static final long DEFAULT_MAX_REQUEST_BODY_SIZE = 10L * 1024 * 1024;
+
+    /**
      * Default value for {@link #getWebComponentDisconnect()} = {@value}.
      * 
      * @since 2.0
@@ -100,6 +106,7 @@ public class DefaultDeploymentConfiguration
     private boolean productionMode;
     private boolean xsrfProtectionEnabled;
     private int heartbeatInterval;
+    private long maxRequestBodySize;
     private int maxMessageSuspendTimeout;
     private int webComponentDisconnect;
     private boolean closeIdleSessions;
@@ -139,6 +146,7 @@ public class DefaultDeploymentConfiguration
         checkRequestTiming();
         checkXsrfProtection(log);
         checkHeartbeatInterval();
+        checkMaxRequestBodySize();
         checkMaxMessageSuspendTimeout();
         checkWebComponentDisconnectTimeout();
         checkCloseIdleSessions();
@@ -208,6 +216,16 @@ public class DefaultDeploymentConfiguration
     @Override
     public int getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default is 10&nbsp;MB.
+     */
+    @Override
+    public long getMaxRequestBodySize() {
+        return maxRequestBodySize;
     }
 
     /**
@@ -362,6 +380,20 @@ public class DefaultDeploymentConfiguration
         } catch (NumberFormatException e) {
             warnings.add(WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC);
             heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+        }
+    }
+
+    private void checkMaxRequestBodySize() {
+        try {
+            maxRequestBodySize = getApplicationOrSystemProperty(
+                    InitParameters.SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE,
+                    DEFAULT_MAX_REQUEST_BODY_SIZE, Long::parseLong);
+        } catch (NumberFormatException e) {
+            String warning = "WARNING: maxRequestBodySize has been set to an illegal value."
+                    + " The default of " + DEFAULT_MAX_REQUEST_BODY_SIZE
+                    + " characters will be used.";
+            warnings.add(warning);
+            maxRequestBodySize = DEFAULT_MAX_REQUEST_BODY_SIZE;
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -71,10 +71,8 @@ public class InitParameters implements Serializable {
     /**
      * Configuration parameter name for the maximum size, in characters, that
      * Flow reads from a client-to-server UIDL/RPC or push request body before
-     * rejecting the request with HTTP 413 (Request Entity Too Large). This
-     * guards against denial-of-service attacks that stream arbitrarily large
-     * payloads to exhaust server memory. The default is 10&nbsp;MB; set the
-     * value to {@code -1} to disable the limit.
+     * rejecting the request with HTTP 413 (Request Entity Too Large). The
+     * default is 10&nbsp;MB; set the value to {@code -1} to disable the limit.
      * <p>
      * This limit does not apply to file uploads, which are streamed in chunks
      * and have their own separate size limits (request size, file size and file
@@ -90,9 +88,7 @@ public class InitParameters implements Serializable {
      * request body size limit and a request read timeout at the servlet
      * container or reverse proxy (for example Tomcat {@code connectionTimeout}
      * and {@code maxSwallowSize}, or nginx {@code client_max_body_size} and
-     * {@code client_body_timeout}). The read timeout in particular guards
-     * against slow-POST attacks that drip the body slowly to hold a worker
-     * thread open without exceeding this size limit.
+     * {@code client_body_timeout}).
      */
     public static final String SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE = "maxRequestBodySize";
     public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -67,6 +67,34 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_FRAME_OPTIONS = "frameOptions";
     public static final String SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING = "pushLongPollingSuspendTimeout";
     public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = "maxMessageSuspendTimeout";
+
+    /**
+     * Configuration parameter name for the maximum size, in characters, that
+     * Flow reads from a client-to-server UIDL/RPC or push request body before
+     * rejecting the request with HTTP 413 (Request Entity Too Large). This
+     * guards against denial-of-service attacks that stream arbitrarily large
+     * payloads to exhaust server memory. The default is 10&nbsp;MB; set the
+     * value to {@code -1} to disable the limit.
+     * <p>
+     * This limit does not apply to file uploads, which are streamed in chunks
+     * and have their own separate size limits (request size, file size and file
+     * count).
+     * <p>
+     * The body is read incrementally and the limit is enforced on the running
+     * total, so the request is rejected mid-stream once the limit is exceeded;
+     * even chunked ({@code Transfer-Encoding: chunked}) requests without a
+     * {@code Content-Length} header cannot bypass it. For this to hold, Flow
+     * must be the first component to read the body: if a filter or request
+     * wrapper in front of Flow buffers the whole body first, that memory cost
+     * is incurred before this check runs. As defense-in-depth, also configure a
+     * request body size limit and a request read timeout at the servlet
+     * container or reverse proxy (for example Tomcat {@code connectionTimeout}
+     * and {@code maxSwallowSize}, or nginx {@code client_max_body_size} and
+     * {@code client_body_timeout}). The read timeout in particular guards
+     * against slow-POST attacks that drip the body slowly to hold a worker
+     * thread open without exceeding this size limit.
+     */
+    public static final String SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE = "maxRequestBodySize";
     public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";
     public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
     public static final String NODE_VERSION = "node.version";

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -89,6 +89,14 @@ public class InitParameters implements Serializable {
      * container or reverse proxy (for example Tomcat {@code connectionTimeout}
      * and {@code maxSwallowSize}, or nginx {@code client_max_body_size} and
      * {@code client_body_timeout}).
+     * <p>
+     * Be careful not to set the limit too low: every Flow interaction adds a
+     * small protocol overhead (roughly 100&nbsp;bytes per request on top of the
+     * actual payload), and request bodies also grow with the size of component
+     * state changes and RPC arguments sent from the browser. A limit that is
+     * too low will reject legitimate interactions and make the application
+     * unusable. Choose a value that comfortably accommodates the largest
+     * expected UIDL/RPC payload produced by the application.
      */
     public static final String SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE = "maxRequestBodySize";
     public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -246,6 +246,14 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
+    public long getMaxRequestBodySize() {
+        return getApplicationOrSystemProperty(
+                InitParameters.SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE,
+                DefaultDeploymentConfiguration.DEFAULT_MAX_REQUEST_BODY_SIZE,
+                Long::parseLong);
+    }
+
+    @Override
     public int getMaxMessageSuspendTimeout() {
         return DefaultDeploymentConfiguration.DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/RequestBodyTooLargeException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/RequestBodyTooLargeException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a client-to-server UIDL/RPC or push request body exceeds the
+ * configured maximum size while it is being read.
+ * <p>
+ * Extends {@link IOException} so that it propagates through the existing
+ * request-handling signatures. Request handlers translate this into an HTTP 413
+ * (Request Entity Too Large) response, or, for push messages, into a refresh
+ * and disconnect.
+ *
+ * @see com.vaadin.flow.function.DeploymentConfiguration#getMaxRequestBodySize()
+ * @see SynchronizedRequestHandler#getRequestBody(java.io.Reader, long)
+ */
+public class RequestBodyTooLargeException extends IOException {
+
+    private final long maxBodySize;
+
+    /**
+     * Creates a new exception for a request body that exceeded the given
+     * maximum size.
+     *
+     * @param maxBodySize
+     *            the configured maximum request body size, in characters
+     */
+    public RequestBodyTooLargeException(long maxBodySize) {
+        super("Request body exceeds the maximum allowed size of " + maxBodySize
+                + " characters. The limit can be changed with the '"
+                + InitParameters.SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE
+                + "' configuration property (-1 disables it).");
+        this.maxBodySize = maxBodySize;
+    }
+
+    /**
+     * Gets the configured maximum request body size, in characters, that was
+     * exceeded.
+     *
+     * @return the maximum request body size in characters
+     */
+    public long getMaxBodySize() {
+        return maxBodySize;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/SynchronizedRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SynchronizedRequestHandler.java
@@ -21,6 +21,8 @@ import java.io.Reader;
 import java.io.Serializable;
 import java.util.Optional;
 
+import org.slf4j.LoggerFactory;
+
 /**
  * RequestHandler which takes care of locking and unlocking of the VaadinSession
  * automatically. The session is locked before
@@ -59,8 +61,14 @@ public abstract class SynchronizedRequestHandler implements RequestHandler {
         try {
             if (isReadAndWriteOutsideSessionLock()) {
                 BufferedReader reader = request.getReader();
-                String requestBody = reader == null ? null
-                        : getRequestBody(reader);
+                String requestBody;
+                try {
+                    requestBody = reader == null ? null
+                            : getRequestBody(reader,
+                                    getMaxRequestBodySize(request));
+                } catch (RequestBodyTooLargeException e) {
+                    return rejectOversizedRequest(response, e);
+                }
                 session.lock();
                 Optional<ResponseWriter> responseWriter = synchronizedHandleRequest(
                         session, request, response, requestBody);
@@ -169,18 +177,85 @@ public abstract class SynchronizedRequestHandler implements RequestHandler {
         return true;
     }
 
+    /**
+     * Reads the entire request body from the given reader without any size
+     * limit.
+     * <p>
+     * Prefer {@link #getRequestBody(Reader, long)} on request-handling code
+     * paths so that the configured maximum request body size is enforced.
+     *
+     * @param reader
+     *            the reader to read the request body from
+     * @return the request body as a string
+     * @throws IOException
+     *             if reading fails
+     */
     public static String getRequestBody(Reader reader) throws IOException {
+        return getRequestBody(reader, -1L);
+    }
+
+    /**
+     * Reads the request body from the given reader, rejecting it once it
+     * exceeds {@code maxBodySize} characters.
+     * <p>
+     * The limit is enforced on the number of characters read from the reader.
+     * For typical ASCII/UTF-8 JSON payloads this equals the number of bytes;
+     * multi-byte content makes the effective byte limit larger.
+     *
+     * @param reader
+     *            the reader to read the request body from
+     * @param maxBodySize
+     *            the maximum number of characters to read, or a negative number
+     *            to read without any limit
+     * @return the request body as a string
+     * @throws IOException
+     *             if reading fails
+     * @throws RequestBodyTooLargeException
+     *             if the body exceeds {@code maxBodySize} characters
+     */
+    public static String getRequestBody(Reader reader, long maxBodySize)
+            throws IOException {
         StringBuilder sb = new StringBuilder(MAX_BUFFER_SIZE);
         char[] buffer = new char[MAX_BUFFER_SIZE];
+        long total = 0;
 
         while (true) {
             int read = reader.read(buffer);
             if (read == -1) {
                 break;
             }
+            total += read;
+            if (maxBodySize >= 0 && total > maxBodySize) {
+                throw new RequestBodyTooLargeException(maxBodySize);
+            }
             sb.append(buffer, 0, read);
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Gets the configured maximum request body size for the given request, in
+     * characters.
+     *
+     * @param request
+     *            the request being handled
+     * @return the maximum request body size in characters, or a negative number
+     *         if the limit is disabled
+     */
+    public static long getMaxRequestBodySize(VaadinRequest request) {
+        return request.getService().getDeploymentConfiguration()
+                .getMaxRequestBodySize();
+    }
+
+    private static boolean rejectOversizedRequest(VaadinResponse response,
+            RequestBodyTooLargeException e) throws IOException {
+        LoggerFactory.getLogger(SynchronizedRequestHandler.class)
+                .warn("Rejected a request with a body larger than the "
+                        + "configured maximum of {} characters",
+                        e.getMaxBodySize());
+        response.sendError(HttpStatusCode.REQUEST_ENTITY_TOO_LARGE.getCode(),
+                e.getMessage());
+        return true;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.internal.BrowserLiveReloadAccessor;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.server.HandlerHelper;
+import com.vaadin.flow.server.RequestBodyTooLargeException;
 import com.vaadin.flow.server.SessionExpiredException;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.SystemMessages;
@@ -167,9 +168,17 @@ public class PushHandler {
 
         try {
             new ServerRpcHandler().handleRpc(ui,
-                    SynchronizedRequestHandler.getRequestBody(reader),
+                    SynchronizedRequestHandler.getRequestBody(reader,
+                            SynchronizedRequestHandler
+                                    .getMaxRequestBodySize(vaadinRequest)),
                     vaadinRequest);
             connection.push(false);
+        } catch (RequestBodyTooLargeException e) {
+            getLogger().warn(
+                    "Rejected a push message with a body larger than the "
+                            + "configured maximum of {} characters",
+                    e.getMaxBodySize());
+            sendRefreshAndDisconnect(resource);
         } catch (JacksonException e) {
             getLogger().error("Error writing JSON to response", e);
             // Refresh on client side

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.internal.MessageDigestUtil;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.RequestBodyTooLargeException;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -324,8 +325,7 @@ public class ServerRpcHandler implements Serializable {
     public void handleRpc(UI ui, Reader reader, VaadinRequest request)
             throws IOException, InvalidUIDLSecurityKeyException,
             MessageIdSyncException {
-        handleRpc(ui, SynchronizedRequestHandler.getRequestBody(reader),
-                request);
+        handleRpc(ui, getMessage(reader, request), request);
     }
 
     /**
@@ -695,20 +695,27 @@ public class ServerRpcHandler implements Serializable {
     }
 
     protected String getMessage(Reader reader) throws IOException {
+        return SynchronizedRequestHandler.getRequestBody(reader);
+    }
 
-        StringBuilder sb = new StringBuilder(
-                SynchronizedRequestHandler.MAX_BUFFER_SIZE);
-        char[] buffer = new char[SynchronizedRequestHandler.MAX_BUFFER_SIZE];
-
-        while (true) {
-            int read = reader.read(buffer);
-            if (read == -1) {
-                break;
-            }
-            sb.append(buffer, 0, read);
-        }
-
-        return sb.toString();
+    /**
+     * Reads the RPC message from the given reader, enforcing the maximum
+     * request body size configured for the given request.
+     *
+     * @param reader
+     *            the reader to read the message from
+     * @param request
+     *            the request the message was received through
+     * @return the message as a string
+     * @throws IOException
+     *             if reading fails
+     * @throws RequestBodyTooLargeException
+     *             if the message exceeds the configured maximum size
+     */
+    protected String getMessage(Reader reader, VaadinRequest request)
+            throws IOException {
+        return SynchronizedRequestHandler.getRequestBody(reader,
+                SynchronizedRequestHandler.getMaxRequestBodySize(request));
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.internal.JsonDecodingException;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
 import com.vaadin.flow.server.HttpStatusCode;
+import com.vaadin.flow.server.RequestBodyTooLargeException;
 import com.vaadin.flow.server.SessionExpiredHandler;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.SystemMessages;
@@ -103,8 +104,17 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
     @Override
     public boolean synchronizedHandleRequest(VaadinSession session,
             VaadinRequest request, VaadinResponse response) throws IOException {
-        String requestBody = SynchronizedRequestHandler
-                .getRequestBody(request.getReader());
+        String requestBody;
+        try {
+            requestBody = SynchronizedRequestHandler.getRequestBody(
+                    request.getReader(),
+                    SynchronizedRequestHandler.getMaxRequestBodySize(request));
+        } catch (RequestBodyTooLargeException e) {
+            response.sendError(
+                    HttpStatusCode.REQUEST_ENTITY_TOO_LARGE.getCode(),
+                    e.getMessage());
+            return true;
+        }
         Optional<ResponseWriter> responseWriter = synchronizedHandleRequest(
                 session, request, response, requestBody);
         if (responseWriter.isPresent()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -124,6 +124,11 @@ class AbstractDeploymentConfigurationTest {
         }
 
         @Override
+        public long getMaxRequestBodySize() {
+            return -1;
+        }
+
+        @Override
         public int getMaxMessageSuspendTimeout() {
             return 0;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -185,6 +185,37 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
+    void maxRequestBodySize_defaultValue() {
+        DefaultDeploymentConfiguration config = createDeploymentConfig(
+                new Properties());
+        assertEquals(
+                DefaultDeploymentConfiguration.DEFAULT_MAX_REQUEST_BODY_SIZE,
+                config.getMaxRequestBodySize());
+    }
+
+    @Test
+    void maxRequestBodySize_validValue_accepted() {
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                InitParameters.SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE, "2048");
+        DefaultDeploymentConfiguration config = createDeploymentConfig(
+                initParameters);
+        assertEquals(2048, config.getMaxRequestBodySize());
+    }
+
+    @Test
+    void maxRequestBodySize_invalidValue_defaultValue() {
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                InitParameters.SERVLET_PARAMETER_MAX_REQUEST_BODY_SIZE, "kk");
+        DefaultDeploymentConfiguration config = createDeploymentConfig(
+                initParameters);
+        assertEquals(
+                DefaultDeploymentConfiguration.DEFAULT_MAX_REQUEST_BODY_SIZE,
+                config.getMaxRequestBodySize());
+    }
+
+    @Test
     void isProductionMode_productionModeIsSetViaParentOnly_productionModeIsTakenFromParent() {
         ApplicationConfiguration appConfig = setupAppConfig();
         Mockito.when(appConfig.isProductionMode()).thenReturn(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/SynchronizedRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/SynchronizedRequestHandlerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import java.io.StringReader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SynchronizedRequestHandlerTest {
+
+    @Test
+    void getRequestBody_underLimit_readsBody() throws Exception {
+        String body = "a".repeat(1000);
+        assertEquals(body, SynchronizedRequestHandler
+                .getRequestBody(new StringReader(body), 1000));
+    }
+
+    @Test
+    void getRequestBody_overLimit_throws() {
+        String body = "a".repeat(1001);
+        assertThrows(RequestBodyTooLargeException.class,
+                () -> SynchronizedRequestHandler
+                        .getRequestBody(new StringReader(body), 1000));
+    }
+
+    @Test
+    void getRequestBody_negativeLimit_readsWithoutLimit() throws Exception {
+        String body = "a".repeat(200_000);
+        assertEquals(body, SynchronizedRequestHandler
+                .getRequestBody(new StringReader(body), -1));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
@@ -82,6 +82,8 @@ class ServerRpcHandlerTest {
         deploymentConfiguration = Mockito.mock(DeploymentConfiguration.class);
         Mockito.when(service.getDeploymentConfiguration())
                 .thenReturn(deploymentConfiguration);
+        Mockito.when(deploymentConfiguration.getMaxRequestBodySize())
+                .thenReturn(-1L);
 
         uiTree = new StateTree(uiInternals);
         Mockito.when(uiInternals.getStateTree()).thenReturn(uiTree);

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -33,6 +33,7 @@ public class MockDeploymentConfiguration
     private boolean reuseDevServer = true;
     private boolean xsrfProtectionEnabled = true;
     private int heartbeatInterval = 300;
+    private long maxRequestBodySize = 10L * 1024 * 1024;
     private int maxMessageSuspendTimeout = 5000;
     private int webComponentDisconnect = 300;
     private boolean closeIdleSessions = false;
@@ -99,6 +100,15 @@ public class MockDeploymentConfiguration
     @Override
     public int getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    @Override
+    public long getMaxRequestBodySize() {
+        return maxRequestBodySize;
+    }
+
+    public void setMaxRequestBodySize(long maxRequestBodySize) {
+        this.maxRequestBodySize = maxRequestBodySize;
     }
 
     @Override


### PR DESCRIPTION
Add maxRequestBodySize property to limit UIDL/RPC and push request body size (-1 disables); the default is 10 MB; does not affect uploads.