### PR TITLE
chore: cache `EndpointRequestUtil#isHillaAvailable` result

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
@@ -57,16 +57,35 @@ public interface EndpointRequestUtil extends Serializable {
 
     /**
      * Checks if Hilla is available.
+     * <p>
+     * The result is computed once on first access and cached, since the
+     * availability of the Hilla endpoint class cannot change during the
+     * lifetime of the classloader that loaded this interface.
      *
      * @return true if Hilla is available, false otherwise
      * @since 24.0
      */
     static boolean isHillaAvailable() {
-        try {
-            Class.forName(HILLA_ENDPOINT_CLASS);
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
+        return HillaAvailability.AVAILABLE;
+    }
+
+    /**
+     * Holder for the lazily-computed, cached Hilla availability flag.
+     * <p>
+     * Using a nested class defers the {@link Class#forName(String)} lookup
+     * until {@link #isHillaAvailable()} is first called and relies on the JVM
+     * class-initialization guarantees for thread safety.
+     */
+    class HillaAvailability {
+        private static final boolean AVAILABLE = computeAvailable();
+
+        private static boolean computeAvailable() {
+            try {
+                Class.forName(HILLA_ENDPOINT_CLASS);
+                return true;
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
@@ -79,6 +79,9 @@ public interface EndpointRequestUtil extends Serializable {
     class HillaAvailability {
         private static final boolean AVAILABLE = computeAvailable();
 
+        private HillaAvailability() {
+        }
+
         private static boolean computeAvailable() {
             try {
                 Class.forName(HILLA_ENDPOINT_CLASS);


### PR DESCRIPTION
`isHillaAvailable()` called `Class.forName` on every invocation, repeatedly searching the classloader and throwing/catching `ClassNotFoundException` when Hilla is absent, even though the result cannot change during the classloader's lifetime.

Cache the availability flag in a lazily-initialized holder class so the class lookup happens only once.

Fixes #24878