### PR TITLE
refactor: warn about TreeDataProvider default change in V26

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -40,9 +40,12 @@ public class TreeDataProvider<T>
      * @deprecated this constructor currently defaults to
      *             {@link HierarchyFormat#NESTED}, but starting from Vaadin 26
      *             it will default to {@link HierarchyFormat#FLATTENED} instead.
-     *             To keep using {@link HierarchyFormat#NESTED}, use
+     *             This may affect TreeGrid methods whose behavior depends on
+     *             the hierarchy format, such as {@code scrollToIndex}. To avoid
+     *             unexpected changes, switch to
      *             {@link #TreeDataProvider(TreeData, HierarchyFormat)} and pass
-     *             it explicitly.
+     *             {@link HierarchyFormat#NESTED} explicitly to keep the current
+     *             default behavior.
      */
     @Deprecated(since = "25.3")
     public TreeDataProvider(TreeData<T> treeData) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -37,7 +37,14 @@ public class TreeDataProvider<T>
      * @param treeData
      *            the backing {@link TreeData} for this provider, not
      *            {@code null}
+     * @deprecated this constructor currently defaults to
+     *             {@link HierarchyFormat#NESTED}, but starting from Vaadin 26
+     *             it will default to {@link HierarchyFormat#FLATTENED} instead.
+     *             To keep using {@link HierarchyFormat#NESTED}, use
+     *             {@link #TreeDataProvider(TreeData, HierarchyFormat)} and pass
+     *             it explicitly.
      */
+    @Deprecated(since = "25.3")
     public TreeDataProvider(TreeData<T> treeData) {
         super(treeData);
     }


### PR DESCRIPTION
- Deprecates `TreeDataProvider(TreeData<T>)` since it currently defaults to `HierarchyFormat.NESTED`, but starting from Vaadin 26 it will default to `HierarchyFormat.FLATTENED` instead.
- Points callers who want to keep the current `NESTED` format to explicitly pass it via `TreeDataProvider(TreeData, HierarchyFormat)`.