### PR TITLE
fix: Clean up countInstances

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
@@ -231,7 +231,13 @@ public class DefaultApplicationConfigurationFactory
     }
 
     private int countInstances(String input, String value) {
-        return input.split(value, -1).length - 1;
+        int count = 0;
+        int index = input.indexOf(value);
+        while (index != -1) {
+            count++;
+            index = input.indexOf(value, index + value.length());
+        }
+        return count;
     }
 
     private Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
@@ -230,6 +230,22 @@ public class DefaultApplicationConfigurationFactory
         return FrontendUtils.streamToString(firstResource.openStream());
     }
 
+    /**
+     * Counts how many times {@code value} occurs as a non-overlapping substring
+     * within {@code input}.
+     * <p>
+     * Used to determine how many nested {@code jar!/} segments appear in a
+     * resource path, which indicates whether the resource is packaged inside
+     * one or several jars.
+     *
+     * @param input
+     *            the string to search within, not {@code null}
+     * @param value
+     *            the substring to count occurrences of, not {@code null} and
+     *            not empty
+     * @return the number of non-overlapping occurrences of {@code value} in
+     *         {@code input}, or {@code 0} if none are found
+     */
     private int countInstances(String input, String value) {
         int count = 0;
         int index = input.indexOf(value);


### PR DESCRIPTION
Make count instances more effective
by not using split that compiles
a pattern and generates an array
for each invocation.

fixes #9264
