### PR TITLE
fix: Prevent refreshViewport from reloading data from data provider

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -103,7 +103,10 @@ public class DataCommunicator<T> implements Serializable {
     private int assumedSize;
     private int lastSent = -1;
 
-    private boolean resendEntireRange = true;
+    // Reloads the viewport range from the data provider and resends it
+    private boolean reloadViewportRange = true;
+    // Resends the viewport range without reloading it from the data provider
+    private boolean resendViewportRange = false;
     private boolean assumeEmptyClient = true;
 
     private int nextUpdateId = 0;
@@ -421,7 +424,7 @@ public class DataCommunicator<T> implements Serializable {
     public void reset() {
         skipCountIncreaseUntilReset = false;
         sizeReset = true;
-        resendEntireRange = true;
+        reloadViewportRange = true;
         dataGenerator.destroyAllData();
         updatedData.clear();
         requestFlush();
@@ -443,12 +446,13 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     /**
-     * Regenerates and resends data for all items in the current viewport.
-     * 
+     * Regenerates and resends data for all items in the current viewport. The
+     * items themselves are not reloaded from the data provider.
+     *
      * @since 25.0.1
      */
     protected void refreshViewport() {
-        resendEntireRange = true;
+        resendViewportRange = true;
         requestFlush();
     }
 
@@ -582,7 +586,7 @@ public class DataCommunicator<T> implements Serializable {
      */
     public int getItemCount() {
         if (isDefinedSize()
-                && (resendEntireRange || assumeEmptyClient || sizeReset)) {
+                && (reloadViewportRange || assumeEmptyClient || sizeReset)) {
             // TODO it could be possible to cache the value returned here
             // and use it next time instead of making another query, unless
             // the conditions like filter (or another reset) have changed
@@ -1008,7 +1012,7 @@ public class DataCommunicator<T> implements Serializable {
     private void updateUndefinedSize() {
         assert !definedSize
                 : "This method should never be called when using defined size";
-        if (resendEntireRange || sizeReset) {
+        if (reloadViewportRange || sizeReset) {
             // things have reset
             assumedSize = getItemCountEstimate();
         }
@@ -1253,7 +1257,7 @@ public class DataCommunicator<T> implements Serializable {
         // Phase 1: Find all items that the client should have
 
         // With defined size the backend is only queried when necessary
-        if (definedSize && (resendEntireRange || sizeReset)) {
+        if (definedSize && (reloadViewportRange || sizeReset)) {
             assumedSize = getDataProviderSize();
         } else if (!definedSize
                 && (!skipCountIncreaseUntilReset || sizeReset)) {
@@ -1263,7 +1267,7 @@ public class DataCommunicator<T> implements Serializable {
         effectiveRequested = viewportRange
                 .restrictTo(Range.withLength(0, assumedSize));
 
-        resendEntireRange |= !(previousActive.intersects(effectiveRequested)
+        reloadViewportRange |= !(previousActive.intersects(effectiveRequested)
                 || (previousActive.isEmpty() && effectiveRequested.isEmpty()));
 
         UI ui = getUI();
@@ -1349,7 +1353,8 @@ public class DataCommunicator<T> implements Serializable {
         boolean updated = collectChangesToSend(previousActive,
                 effectiveRequested, update);
 
-        resendEntireRange = false;
+        reloadViewportRange = false;
+        resendViewportRange = false;
         assumeEmptyClient = false;
         sizeReset = false;
 
@@ -1452,7 +1457,7 @@ public class DataCommunicator<T> implements Serializable {
     private boolean collectChangesToSend(final Range previousActive,
             final Range effectiveRequested, Update update) {
         boolean updated = false;
-        if (assumeEmptyClient || resendEntireRange) {
+        if (assumeEmptyClient || reloadViewportRange || resendViewportRange) {
             if (!assumeEmptyClient) {
                 /*
                  * TODO: Not necessary to clear something that would be set back
@@ -1507,7 +1512,7 @@ public class DataCommunicator<T> implements Serializable {
          * actually be useful can be optimized away once we have some actual
          * test coverage for the logic here.
          */
-        if (resendEntireRange) {
+        if (reloadViewportRange) {
             return activate(effectiveRequested);
         } else {
             List<String> newActiveKeyOrder = new ArrayList<>();

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -278,6 +278,42 @@ public class DataCommunicatorTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
+    void refreshViewport_dataProviderNotQueried(
+            boolean dataProviderWithParallelStream) {
+        this.dataProviderWithParallelStream = dataProviderWithParallelStream;
+        var dataProviderQueryCount = new AtomicInteger(0);
+        dataCommunicator.setDataProvider(new AbstractDataProvider<>() {
+            @Override
+            public boolean isInMemory() {
+                return true;
+            }
+
+            @Override
+            public int size(Query<Item, Object> query) {
+                dataProviderQueryCount.incrementAndGet();
+                return 100;
+            }
+
+            @Override
+            public Stream<Item> fetch(Query<Item, Object> query) {
+                dataProviderQueryCount.incrementAndGet();
+                return asParallelIfRequired(IntStream.range(query.getOffset(),
+                        query.getLimit() + query.getOffset()))
+                        .mapToObj(Item::new);
+            }
+        }, null);
+        dataCommunicator.setViewportRange(0, 6);
+        fakeClientCommunication();
+        dataProviderQueryCount.set(0);
+
+        dataCommunicator.refreshViewport();
+        fakeClientCommunication();
+        assertEquals(0, dataProviderQueryCount.get(),
+                "Expected no data provider queries on viewport refresh");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     void setFlushRequest_remove_setFlushRequest_reattach_noEndlessFlushLoop(
             boolean dataProviderWithParallelStream) {
         this.dataProviderWithParallelStream = dataProviderWithParallelStream;


### PR DESCRIPTION
## Description

`DataCommunicator#refreshViewport` used to set the same flag as `reset()`, which made the flush re-query the item count and re-fetch the viewport range from the data provider. Now it only regenerates and resends data for the items that are already active, matching the behavior of `HierarchicalDataCommunicator#refreshViewport`.

Changes:
- The former `resendEntireRange` flag is renamed to `reloadViewportRange` (it reloads the viewport range from the data provider and resends it).
- A new `resendViewportRange` flag drives the resend-only path used by `refreshViewport`: the active range is regenerated through the data generators and resent via `update.set` without any data provider queries, using the same wire format as before.
- If the viewport range changes in the same roundtrip, newly visible items are still fetched from the data provider as they were never loaded.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing.
- [x] I have performed self-review and corrected misspellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
