### PR TITLE
fix: make URL_SAFE_SCHEMES init parameter name consistent

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -62,8 +62,13 @@ public abstract class AbstractDeploymentConfiguration extends
     public Set<String> getUrlSafeSchemes() {
         Set<String> cached = urlSafeSchemes;
         if (cached == null) {
-            cached = parseUrlSafeSchemes(
-                    getStringProperty(InitParameters.URL_SAFE_SCHEMES, null));
+            String configured = getStringProperty(
+                    InitParameters.URL_SAFE_SCHEMES, null);
+            if (configured == null) {
+                configured = getStringProperty(
+                        InitParameters.URL_SAFE_SCHEMES_LEGACY, null);
+            }
+            cached = parseUrlSafeSchemes(configured);
             urlSafeSchemes = cached;
         }
         return cached;

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -430,6 +430,17 @@ public class InitParameters implements Serializable {
      * 
      * @since 25.2
      */
-    public static final String URL_SAFE_SCHEMES = "com.vaadin.safeUrlSchemes";
+    public static final String URL_SAFE_SCHEMES = "safeUrlSchemes";
+
+    /**
+     * Legacy name of the {@link #URL_SAFE_SCHEMES} configuration property, kept
+     * for backwards compatibility with applications configured against Vaadin
+     * 25.2.1. Use {@link #URL_SAFE_SCHEMES} instead; when both are present, the
+     * new name takes precedence.
+     *
+     * @deprecated use {@link #URL_SAFE_SCHEMES} instead
+     */
+    @Deprecated
+    public static final String URL_SAFE_SCHEMES_LEGACY = "com.vaadin.safeUrlSchemes";
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -70,6 +70,22 @@ class AbstractDeploymentConfigurationTest {
     }
 
     @Test
+    void getUrlSafeSchemes_legacyPropertyName_stillSupported() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES_LEGACY, " HTTPS , MyApp ");
+        assertEquals(Set.of("https", "myapp"), config.getUrlSafeSchemes());
+    }
+
+    @Test
+    void getUrlSafeSchemes_newPropertyNameTakesPrecedenceOverLegacy() {
+        Properties props = new Properties();
+        props.put(InitParameters.URL_SAFE_SCHEMES, "current");
+        props.put(InitParameters.URL_SAFE_SCHEMES_LEGACY, "legacy");
+        DeploymentConfiguration config = new DeploymentConfigImpl(props);
+        assertEquals(Set.of("current"), config.getUrlSafeSchemes());
+    }
+
+    @Test
     void getUrlSafeSchemes_memoizedAcrossCalls() {
         DeploymentConfiguration config = getConfig(
                 InitParameters.URL_SAFE_SCHEMES, "custom");


### PR DESCRIPTION
`InitParameters.URL_SAFE_SCHEMES` used the value `com.vaadin.safeUrlSchemes`, which is inconsistent with every other parameter in the class — none of them carry a `com.vaadin.` prefix. Since the parameter already shipped in 25.2.1, the old name must keep working to avoid breaking existing configurations.

Change the canonical value to `safeUrlSchemes` and add a deprecated `URL_SAFE_SCHEMES_LEGACY` constant holding the previous value. `AbstractDeploymentConfiguration#getUrlSafeSchemes` now reads the new name first and falls back to the legacy name, with the new name taking precedence when both are present.
