### PR TITLE
feat: reuse shared metadata cache when scanning

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -57,6 +57,8 @@ import org.springframework.context.annotation.ClassPathScanningCandidateComponen
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.core.type.filter.AssignableTypeFilter;
 
@@ -111,6 +113,7 @@ public class VaadinServletContextInitializer
     private static boolean devModeCachingEnabled;
     private ApplicationContext appContext;
     private ResourceLoader customLoader;
+    private MetadataReaderFactory metadataReaderFactory;
 
     /**
      * Packages that should be excluded when scanning all packages.
@@ -166,10 +169,16 @@ public class VaadinServletContextInitializer
             extends ClassPathScanningCandidateComponentProvider {
         private ClassPathScanner(Environment environment,
                 ResourceLoader resourceLoader,
+                MetadataReaderFactory metadataReaderFactory,
                 Collection<Class<? extends Annotation>> annotations,
                 Collection<Class<?>> types) {
             super(false, environment);
             setResourceLoader(resourceLoader);
+            // Keep the filtering resource loader as the pattern resolver, but
+            // override the metadata reader factory (which setResourceLoader
+            // just replaced) so class metadata is read through a cache shared
+            // across all scan passes. Must be called after setResourceLoader.
+            setMetadataReaderFactory(metadataReaderFactory);
 
             annotations.stream().map(AnnotationTypeFilter::new)
                     .forEach(this::addIncludeFilter);
@@ -883,9 +892,30 @@ public class VaadinServletContextInitializer
             Collection<Class<? extends Annotation>> annotations,
             Collection<Class<?>> types) {
         ClassPathScanner scanner = new ClassPathScanner(
-                appContext.getEnvironment(), loader, annotations, types);
+                appContext.getEnvironment(), loader, getMetadataReaderFactory(),
+                annotations, types);
         return packages.stream().map(scanner::findCandidateComponents)
                 .flatMap(Collection::stream).map(this::getBeanClass);
+    }
+
+    /**
+     * Returns a shared {@link MetadataReaderFactory} reused by every scan pass.
+     * <p>
+     * It is backed by the application context, which is a
+     * {@link org.springframework.core.io.DefaultResourceLoader}, so that
+     * {@link CachingMetadataReaderFactory} stores parsed class metadata in the
+     * context's shared, unbounded resource cache instead of a per-scan cache
+     * bounded to {@value CachingMetadataReaderFactory#DEFAULT_CACHE_LIMIT}
+     * entries. This avoids re-parsing the same classes for each of the many
+     * scan passes (routes, error handlers, web components, ...) done at
+     * startup.
+     */
+    private MetadataReaderFactory getMetadataReaderFactory() {
+        if (metadataReaderFactory == null) {
+            metadataReaderFactory = new CachingMetadataReaderFactory(
+                    appContext);
+        }
+        return metadataReaderFactory;
     }
 
     private Class<?> getBeanClass(BeanDefinition beanDefinition) {

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
@@ -42,9 +42,11 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
+import org.springframework.core.type.classreading.MetadataReader;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.di.Lookup;
@@ -61,6 +63,7 @@ import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.server.startup.ServletDeployer;
+import com.vaadin.flow.spring.io.FilterableResourceResolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -246,6 +249,30 @@ class VaadinServletContextInitializerTest {
                     resource -> assertThat(getResourcePath(resource)).endsWith(
                             "/com/example/application/Application.class"));
         }
+    }
+
+    @Test
+    void classPathScan_reusesApplicationContextSharedMetadataCache() {
+        GenericApplicationContext context = new GenericApplicationContext();
+
+        VaadinServletContextInitializer initializer = new VaadinServletContextInitializer(
+                context);
+
+        // The shared cache is empty until a scan populates it.
+        Map<Resource, MetadataReader> sharedCache = context
+                .getResourceCache(MetadataReader.class);
+        assertThat(sharedCache).isEmpty();
+
+        // Reading class metadata during a scan must go through the
+        // application context's shared, unbounded resource cache instead of a
+        // per-scan bounded cache, so the parsed metadata is reused across the
+        // many scan passes performed at startup.
+        initializer.findBySuperType(
+                Collections.singletonList(FilterableResourceResolver.class
+                        .getPackage().getName()),
+                FilterableResourceResolver.class).count();
+
+        assertThat(context.getResourceCache(MetadataReader.class)).isNotEmpty();
     }
 
     private static String getResourcePath(Resource resource) {


### PR DESCRIPTION
Class and annotation scanning at startup runs many passes (routes, error handlers, web components, lookup, ...), each building a new `ClassPathScanner`. Because `CustomResourceLoader` does not extend `DefaultResourceLoader`, Spring's `CachingMetadataReaderFactory` falls back to a per-scan cache bounded to 256 entries instead of the application context's shared, unbounded resource cache. Parsed class metadata is therefore discarded and re-computed on every pass, slowing down startup on large classpaths.

Keep the filtering `CustomResourceLoader` as the scanner's pattern resolver so package and JAR filtering is preserved, and override the scanner's `MetadataReaderFactory` with a single shared `CachingMetadataReaderFactory` backed by the application context. As the context is a `DefaultResourceLoader`, the factory now stores metadata in the context's shared cache and reuses it across all scan passes.

Fixes #24881