### PR TITLE
fix: respect custom npm registry in seeded package-lock.json

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,29 +132,40 @@ public class BundleBuildUtils {
     }
 
     /**
-     * Writes the seeded lock file, stripping the hardcoded {@code resolved}
-     * download URLs for the npm {@code package-lock.json} when npm is
-     * configured with a custom registry, so that {@code npm install}
-     * re-resolves them against that registry instead of reusing the
-     * {@code npmjs.org} URLs baked into the dev-bundle template. The
-     * {@code integrity} content hashes are kept so npm still verifies the
-     * downloaded tarballs against the versions Vaadin tested. In all other
-     * cases the content is written verbatim.
+     * Writes the seeded lock file, stripping from the npm
+     * {@code package-lock.json} every {@code resolved} download URL that does
+     * not point at one of the configured custom registries, so that
+     * {@code npm install} re-resolves those against the current configuration
+     * instead of reusing the URLs baked into the seed. This drops both the
+     * {@code npmjs.org} URLs hardcoded in the dev-bundle template and any stale
+     * URLs from registries no longer configured. Entries already resolved
+     * against a configured custom registry (e.g. a lock seeded from a bundle
+     * previously built locally with that registry) are left untouched, keeping
+     * npm's fast path. The {@code integrity} content hashes are kept so npm
+     * still verifies the downloaded tarballs against the versions Vaadin
+     * tested. When no custom registry is configured the content is written
+     * verbatim.
      */
     private static void writePackageLock(String contents, File packageLock,
             Options options, FrontendTools frontendTools) throws IOException {
         String toWrite = contents;
-        if (!options.isEnablePnpm()
-                && frontendTools.hasCustomNpmRegistry(options.getNpmFolder())) {
-            toWrite = stripResolvedUrls(contents, packageLock);
+        if (!options.isEnablePnpm()) {
+            Set<String> customRegistries = frontendTools
+                    .getCustomNpmRegistries(options.getNpmFolder());
+            if (!customRegistries.isEmpty()) {
+                toWrite = stripForeignResolvedUrls(contents, packageLock,
+                        customRegistries);
+            }
         }
         Files.writeString(packageLock.toPath(), toWrite);
     }
 
-    private static String stripResolvedUrls(String contents, File packageLock) {
+    private static String stripForeignResolvedUrls(String contents,
+            File packageLock, Set<String> customRegistries) {
         try {
             ObjectNode root = JacksonUtils.readTree(contents);
-            removeResolvedEntries(root.get("packages"));
+            removeForeignResolvedEntries(root.get("packages"),
+                    customRegistries);
             return JacksonUtils.toFileJson(root);
         } catch (RuntimeException e) {
             getLogger().debug(
@@ -163,14 +175,33 @@ public class BundleBuildUtils {
         }
     }
 
-    private static void removeResolvedEntries(JsonNode section) {
+    private static void removeForeignResolvedEntries(JsonNode section,
+            Set<String> customRegistries) {
         if (section instanceof ObjectNode entries) {
             for (String name : entries.propertyNames()) {
-                if (entries.get(name) instanceof ObjectNode entry) {
+                if (entries.get(name) instanceof ObjectNode entry
+                        && !resolvesFromCustomRegistry(entry,
+                                customRegistries)) {
                     entry.remove("resolved");
                 }
             }
         }
+    }
+
+    /**
+     * Whether the entry's {@code resolved} URL points at one of the configured
+     * custom registries. Only such entries are kept, so npm keeps reusing their
+     * correct URLs; every other {@code resolved} URL (the public npm registry
+     * or a registry no longer configured) is stripped so npm re-resolves it
+     * against the current configuration. Entries without a {@code resolved} URL
+     * are treated as not matching, which is a no-op since there is nothing to
+     * remove.
+     */
+    private static boolean resolvesFromCustomRegistry(ObjectNode entry,
+            Set<String> customRegistries) {
+        return entry.get("resolved") instanceof JsonNode resolved
+                && resolved.isString() && customRegistries.stream()
+                        .anyMatch(resolved.asString()::startsWith);
     }
 
 }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
@@ -19,12 +19,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.internal.FileIOUtils;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
 
 import static com.vaadin.flow.server.Constants.DEV_BUNDLE_JAR_PATH;
@@ -88,8 +90,8 @@ public class BundleBuildUtils {
         if (devBundleFolder.exists()) {
             File devPackageLock = new File(devBundleFolder, packageLockFile);
             if (devPackageLock.exists()) {
-                Files.copy(devPackageLock.toPath(), packageLock.toPath(),
-                        StandardCopyOption.REPLACE_EXISTING);
+                writePackageLock(Files.readString(devPackageLock.toPath()),
+                        packageLock, options);
                 return;
             }
         }
@@ -115,12 +117,93 @@ public class BundleBuildUtils {
         }
         if (resource != null) {
             String filecontents = FileIOUtils.urlToString(resource);
-            Files.writeString(packageLock.toPath(), filecontents);
+            writePackageLock(filecontents, packageLock, options);
         } else {
             getLogger().debug(
                     "The '{}' file cannot be created because the dev-bundle JAR does not contain a suitable template.",
                     packageLockFile);
         }
+    }
+
+    /**
+     * Writes the seeded lock file, stripping the hardcoded {@code resolved}
+     * download URLs for the npm {@code package-lock.json} when the project
+     * configures a custom registry, so that {@code npm install} re-resolves
+     * them against that registry instead of reusing the {@code npmjs.org} URLs
+     * baked into the dev-bundle template. The {@code integrity} content hashes
+     * are kept so npm still verifies the downloaded tarballs against the
+     * versions Vaadin tested. In all other cases the content is written
+     * verbatim.
+     */
+    private static void writePackageLock(String contents, File packageLock,
+            Options options) throws IOException {
+        String toWrite = contents;
+        if (!options.isEnablePnpm() && hasCustomRegistry(options)) {
+            toWrite = stripResolvedUrls(contents, packageLock);
+        }
+        Files.writeString(packageLock.toPath(), toWrite);
+    }
+
+    private static String stripResolvedUrls(String contents, File packageLock) {
+        try {
+            ObjectNode root = JacksonUtils.readTree(contents);
+            removeResolvedEntries(root.get("packages"));
+            return JacksonUtils.toFileJson(root);
+        } catch (RuntimeException e) {
+            getLogger().debug(
+                    "Could not process '{}' to strip registry URLs; copying it verbatim.",
+                    packageLock.getName(), e);
+            return contents;
+        }
+    }
+
+    private static void removeResolvedEntries(JsonNode section) {
+        if (section instanceof ObjectNode entries) {
+            for (String name : entries.propertyNames()) {
+                if (entries.get(name) instanceof ObjectNode entry) {
+                    entry.remove("resolved");
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks whether a custom npm registry is configured in the project or user
+     * {@code .npmrc}. A global {@code registry=...} or a scoped
+     * {@code @scope:registry=...} entry both count.
+     */
+    private static boolean hasCustomRegistry(Options options) {
+        return npmrcDefinesRegistry(new File(options.getNpmFolder(), ".npmrc"))
+                || npmrcDefinesRegistry(
+                        new File(FileIOUtils.getUserDirectory(), ".npmrc"));
+    }
+
+    private static boolean npmrcDefinesRegistry(File npmrc) {
+        if (!npmrc.exists()) {
+            return false;
+        }
+        try {
+            for (String rawLine : Files.readAllLines(npmrc.toPath())) {
+                String line = rawLine.trim();
+                if (line.isEmpty() || line.startsWith("#")
+                        || line.startsWith(";")) {
+                    continue;
+                }
+                int separator = line.indexOf('=');
+                if (separator < 0) {
+                    continue;
+                }
+                String key = line.substring(0, separator).trim();
+                if (key.equals("registry") || key.endsWith(":registry")) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            getLogger().debug(
+                    "Could not read '{}' to detect a custom registry.", npmrc,
+                    e);
+        }
+        return false;
     }
 
 }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
@@ -26,6 +26,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.internal.FileIOUtils;
+import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
 
@@ -45,6 +46,11 @@ public class BundleBuildUtils {
      *            task options
      */
     public static void copyPackageLockFromBundle(Options options) {
+        copyPackageLockFromBundle(options, createFrontendTools(options));
+    }
+
+    static void copyPackageLockFromBundle(Options options,
+            FrontendTools frontendTools) {
         try {
             if (FrontendBuildUtils.isPlatformMajorVersionUpdated(
                     options.getClassFinder(), options.getNodeModulesFolder(),
@@ -70,7 +76,7 @@ public class BundleBuildUtils {
         }
 
         try {
-            copyAppropriatePackageLock(options, packageLock);
+            copyAppropriatePackageLock(options, packageLock, frontendTools);
         } catch (IOException ioe) {
             getLogger().error(
                     "Failed to copy existing `" + lockFile + "` to use", ioe);
@@ -78,8 +84,22 @@ public class BundleBuildUtils {
 
     }
 
+    private static FrontendTools createFrontendTools(Options options) {
+        FrontendToolsSettings settings = new FrontendToolsSettings(
+                options.getNpmFolder().getAbsolutePath(),
+                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
+        settings.setNodeDownloadRoot(options.getNodeDownloadRoot());
+        settings.setForceAlternativeNode(options.isRequireHomeNodeExec());
+        settings.setNodeFolder(options.getNodeFolder());
+        settings.setUseGlobalPnpm(options.isUseGlobalPnpm());
+        settings.setNodeVersion(options.getNodeVersion());
+        settings.setIgnoreVersionChecks(
+                options.isFrontendIgnoreVersionChecks());
+        return new FrontendTools(settings);
+    }
+
     private static void copyAppropriatePackageLock(Options options,
-            File packageLock) throws IOException {
+            File packageLock, FrontendTools frontendTools) throws IOException {
         File devBundleFolder = new File(
                 new File(options.getNpmFolder(),
                         options.getBuildDirectoryName()),
@@ -91,7 +111,7 @@ public class BundleBuildUtils {
             File devPackageLock = new File(devBundleFolder, packageLockFile);
             if (devPackageLock.exists()) {
                 writePackageLock(Files.readString(devPackageLock.toPath()),
-                        packageLock, options);
+                        packageLock, options, frontendTools);
                 return;
             }
         }
@@ -117,7 +137,7 @@ public class BundleBuildUtils {
         }
         if (resource != null) {
             String filecontents = FileIOUtils.urlToString(resource);
-            writePackageLock(filecontents, packageLock, options);
+            writePackageLock(filecontents, packageLock, options, frontendTools);
         } else {
             getLogger().debug(
                     "The '{}' file cannot be created because the dev-bundle JAR does not contain a suitable template.",
@@ -127,18 +147,19 @@ public class BundleBuildUtils {
 
     /**
      * Writes the seeded lock file, stripping the hardcoded {@code resolved}
-     * download URLs for the npm {@code package-lock.json} when the project
-     * configures a custom registry, so that {@code npm install} re-resolves
-     * them against that registry instead of reusing the {@code npmjs.org} URLs
-     * baked into the dev-bundle template. The {@code integrity} content hashes
-     * are kept so npm still verifies the downloaded tarballs against the
-     * versions Vaadin tested. In all other cases the content is written
-     * verbatim.
+     * download URLs for the npm {@code package-lock.json} when npm is
+     * configured with a custom registry, so that {@code npm install}
+     * re-resolves them against that registry instead of reusing the
+     * {@code npmjs.org} URLs baked into the dev-bundle template. The
+     * {@code integrity} content hashes are kept so npm still verifies the
+     * downloaded tarballs against the versions Vaadin tested. In all other
+     * cases the content is written verbatim.
      */
     private static void writePackageLock(String contents, File packageLock,
-            Options options) throws IOException {
+            Options options, FrontendTools frontendTools) throws IOException {
         String toWrite = contents;
-        if (!options.isEnablePnpm() && hasCustomRegistry(options)) {
+        if (!options.isEnablePnpm()
+                && frontendTools.hasCustomNpmRegistry(options.getNpmFolder())) {
             toWrite = stripResolvedUrls(contents, packageLock);
         }
         Files.writeString(packageLock.toPath(), toWrite);
@@ -165,45 +186,6 @@ public class BundleBuildUtils {
                 }
             }
         }
-    }
-
-    /**
-     * Checks whether a custom npm registry is configured in the project or user
-     * {@code .npmrc}. A global {@code registry=...} or a scoped
-     * {@code @scope:registry=...} entry both count.
-     */
-    private static boolean hasCustomRegistry(Options options) {
-        return npmrcDefinesRegistry(new File(options.getNpmFolder(), ".npmrc"))
-                || npmrcDefinesRegistry(
-                        new File(FileIOUtils.getUserDirectory(), ".npmrc"));
-    }
-
-    private static boolean npmrcDefinesRegistry(File npmrc) {
-        if (!npmrc.exists()) {
-            return false;
-        }
-        try {
-            for (String rawLine : Files.readAllLines(npmrc.toPath())) {
-                String line = rawLine.trim();
-                if (line.isEmpty() || line.startsWith("#")
-                        || line.startsWith(";")) {
-                    continue;
-                }
-                int separator = line.indexOf('=');
-                if (separator < 0) {
-                    continue;
-                }
-                String key = line.substring(0, separator).trim();
-                if (key.equals("registry") || key.endsWith(":registry")) {
-                    return true;
-                }
-            }
-        } catch (IOException e) {
-            getLogger().debug(
-                    "Could not read '{}' to detect a custom registry.", npmrc,
-                    e);
-        }
-        return false;
     }
 
 }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleBuildUtils.java
@@ -26,7 +26,6 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.internal.FileIOUtils;
-import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
 
@@ -46,7 +45,7 @@ public class BundleBuildUtils {
      *            task options
      */
     public static void copyPackageLockFromBundle(Options options) {
-        copyPackageLockFromBundle(options, createFrontendTools(options));
+        copyPackageLockFromBundle(options, FrontendTools.fromOptions(options));
     }
 
     static void copyPackageLockFromBundle(Options options,
@@ -82,20 +81,6 @@ public class BundleBuildUtils {
                     "Failed to copy existing `" + lockFile + "` to use", ioe);
         }
 
-    }
-
-    private static FrontendTools createFrontendTools(Options options) {
-        FrontendToolsSettings settings = new FrontendToolsSettings(
-                options.getNpmFolder().getAbsolutePath(),
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
-        settings.setNodeDownloadRoot(options.getNodeDownloadRoot());
-        settings.setForceAlternativeNode(options.isRequireHomeNodeExec());
-        settings.setNodeFolder(options.getNodeFolder());
-        settings.setUseGlobalPnpm(options.isUseGlobalPnpm());
-        settings.setNodeVersion(options.getNodeVersion());
-        settings.setIgnoreVersionChecks(
-                options.isFrontendIgnoreVersionChecks());
-        return new FrontendTools(settings);
     }
 
     private static void copyAppropriatePackageLock(Options options,

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -314,6 +314,29 @@ public class FrontendTools {
     }
 
     /**
+     * Creates a {@link FrontendTools} instance configured from the given
+     * {@link Options}, using the node/pnpm related settings collected there.
+     *
+     * @param options
+     *            the task options to read the frontend tools configuration
+     *            from, not {@code null}
+     * @return a new {@link FrontendTools} instance
+     */
+    public static FrontendTools fromOptions(Options options) {
+        FrontendToolsSettings settings = new FrontendToolsSettings(
+                options.getNpmFolder().getAbsolutePath(),
+                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
+        settings.setNodeDownloadRoot(options.getNodeDownloadRoot());
+        settings.setForceAlternativeNode(options.isRequireHomeNodeExec());
+        settings.setNodeFolder(options.getNodeFolder());
+        settings.setUseGlobalPnpm(options.isUseGlobalPnpm());
+        settings.setNodeVersion(options.getNodeVersion());
+        settings.setIgnoreVersionChecks(
+                options.isFrontendIgnoreVersionChecks());
+        return new FrontendTools(settings);
+    }
+
+    /**
      * Locate <code>node</code> executable.
      *
      * @return the full path to the executable

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -23,10 +23,13 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.NonNull;
@@ -540,24 +543,26 @@ public class FrontendTools {
     }
 
     /**
-     * Checks whether npm resolves package downloads against a registry other
-     * than the public npm registry.
+     * Returns the URLs of every configured registry that is not the public npm
+     * registry, i.e. the registries packages are expected to be downloaded
+     * from.
      * <p>
-     * The check delegates to npm itself, so it accounts for every configuration
-     * source and precedence rule npm applies (command line, environment
-     * variables, project/user/global/builtin {@code .npmrc}) and covers both
-     * the global {@code registry} and any scoped {@code @scope:registry}
-     * entries. If the configuration cannot be read the default registry is
-     * assumed.
+     * The configuration is read from npm itself, so it accounts for every
+     * configuration source and precedence rule npm applies (command line,
+     * environment variables, project/user/global/builtin {@code .npmrc}) and
+     * covers both the global {@code registry} and any scoped
+     * {@code @scope:registry} entries. If the configuration cannot be read an
+     * empty set is returned. The returned URLs always end with a slash, so they
+     * can be matched as a prefix against package download URLs.
      *
      * @param workingDirectory
      *            the directory the configuration is resolved from, so that a
      *            project {@code .npmrc} is taken into account
-     * @return {@code true} if a custom global or scoped registry is configured
+     * @return the custom registry URLs, or an empty set if only the default
+     *         registry is configured
      */
-    boolean hasCustomNpmRegistry(File workingDirectory) {
-        return containsCustomRegistry(
-                getConfiguredRegistries(workingDirectory));
+    Set<String> getCustomNpmRegistries(File workingDirectory) {
+        return customRegistries(getConfiguredRegistries(workingDirectory));
     }
 
     /**
@@ -594,9 +599,16 @@ public class FrontendTools {
         return registries;
     }
 
-    static boolean containsCustomRegistry(Map<String, String> registries) {
+    /**
+     * Extracts the custom (non-default) registry URLs from the given
+     * configuration, normalized to always end with a slash so they can be
+     * matched as a prefix against package download URLs.
+     */
+    static Set<String> customRegistries(Map<String, String> registries) {
         return registries.values().stream()
-                .anyMatch(registry -> !isDefaultNpmRegistry(registry));
+                .filter(registry -> !isDefaultNpmRegistry(registry))
+                .map(FrontendTools::ensureTrailingSlash)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private static boolean isDefaultNpmRegistry(String registry) {
@@ -604,6 +616,10 @@ public class FrontendTools {
                 ? registry.substring(0, registry.length() - 1)
                 : registry;
         return "https://registry.npmjs.org".equals(normalized);
+    }
+
+    private static String ensureTrailingSlash(String url) {
+        return url.endsWith("/") ? url : url + "/";
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -32,11 +32,13 @@ import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.internal.FrontendUtils.UnknownVersionException;
 import com.vaadin.flow.internal.FrontendVersion;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.internal.Platform;
 import com.vaadin.flow.server.InitParameters;
@@ -512,6 +514,73 @@ public class FrontendTools {
                             String.join(" ", npmCacheCommand)));
         }
         return new File(output);
+    }
+
+    /**
+     * Checks whether npm resolves package downloads against a registry other
+     * than the public npm registry.
+     * <p>
+     * The check delegates to npm itself, so it accounts for every configuration
+     * source and precedence rule npm applies (command line, environment
+     * variables, project/user/global/builtin {@code .npmrc}) and covers both
+     * the global {@code registry} and any scoped {@code @scope:registry}
+     * entries. If the configuration cannot be read the default registry is
+     * assumed.
+     *
+     * @param workingDirectory
+     *            the directory the configuration is resolved from, so that a
+     *            project {@code .npmrc} is taken into account
+     * @return {@code true} if a custom global or scoped registry is configured
+     */
+    boolean hasCustomNpmRegistry(File workingDirectory) {
+        return containsCustomRegistry(
+                getConfiguredRegistries(workingDirectory));
+    }
+
+    /**
+     * Reads the registry URLs npm resolves for the given directory by running
+     * {@code npm config ls --json}. The returned map contains the global
+     * {@code registry} entry and every scoped {@code @scope:registry} entry, as
+     * resolved by npm across all its configuration sources.
+     *
+     * @param workingDirectory
+     *            the directory to resolve the configuration from
+     * @return the configured registry keys mapped to their URLs, or an empty
+     *         map if the configuration cannot be read
+     */
+    Map<String, String> getConfiguredRegistries(File workingDirectory) {
+        List<String> command = new ArrayList<>(getNpmExecutable(false));
+        command.add("config");
+        command.add("ls");
+        command.add("--json");
+        Map<String, String> registries = new HashMap<>();
+        try {
+            String output = FrontendUtils.executeCommand(command,
+                    builder -> builder.directory(workingDirectory));
+            JsonNode config = JacksonUtils.readTree(output);
+            for (String key : config.propertyNames()) {
+                if ((key.equals("registry") || key.endsWith(":registry"))
+                        && config.get(key).isString()) {
+                    registries.put(key, config.get(key).asString());
+                }
+            }
+        } catch (CommandExecutionException | RuntimeException e) {
+            getLogger().debug("Could not read the npm registry configuration; "
+                    + "assuming the default registry.", e);
+        }
+        return registries;
+    }
+
+    static boolean containsCustomRegistry(Map<String, String> registries) {
+        return registries.values().stream()
+                .anyMatch(registry -> !isDefaultNpmRegistry(registry));
+    }
+
+    private static boolean isDefaultNpmRegistry(String registry) {
+        String normalized = registry.endsWith("/")
+                ? registry.substring(0, registry.length() - 1)
+                : registry;
+        return "https://registry.npmjs.org".equals(normalized);
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -134,17 +134,7 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
             throws ExecutionFailedException {
         Logger logger = getLogger();
 
-        FrontendToolsSettings settings = new FrontendToolsSettings(
-                options.getNpmFolder().getAbsolutePath(),
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
-        settings.setNodeDownloadRoot(options.getNodeDownloadRoot());
-        settings.setForceAlternativeNode(options.isRequireHomeNodeExec());
-        settings.setNodeFolder(options.getNodeFolder());
-        settings.setUseGlobalPnpm(options.isUseGlobalPnpm());
-        settings.setNodeVersion(options.getNodeVersion());
-        settings.setIgnoreVersionChecks(
-                options.isFrontendIgnoreVersionChecks());
-        FrontendTools frontendTools = new FrontendTools(settings);
+        FrontendTools frontendTools = FrontendTools.fromOptions(options);
 
         File buildExecutable;
         try {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleBuildUtilsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleBuildUtilsTest.java
@@ -41,6 +41,13 @@ class BundleBuildUtilsTest {
     @TempDir
     File temporaryFolder;
 
+    private static FrontendTools mockTools(boolean customRegistry) {
+        FrontendTools tools = Mockito.mock(FrontendTools.class);
+        Mockito.when(tools.hasCustomNpmRegistry(Mockito.any()))
+                .thenReturn(customRegistry);
+        return tools;
+    }
+
     @Test
     void packageLockExists_nothingIsCopied() throws IOException {
         ClassFinder finder = Mockito.mock(ClassFinder.class);
@@ -64,7 +71,7 @@ class BundleBuildUtilsTest {
 
         FileUtils.write(devPackageLockJson, "{ \"bundleFile\"}");
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String packageLockContents = FileUtils
                 .readFileToString(packageLockFile, StandardCharsets.UTF_8);
@@ -98,7 +105,7 @@ class BundleBuildUtilsTest {
         final String packageLockContent = "{ \"bundleFile\"}";
         FileUtils.write(devPackageLockJson, packageLockContent);
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String packageLockContents = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
@@ -133,7 +140,7 @@ class BundleBuildUtilsTest {
                 DEV_BUNDLE_JAR_PATH + "hybrid-" + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(jarHybridPackageLock.toURI().toURL());
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String packageLockContents = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
@@ -173,7 +180,7 @@ class BundleBuildUtilsTest {
                 DEV_BUNDLE_JAR_PATH + "hybrid-" + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(jarHybridPackageLock.toURI().toURL());
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String packageLockContents = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
@@ -208,7 +215,7 @@ class BundleBuildUtilsTest {
                 DEV_BUNDLE_JAR_PATH + "hybrid-" + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(null);
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String packageLockContents = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
@@ -246,7 +253,7 @@ class BundleBuildUtilsTest {
         FileUtils.write(devPackageLock, packageLockContent);
         FileUtils.write(devPackageLockJson, "{ \"json\"}");
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String packageLockContents = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_YAML),
@@ -278,13 +285,10 @@ class BundleBuildUtilsTest {
             """;
 
     @Test
-    void customRegistryInNpmrc_resolvedStrippedIntegrityKept()
+    void customRegistryConfigured_resolvedStrippedIntegrityKept()
             throws IOException {
         Options options = new MockOptions(temporaryFolder)
                 .withBuildDirectory("target");
-
-        Files.writeString(new File(options.getNpmFolder(), ".npmrc").toPath(),
-                "registry=https://my.registry/repository/npm/\n");
 
         File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
         FileUtils.write(jarPackageLock, LOCK_WITH_NPMJS_URLS,
@@ -293,7 +297,7 @@ class BundleBuildUtilsTest {
                 .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(jarPackageLock.toURI().toURL());
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(true));
 
         final String result = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
@@ -323,7 +327,7 @@ class BundleBuildUtilsTest {
                 .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(jarPackageLock.toURI().toURL());
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String result = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
@@ -334,42 +338,9 @@ class BundleBuildUtilsTest {
     }
 
     @Test
-    void scopedCustomRegistryInNpmrc_resolvedStripped() throws IOException {
-        Options options = new MockOptions(temporaryFolder)
-                .withBuildDirectory("target");
-
-        Files.writeString(new File(options.getNpmFolder(), ".npmrc").toPath(),
-                """
-                        @myorg:registry=https://somewhere-else.com/myorg
-                        @another:registry=https://somewhere-else.com/another
-                        """);
-
-        File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
-        FileUtils.write(jarPackageLock, LOCK_WITH_NPMJS_URLS,
-                StandardCharsets.UTF_8);
-        Mockito.when(options.getClassFinder()
-                .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
-                .thenReturn(jarPackageLock.toURI().toURL());
-
-        BundleBuildUtils.copyPackageLockFromBundle(options);
-
-        final String result = FileUtils.readFileToString(
-                new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
-                StandardCharsets.UTF_8);
-
-        assertFalse(result.contains("\"resolved\""),
-                "A scoped @scope:registry entry should also trigger stripping of resolved fields");
-        assertTrue(result.contains("sha512-fooHash"),
-                "integrity fields should be preserved");
-    }
-
-    @Test
     void customRegistry_invalidJson_copiedVerbatim() throws IOException {
         Options options = new MockOptions(temporaryFolder)
                 .withBuildDirectory("target");
-
-        Files.writeString(new File(options.getNpmFolder(), ".npmrc").toPath(),
-                "registry=https://my.registry/repository/npm/\n");
 
         final String notJson = "{ not valid json";
         File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
@@ -378,7 +349,7 @@ class BundleBuildUtilsTest {
                 .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(jarPackageLock.toURI().toURL());
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(true));
 
         final String result = FileUtils.readFileToString(
                 new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
@@ -412,7 +383,7 @@ class BundleBuildUtilsTest {
 
         FileUtils.write(devPackageLockJson, "{ \"bundleFile\"}");
 
-        BundleBuildUtils.copyPackageLockFromBundle(options);
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(false));
 
         final String packageLockContents = FileUtils
                 .readFileToString(packageLockFile, StandardCharsets.UTF_8);

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleBuildUtilsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleBuildUtilsTest.java
@@ -33,6 +33,8 @@ import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.Constants.DEV_BUNDLE_JAR_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BundleBuildUtilsTest {
 
@@ -252,6 +254,138 @@ class BundleBuildUtilsTest {
 
         assertEquals(packageLockContent, packageLockContents,
                 "dev-bundle file should be used");
+    }
+
+    private static final String LOCK_WITH_NPMJS_URLS = """
+            {
+              "name": "test",
+              "lockfileVersion": 3,
+              "requires": true,
+              "packages": {
+                "": { "name": "test" },
+                "node_modules/foo": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+                  "integrity": "sha512-fooHash"
+                },
+                "node_modules/bar": {
+                  "version": "2.3.4",
+                  "resolved": "https://registry.npmjs.org/bar/-/bar-2.3.4.tgz",
+                  "integrity": "sha512-barHash"
+                }
+              }
+            }
+            """;
+
+    @Test
+    void customRegistryInNpmrc_resolvedStrippedIntegrityKept()
+            throws IOException {
+        Options options = new MockOptions(temporaryFolder)
+                .withBuildDirectory("target");
+
+        Files.writeString(new File(options.getNpmFolder(), ".npmrc").toPath(),
+                "registry=https://my.registry/repository/npm/\n");
+
+        File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
+        FileUtils.write(jarPackageLock, LOCK_WITH_NPMJS_URLS,
+                StandardCharsets.UTF_8);
+        Mockito.when(options.getClassFinder()
+                .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
+                .thenReturn(jarPackageLock.toURI().toURL());
+
+        BundleBuildUtils.copyPackageLockFromBundle(options);
+
+        final String result = FileUtils.readFileToString(
+                new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
+                StandardCharsets.UTF_8);
+
+        assertFalse(result.contains("registry.npmjs.org"),
+                "resolved URLs pointing to npmjs.org should be stripped when a custom registry is configured");
+        assertFalse(result.contains("\"resolved\""),
+                "resolved fields should be removed so npm re-resolves against the configured registry");
+        assertTrue(
+                result.contains("sha512-fooHash")
+                        && result.contains("sha512-barHash"),
+                "integrity fields should be preserved");
+        assertTrue(result.contains("\"version\": \"1.0.0\""),
+                "version pins should be preserved");
+    }
+
+    @Test
+    void noCustomRegistry_resolvedKeptVerbatim() throws IOException {
+        Options options = new MockOptions(temporaryFolder)
+                .withBuildDirectory("target");
+
+        File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
+        FileUtils.write(jarPackageLock, LOCK_WITH_NPMJS_URLS,
+                StandardCharsets.UTF_8);
+        Mockito.when(options.getClassFinder()
+                .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
+                .thenReturn(jarPackageLock.toURI().toURL());
+
+        BundleBuildUtils.copyPackageLockFromBundle(options);
+
+        final String result = FileUtils.readFileToString(
+                new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
+                StandardCharsets.UTF_8);
+
+        assertEquals(LOCK_WITH_NPMJS_URLS, result,
+                "Without a custom registry the lock should be copied verbatim");
+    }
+
+    @Test
+    void scopedCustomRegistryInNpmrc_resolvedStripped() throws IOException {
+        Options options = new MockOptions(temporaryFolder)
+                .withBuildDirectory("target");
+
+        Files.writeString(new File(options.getNpmFolder(), ".npmrc").toPath(),
+                """
+                        @myorg:registry=https://somewhere-else.com/myorg
+                        @another:registry=https://somewhere-else.com/another
+                        """);
+
+        File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
+        FileUtils.write(jarPackageLock, LOCK_WITH_NPMJS_URLS,
+                StandardCharsets.UTF_8);
+        Mockito.when(options.getClassFinder()
+                .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
+                .thenReturn(jarPackageLock.toURI().toURL());
+
+        BundleBuildUtils.copyPackageLockFromBundle(options);
+
+        final String result = FileUtils.readFileToString(
+                new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
+                StandardCharsets.UTF_8);
+
+        assertFalse(result.contains("\"resolved\""),
+                "A scoped @scope:registry entry should also trigger stripping of resolved fields");
+        assertTrue(result.contains("sha512-fooHash"),
+                "integrity fields should be preserved");
+    }
+
+    @Test
+    void customRegistry_invalidJson_copiedVerbatim() throws IOException {
+        Options options = new MockOptions(temporaryFolder)
+                .withBuildDirectory("target");
+
+        Files.writeString(new File(options.getNpmFolder(), ".npmrc").toPath(),
+                "registry=https://my.registry/repository/npm/\n");
+
+        final String notJson = "{ not valid json";
+        File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
+        FileUtils.write(jarPackageLock, notJson, StandardCharsets.UTF_8);
+        Mockito.when(options.getClassFinder()
+                .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
+                .thenReturn(jarPackageLock.toURI().toURL());
+
+        BundleBuildUtils.copyPackageLockFromBundle(options);
+
+        final String result = FileUtils.readFileToString(
+                new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
+                StandardCharsets.UTF_8);
+
+        assertEquals(notJson, result,
+                "Unparseable content should be copied verbatim without failing the build");
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleBuildUtilsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleBuildUtilsTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
@@ -41,10 +42,17 @@ class BundleBuildUtilsTest {
     @TempDir
     File temporaryFolder;
 
+    private static final String CUSTOM_REGISTRY_URL = "https://nexus.example.com/repository/npm/";
+
     private static FrontendTools mockTools(boolean customRegistry) {
+        return mockTools(
+                customRegistry ? Set.of(CUSTOM_REGISTRY_URL) : Set.of());
+    }
+
+    private static FrontendTools mockTools(Set<String> customRegistries) {
         FrontendTools tools = Mockito.mock(FrontendTools.class);
-        Mockito.when(tools.hasCustomNpmRegistry(Mockito.any()))
-                .thenReturn(customRegistry);
+        Mockito.when(tools.getCustomNpmRegistries(Mockito.any()))
+                .thenReturn(customRegistries);
         return tools;
     }
 
@@ -313,6 +321,119 @@ class BundleBuildUtilsTest {
                 "integrity fields should be preserved");
         assertTrue(result.contains("\"version\": \"1.0.0\""),
                 "version pins should be preserved");
+    }
+
+    private static final String LOCK_WITH_CUSTOM_REGISTRY_URLS = """
+            {
+              "name": "test",
+              "lockfileVersion": 3,
+              "requires": true,
+              "packages": {
+                "": { "name": "test" },
+                "node_modules/foo": {
+                  "version": "1.0.0",
+                  "resolved": "https://nexus.example.com/repository/npm/foo/-/foo-1.0.0.tgz",
+                  "integrity": "sha512-fooHash"
+                },
+                "node_modules/bar": {
+                  "version": "2.3.4",
+                  "resolved": "https://registry.npmjs.org/bar/-/bar-2.3.4.tgz",
+                  "integrity": "sha512-barHash"
+                }
+              }
+            }
+            """;
+
+    @Test
+    void customRegistryConfigured_resolvedFromCustomRegistryKept()
+            throws IOException {
+        Options options = new MockOptions(temporaryFolder)
+                .withBuildDirectory("target");
+
+        File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
+        FileUtils.write(jarPackageLock, LOCK_WITH_CUSTOM_REGISTRY_URLS,
+                StandardCharsets.UTF_8);
+        Mockito.when(options.getClassFinder()
+                .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
+                .thenReturn(jarPackageLock.toURI().toURL());
+
+        BundleBuildUtils.copyPackageLockFromBundle(options, mockTools(true));
+
+        final String result = FileUtils.readFileToString(
+                new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
+                StandardCharsets.UTF_8);
+
+        assertTrue(result.contains(
+                "https://nexus.example.com/repository/npm/foo/-/foo-1.0.0.tgz"),
+                "resolved URLs already pointing at the custom registry should be kept so npm does not needlessly re-resolve them");
+        assertFalse(result.contains("registry.npmjs.org"),
+                "resolved URLs pointing to npmjs.org should still be stripped");
+    }
+
+    private static final String LOCK_WITH_MULTIPLE_REGISTRY_URLS = """
+            {
+              "name": "test",
+              "lockfileVersion": 3,
+              "requires": true,
+              "packages": {
+                "": { "name": "test" },
+                "node_modules/a": {
+                  "resolved": "https://registry-a.example.com/npm/a/-/a-1.0.0.tgz",
+                  "integrity": "sha512-aHash"
+                },
+                "node_modules/b": {
+                  "resolved": "https://registry-b.example.com/npm/b/-/b-1.0.0.tgz",
+                  "integrity": "sha512-bHash"
+                },
+                "node_modules/c": {
+                  "resolved": "https://registry-c.example.com/npm/c/-/c-1.0.0.tgz",
+                  "integrity": "sha512-cHash"
+                },
+                "node_modules/d": {
+                  "resolved": "https://registry-d.example.com/npm/d/-/d-1.0.0.tgz",
+                  "integrity": "sha512-dHash"
+                },
+                "node_modules/e": {
+                  "resolved": "https://registry.npmjs.org/e/-/e-1.0.0.tgz",
+                  "integrity": "sha512-eHash"
+                }
+              }
+            }
+            """;
+
+    @Test
+    void multipleCustomRegistries_onlyConfiguredRegistriesKept()
+            throws IOException {
+        Options options = new MockOptions(temporaryFolder)
+                .withBuildDirectory("target");
+
+        File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
+        FileUtils.write(jarPackageLock, LOCK_WITH_MULTIPLE_REGISTRY_URLS,
+                StandardCharsets.UTF_8);
+        Mockito.when(options.getClassFinder()
+                .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
+                .thenReturn(jarPackageLock.toURI().toURL());
+
+        // Only registries A and B are configured; C, D and the default npm
+        // registry are not.
+        BundleBuildUtils.copyPackageLockFromBundle(options,
+                mockTools(Set.of("https://registry-a.example.com/npm/",
+                        "https://registry-b.example.com/npm/")));
+
+        final String result = FileUtils.readFileToString(
+                new File(options.getNpmFolder(), Constants.PACKAGE_LOCK_JSON),
+                StandardCharsets.UTF_8);
+
+        assertTrue(result.contains("registry-a.example.com"),
+                "resolved URLs from configured registry A should be kept");
+        assertTrue(result.contains("registry-b.example.com"),
+                "resolved URLs from configured registry B should be kept");
+        assertFalse(result.contains("registry-c.example.com"),
+                "resolved URLs from unconfigured registry C should be stripped");
+        assertFalse(result.contains("registry-d.example.com"),
+                "resolved URLs from unconfigured registry D should be stripped");
+        assertFalse(result.contains("registry.npmjs.org"),
+                "resolved URLs from the default npm registry should be stripped");
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
@@ -910,6 +911,33 @@ class FrontendToolsTest {
                 ? "node-" + nodeVersion + "\\node_modules\\npm\\bin\\npm-cli.js"
                 : "node-" + nodeVersion
                         + "/lib/node_modules/npm/bin/npm-cli.js";
+    }
+
+    @Test
+    void containsCustomRegistry_defaultRegistryOnly_isNotCustom() {
+        assertFalse(FrontendTools.containsCustomRegistry(
+                Map.of("registry", "https://registry.npmjs.org/")));
+        // npm may report the default without a trailing slash
+        assertFalse(FrontendTools.containsCustomRegistry(
+                Map.of("registry", "https://registry.npmjs.org")));
+    }
+
+    @Test
+    void containsCustomRegistry_noRegistryResolved_isNotCustom() {
+        assertFalse(FrontendTools.containsCustomRegistry(Map.of()));
+    }
+
+    @Test
+    void containsCustomRegistry_customGlobalRegistry_isCustom() {
+        assertTrue(FrontendTools.containsCustomRegistry(
+                Map.of("registry", "https://nexus.corp/repository/npm/")));
+    }
+
+    @Test
+    void containsCustomRegistry_customScopedRegistryWithDefaultGlobal_isCustom() {
+        assertTrue(FrontendTools.containsCustomRegistry(Map.of("registry",
+                "https://registry.npmjs.org/", "@vaadin:registry",
+                "https://nexus.corp/repository/npm/")));
     }
 
 }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -914,30 +915,38 @@ class FrontendToolsTest {
     }
 
     @Test
-    void containsCustomRegistry_defaultRegistryOnly_isNotCustom() {
-        assertFalse(FrontendTools.containsCustomRegistry(
-                Map.of("registry", "https://registry.npmjs.org/")));
+    void customRegistries_defaultRegistryOnly_isEmpty() {
+        assertTrue(FrontendTools
+                .customRegistries(
+                        Map.of("registry", "https://registry.npmjs.org/"))
+                .isEmpty());
         // npm may report the default without a trailing slash
-        assertFalse(FrontendTools.containsCustomRegistry(
-                Map.of("registry", "https://registry.npmjs.org")));
+        assertTrue(FrontendTools
+                .customRegistries(
+                        Map.of("registry", "https://registry.npmjs.org"))
+                .isEmpty());
     }
 
     @Test
-    void containsCustomRegistry_noRegistryResolved_isNotCustom() {
-        assertFalse(FrontendTools.containsCustomRegistry(Map.of()));
+    void customRegistries_noRegistryResolved_isEmpty() {
+        assertTrue(FrontendTools.customRegistries(Map.of()).isEmpty());
     }
 
     @Test
-    void containsCustomRegistry_customGlobalRegistry_isCustom() {
-        assertTrue(FrontendTools.containsCustomRegistry(
-                Map.of("registry", "https://nexus.corp/repository/npm/")));
+    void customRegistries_customGlobalRegistry_isReturnedWithTrailingSlash() {
+        assertEquals(Set.of("https://nexus.corp/repository/npm/"),
+                FrontendTools.customRegistries(Map.of("registry",
+                        "https://nexus.corp/repository/npm")),
+                "the custom registry URL should be returned normalized with a trailing slash");
     }
 
     @Test
-    void containsCustomRegistry_customScopedRegistryWithDefaultGlobal_isCustom() {
-        assertTrue(FrontendTools.containsCustomRegistry(Map.of("registry",
-                "https://registry.npmjs.org/", "@vaadin:registry",
-                "https://nexus.corp/repository/npm/")));
+    void customRegistries_customScopedRegistryWithDefaultGlobal_onlyCustomReturned() {
+        assertEquals(Set.of("https://nexus.corp/repository/npm/"),
+                FrontendTools.customRegistries(Map.of("registry",
+                        "https://registry.npmjs.org/", "@vaadin:registry",
+                        "https://nexus.corp/repository/npm/")),
+                "only the non-default scoped registry should be returned");
     }
 
 }


### PR DESCRIPTION
When seeding a project's `package-lock.json` from the dev-bundle template,
Flow copied it verbatim, keeping the hardcoded `registry.npmjs.org` URLs in
every `resolved` field. With a custom npm registry configured, this leaves a
committed lock (with `cleanFrontendFiles=false`) that still points at
`registry.npmjs.org`, and packages can end up being downloaded from npmjs
instead of the configured registry — for example when only a scoped
`@scope:registry` is set, or when npm's registry-host rewriting is turned
off. This breaks private/air-gapped setups and any tooling that consumes the
lock without npm's rewriting.

Strip the `resolved` fields from the seeded npm `package-lock.json` when a
custom registry is configured, so npm re-resolves the download URLs against
that registry. The `integrity` hashes are kept so npm still verifies the
downloaded tarballs against the versions Vaadin tested. Default setups keep
the verbatim fast-path copy.

Whether a custom registry is configured is now determined by npm itself
(`npm config ls --json`) rather than by scanning `.npmrc` files, so it also
covers registries set through environment variables, the global npmrc, or the
command line, as well as scoped registries.