### PR TITLE
fix: support gradle 9 in plugin

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -10,8 +10,8 @@ plugins {
 	id 'maven-publish'
     id 'idea'
     id 'com.gradle.plugin-publish' version '1.3.1'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.20'
-    id 'org.jetbrains.dokka' version '1.8.20'
+    id 'org.jetbrains.kotlin.jvm' version '2.4.0'
+    id 'org.jetbrains.dokka' version '1.9.20'
 }
 
 /***********************************************************************************************************************
@@ -22,11 +22,21 @@ plugins {
 
 def pom = new XmlSlurper().parse(rootProject.file('pom.xml'))
 defaultTasks('jar', 'test')
-group pom.parent.groupId
+group = pom.parent.groupId.text()
 version = project.hasProperty('vaadin.version') ? project.getProperty('vaadin.version') : pom.parent.version
-archivesBaseName = pom.artifactId
-sourceCompatibility = 21
-targetCompatibility = 21
+
+// The `archivesBaseName` project property and project-level source/target
+// compatibility were provided by the Base/Java plugin conventions, which are
+// removed in Gradle 9. Configure them through the `base` and `java` extensions
+// instead so the build works on both Gradle 8.x and 9.x.
+base {
+    archivesName = pom.artifactId.text()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 /***********************************************************************************************************************
  *
@@ -68,12 +78,12 @@ repositories {
 }
 
 dependencies {
-    implementation('org.jetbrains.kotlin:kotlin-stdlib:1.9.20')
+    implementation('org.jetbrains.kotlin:kotlin-stdlib:2.4.0')
 
     implementation("com.vaadin:flow-plugin-base:${pom.parent.version}")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.20")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:2.4.0")
 }
 
 idea {

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/GradleDeprecationTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/GradleDeprecationTest.kt
@@ -1,0 +1,77 @@
+/**
+ *    Copyright 2000-2026 Vaadin Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.flow.gradle
+
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFalse
+
+/**
+ * Guards Gradle 10 readiness: the plugin must not use APIs that Gradle has
+ * deprecated for removal in Gradle 10 (such as `Project.getProperties()`).
+ * The build is run on the latest released Gradle with `--warning-mode all` so
+ * deprecation stack traces are printed in full; any trace pointing back into
+ * the plugin's own package means the plugin still relies on an API that will
+ * break in Gradle 10.
+ */
+class GradleDeprecationTest : AbstractGradleTest() {
+
+    // Latest released Gradle at the time of writing; deprecations that Gradle
+    // schedules for removal in 10 are already reported by 9.x.
+    private val latestGradleVersion = "9.6.1"
+
+    @Before
+    fun setup() {
+        testProject = TestProject(latestGradleVersion)
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'war'
+                id 'com.vaadin.flow'
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+            }
+        """
+        )
+    }
+
+    @Test
+    fun pluginDoesNotUseApisRemovedInGradle10() {
+        val result = testProject.build("vaadinClean", "--warning-mode=all")
+        result.expectTaskSucceded("vaadinClean")
+
+        // Deprecation warnings print their originating stack trace; a frame in
+        // the plugin's package only appears when the plugin itself triggered
+        // the deprecation. Reject any such frame.
+        assertFalse(
+            result.output.lineSequence().any {
+                it.trimStart().startsWith("at com.vaadin.flow.gradle")
+            },
+            "The Vaadin Gradle plugin triggered a Gradle deprecation warning " +
+                    "(see the build output above). This API is scheduled for " +
+                    "removal and will break the plugin on Gradle 10; replace it " +
+                    "with a supported alternative."
+        )
+    }
+}

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/GradleVersionSupportTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/GradleVersionSupportTest.kt
@@ -40,9 +40,9 @@ class GradleVersionSupportTest(private val versionUnderTest: GradleVersion) : Ab
                         FlowPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION,
                         // Newer Gradle major versions must keep working with the
                         // same published plugin (cross-version support): the
-                        // first Gradle 9 release and a recent 9.x.
+                        // first Gradle 9 release and the latest released 9.x.
                         "9.0.0",
-                        "9.5.0"
+                        "9.6.1"
                     ).map { GradleVersion(it, true) }
     }
 

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/GradleVersionSupportTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/GradleVersionSupportTest.kt
@@ -37,7 +37,12 @@ class GradleVersionSupportTest(private val versionUnderTest: GradleVersion) : Ab
         fun gradleVersionsUnderTest(): List<GradleVersion> =
             arrayOf("8.3", "8.6", "8.9", "8.13").map { GradleVersion(it, false) } +
                     arrayOf(
-                        FlowPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION
+                        FlowPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION,
+                        // Newer Gradle major versions must keep working with the
+                        // same published plugin (cross-version support): the
+                        // first Gradle 9 release and a recent 9.x.
+                        "9.0.0",
+                        "9.5.0"
                     ).map { GradleVersion(it, true) }
     }
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -32,7 +32,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.bundling.War
-import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 
 private val servletApiJarRegex =
     Regex(".*(/|\\\\)(portlet-api|javax\\.servlet-api)-.+jar$")
@@ -66,7 +65,7 @@ internal class GradlePluginAdapter private constructor(
             project.configurations.getByName(config.dependencyScope.get())
         resolvedArtifacts =
             dependencyConfiguration.incoming.artifacts.resolvedArtifacts.map { result ->
-                result.filter { it.id is ModuleComponentArtifactIdentifier }
+                result.filter { it.id.componentIdentifier is ModuleComponentIdentifier }
                     .map { (it.id.componentIdentifier as ModuleComponentIdentifier).moduleIdentifier }
                     .toSet()
             } ?: project.provider { emptySet() }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -34,7 +34,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 import java.net.URI
 
 public abstract class VaadinFlowPluginExtension @Inject constructor(private val project: Project) {
@@ -422,7 +421,7 @@ public class PluginEffectiveConfiguration(
             .incoming.artifacts.resolvedArtifacts
             .map { result ->
                 result.filter {
-                    it.id is ModuleComponentArtifactIdentifier && it.id.componentIdentifier is ModuleComponentIdentifier
+                    it.id.componentIdentifier is ModuleComponentIdentifier
                 }.map {
                     (it.id.componentIdentifier as ModuleComponentIdentifier).moduleIdentifier
                 }.any {

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
-import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
@@ -81,15 +80,10 @@ internal fun Project.getBuildResourcesDir(sourceSetName: String): File = getSour
 internal val Provider<File>.absolutePath: Provider<String> get() = map { it.absolutePath }
 
 /**
- * Same thing as [Provider.map]. Works around the bug in Gradle+Kotlin which
- * renders [Provider.map] unable to return null in Kotlin: https://github.com/gradle/gradle/issues/12388
+ * Passes the value through only when [block] returns `true`, otherwise the
+ * returned provider has no value. Backed by the public [Provider.filter] API.
  */
-internal fun <IN: Any, OUT> Provider<IN>.mapOrNull(block: (IN) -> OUT?): Provider<OUT> = flatMap { Providers.ofNullable(block(it)) }
-
-/**
- * Workaround for https://github.com/gradle/gradle/issues/19981
- */
-internal fun <T: Any> Provider<T>.filterBy(block: (T) -> Boolean): Provider<T> = mapOrNull { if (block(it)) it else null }
+internal fun <T: Any> Provider<T>.filterBy(block: (T) -> Boolean): Provider<T> = filter { block(it) }
 
 /**
  * Passes the value if the file exists.

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -73,7 +73,10 @@ internal fun Collection<File>.toPrettyFormat(): String = joinToString(prefix = "
 internal val Configuration.jars: FileCollection
     get() = filter { it.name.endsWith(".jar", true) }
 
-internal val Project.sourceSets: SourceSetContainer get() = project.properties["sourceSets"] as SourceSetContainer
+// `Project.getProperties()["sourceSets"]` is deprecated and scheduled to fail
+// in Gradle 10. The Java plugin registers the source sets as a typed extension,
+// so fetch it through the extensions API instead.
+internal val Project.sourceSets: SourceSetContainer get() = project.extensions.getByType(SourceSetContainer::class.java)
 internal fun Project.getSourceSet(sourceSetName: String): SourceSet = sourceSets.getByName(sourceSetName)
 internal fun Project.getBuildResourcesDir(sourceSetName: String): File = getSourceSet(sourceSetName).output.resourcesDir!!
 


### PR DESCRIPTION
Fix runtime compatibility.
Fix build script incompatibilities.
Bump kotlin and dokka versions.
Add tests for 9.0.0 and 9.5.0

Fixes #17447
