### PR TITLE
fix: pin types/node to a functional version

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -9,6 +9,7 @@
     "lit": "2.8.0"
   },
   "devDependencies": {
+    "@types/node": "18.19.115",
     "async": "3.2.6",
     "glob": "7.2.3",
     "typescript": "4.9.5",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -179,6 +179,7 @@ public class NodeUpdaterTest {
 
     private Set<String> getCommonDevDeps() {
         Set<String> expectedDependencies = new HashSet<>();
+        expectedDependencies.add("@types/node");
         expectedDependencies.add("typescript");
         expectedDependencies.add("workbox-core");
         expectedDependencies.add("workbox-precaching");


### PR DESCRIPTION
Pin the `@types/node` version
so we have a typescript vesion match.
