### PR TITLE
chore: set TB license before build on re-run (24.10)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -200,17 +200,17 @@ jobs:
         run: |
           tar xf workspace.tar
           tar cf - .m2 | (cd ~ && tar xf -)
+      - name: Set TB License
+        run: |
+          TB_LICENSE=${{secrets.TB_LICENSE}}
+          mkdir -p ~/.vaadin/
+          echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
       - name: Compile and Install Flow
         if: ${{ github.run_attempt > 1 }}
         run: |
           ./scripts/computeMatrix.js set-version --version=999.99-SNAPSHOT
           cmd="mvn install -B -ntp -DskipTests  -pl \!flow-plugins/flow-gradle-plugin"
           eval $cmd -T 2C -q || eval $cmd
-      - name: Set TB License
-        run: |
-          TB_LICENSE=${{secrets.TB_LICENSE}}
-          mkdir -p ~/.vaadin/
-          echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
       - name: Compile Shared modules
         run: |
           if [ ${{matrix.current}} -eq 2 -o ${{matrix.current}} -eq 3 ]; then


### PR DESCRIPTION
Some modules fail to re-run because the build-frontend requires a TB license to be set.