### PR TITLE
feat: validate URL schemes in Anchor, IFrame and Page#open (#24539, #24897) (CP: 25.1)

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -26,7 +26,9 @@ import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.streams.AbstractDownloadHandler;
@@ -70,6 +72,11 @@ public class Anchor extends HtmlContainer
      *            the href to set
      * @param text
      *            the text content to set
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, String text) {
         setHref(href);
@@ -96,6 +103,11 @@ public class Anchor extends HtmlContainer
      *            the href to set
      * @param textSignal
      *            the signal to bind, not {@code null}
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      * @since 25.1
      */
     public Anchor(String href, Signal<String> textSignal) {
@@ -117,6 +129,11 @@ public class Anchor extends HtmlContainer
      *            the text content to set
      * @param target
      *            the target window, tab or frame
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, String text, AnchorTarget target) {
         setHref(href);
@@ -248,6 +265,11 @@ public class Anchor extends HtmlContainer
      *            the href to set
      * @param components
      *            the components to add
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, Component... components) {
         setHref(href);
@@ -268,8 +290,40 @@ public class Anchor extends HtmlContainer
      *
      * @param href
      *            the href to set
+     * @throws IllegalArgumentException
+     *             if the URL uses a scheme that is not considered safe; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setHref(String href) {
+        if (href == null) {
+            throw new IllegalArgumentException("Href must not be null");
+        }
+        if (!UrlUtil.isSafeUrl(href)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "href", href, "setUnsafeHref(String)"));
+        }
+        this.href = href;
+        assignHrefAttribute();
+    }
+
+    /**
+     * Sets the URL that this anchor links to without validating its scheme.
+     * <p>
+     * Unlike {@link #setHref(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} or {@code data:} URL. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #setHref(String)
+     *
+     * @param href
+     *            the href to set
+     */
+    public void setUnsafeHref(String href) {
         if (href == null) {
             throw new IllegalArgumentException("Href must not be null");
         }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.InitParameters;
@@ -73,8 +74,10 @@ public class Anchor extends HtmlContainer
      * @param text
      *            the text content to set
      * @throws IllegalArgumentException
-     *             if {@code href} uses a scheme that is not considered safe;
-     *             see {@link #setUnsafeHref(String)} and the
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property
      */
@@ -104,8 +107,10 @@ public class Anchor extends HtmlContainer
      * @param textSignal
      *            the signal to bind, not {@code null}
      * @throws IllegalArgumentException
-     *             if {@code href} uses a scheme that is not considered safe;
-     *             see {@link #setUnsafeHref(String)} and the
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property
      * @since 25.1
@@ -130,8 +135,10 @@ public class Anchor extends HtmlContainer
      * @param target
      *            the target window, tab or frame
      * @throws IllegalArgumentException
-     *             if {@code href} uses a scheme that is not considered safe;
-     *             see {@link #setUnsafeHref(String)} and the
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property
      */
@@ -266,8 +273,10 @@ public class Anchor extends HtmlContainer
      * @param components
      *            the components to add
      * @throws IllegalArgumentException
-     *             if {@code href} uses a scheme that is not considered safe;
-     *             see {@link #setUnsafeHref(String)} and the
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property
      */
@@ -291,7 +300,9 @@ public class Anchor extends HtmlContainer
      * @param href
      *            the href to set
      * @throws IllegalArgumentException
-     *             if the URL uses a scheme that is not considered safe; see
+     *             if the URL uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
      *             {@link #setUnsafeHref(String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -24,7 +24,9 @@ import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
@@ -131,6 +133,11 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *
      * @param src
      *            Source URL
+     * @throws IllegalArgumentException
+     *             if {@code src} uses a scheme that is not considered safe; see
+     *             {@link #setUnsafeSrc(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public IFrame(String src) {
         setSrc(src);
@@ -160,8 +167,36 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *
      * @param src
      *            Source URL.
+     * @throws IllegalArgumentException
+     *             if the URL uses a scheme that is not considered safe; see
+     *             {@link #setUnsafeSrc(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setSrc(String src) {
+        if (src != null && !UrlUtil.isSafeUrl(src)) {
+            throw new IllegalArgumentException(UrlUtil
+                    .getUnsafeUrlMessage("src", src, "setUnsafeSrc(String)"));
+        }
+        set(srcDescriptor, src);
+    }
+
+    /**
+     * Sets the source of the iframe without validating its scheme.
+     * <p>
+     * Unlike {@link #setSrc(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe, such as
+     * a hard-coded {@code javascript:} or {@code data:} URL. Passing untrusted
+     * input here can expose the application to cross-site scripting (XSS)
+     * attacks.
+     *
+     * @see #setSrc(String)
+     *
+     * @param src
+     *            Source URL.
+     */
+    public void setUnsafeSrc(String src) {
         set(srcDescriptor, src);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.InitParameters;
@@ -134,7 +135,9 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * @param src
      *            Source URL
      * @throws IllegalArgumentException
-     *             if {@code src} uses a scheme that is not considered safe; see
+     *             if {@code src} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
      *             {@link #setUnsafeSrc(String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property
@@ -168,7 +171,9 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * @param src
      *            Source URL.
      * @throws IllegalArgumentException
-     *             if the URL uses a scheme that is not considered safe; see
+     *             if the URL uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
      *             {@link #setUnsafeSrc(String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
@@ -196,6 +197,10 @@ public class Image extends HtmlContainer
 
     /**
      * Sets the image URL.
+     * <p>
+     * Unlike {@link Anchor#setHref(String)} and {@link IFrame#setSrc(String)},
+     * image URLs are not validated against the
+     * {@value InitParameters#URL_SAFE_SCHEMES} configuration.
      *
      * @param src
      *            the image URL

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -28,10 +28,12 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.ServletResourceDownloadHandler;
+import com.vaadin.flow.signals.local.ValueSignal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AnchorTest extends ComponentTest {
@@ -426,6 +428,47 @@ class AnchorTest extends ComponentTest {
 
         assertTrue(anchor.isDownload(),
                 "Custom download handlers should by default add download attribute");
+    }
+
+    @Test
+    void setHref_unsafeScheme_throws() {
+        Anchor anchor = new Anchor();
+        assertThrows(IllegalArgumentException.class,
+                () -> anchor.setHref("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeHref_unsafeScheme_setsHrefWithoutValidation() {
+        Anchor anchor = new Anchor();
+        anchor.setUnsafeHref("javascript:alert(1)");
+        assertEquals("javascript:alert(1)",
+                anchor.getElement().getAttribute("href"));
+    }
+
+    @Test
+    void constructor_stringHrefStringText_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)", "Click"));
+    }
+
+    @Test
+    void constructor_stringHrefSignalText_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)",
+                        new ValueSignal<>("Click")));
+    }
+
+    @Test
+    void constructor_stringHrefStringTextTarget_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)", "Click",
+                        AnchorTarget.BLANK));
+    }
+
+    @Test
+    void constructor_stringHrefComponents_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)"));
     }
 
     private void mockUI() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
@@ -29,14 +29,20 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -51,10 +57,33 @@ abstract class ComponentTest {
 
     private Set<String> WHITE_LIST = new HashSet<>();
 
+    static private MockedStatic<VaadinService> vaadinServiceMockedStatic;
+
+    @BeforeAll
+    static void init() {
+        // Mock strict Flow 25.2+ safe URL scheme validation configuration
+        // for feature validation in component tests (AnchorTest, IFrameTest)
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMockedStatic = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMockedStatic.when(VaadinService::getCurrent)
+                .thenReturn(service);
+    }
+
+    @AfterAll
+    static void clean() {
+        vaadinServiceMockedStatic.close();
+    }
+
     @BeforeEach
     void setup() throws IntrospectionException, InstantiationException,
             IllegalAccessException, ClassNotFoundException,
             InvocationTargetException, NoSuchMethodException {
+
         component = createComponent();
         whitelistProperty("visible");
         whitelistProperty("testId");

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -256,6 +256,11 @@ class HtmlComponentSmokeTest {
             return true;
         }
 
+        if (method.getDeclaringClass() == IFrame.class
+                && method.getName().equals("setUnsafeSrc")) {
+            return true;
+        }
+
         if (method.getDeclaringClass() == HtmlObject.class
                 && method.getName().startsWith("setData")
                 && method.getParameterTypes()[0] == DownloadHandler.class) {
@@ -265,6 +270,11 @@ class HtmlComponentSmokeTest {
         if (method.getDeclaringClass() == Anchor.class
                 && method.getName().startsWith("setHref")
                 && method.getParameterTypes()[0] == DownloadHandler.class) {
+            return true;
+        }
+
+        if (method.getDeclaringClass() == Anchor.class
+                && method.getName().equals("setUnsafeHref")) {
             return true;
         }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IFrameTest extends ComponentTest {
@@ -115,5 +116,25 @@ class IFrameTest extends ComponentTest {
         assertFalse(handler.isInline());
         new TestIFrame(handler);
         assertTrue(handler.isInline());
+    }
+
+    @Test
+    void setSrc_unsafeScheme_throws() {
+        IFrame iframe = new IFrame();
+        assertThrows(IllegalArgumentException.class,
+                () -> iframe.setSrc("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeSrc_unsafeScheme_setsSrcWithoutValidation() {
+        IFrame iframe = new IFrame();
+        iframe.setUnsafeSrc("javascript:alert(1)");
+        assertEquals("javascript:alert(1)", iframe.getSrc());
+    }
+
+    @Test
+    void constructor_unsafeSrc_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new IFrame("javascript:alert(1)"));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.InitParameters;
@@ -485,9 +486,11 @@ public class Page implements Serializable {
      *            the URL to open.
      * @throws IllegalArgumentException
      *             if {@code url} is {@code null}, or if the URL uses a scheme
-     *             that is not considered safe; see {@link #openUnsafe(String)}
-     *             and the {@value InitParameters#URL_SAFE_SCHEMES}
-     *             configuration property
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #openUnsafe(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void open(String url) {
         open(url, "_blank");
@@ -527,7 +530,8 @@ public class Page implements Serializable {
      *            the name of the window.
      * @throws IllegalArgumentException
      *             if {@code url} is {@code null}, or if the URL uses a scheme
-     *             that is not considered safe; see
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
      *             {@link #openUnsafe(String, String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property
@@ -600,7 +604,8 @@ public class Page implements Serializable {
      *            the URI to show
      * @throws IllegalArgumentException
      *             if {@code uri} is {@code null}, or if the URI uses a scheme
-     *             that is not considered safe; call
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; call
      *             {@code openUnsafe(uri, "_self")} to bypass scheme validation,
      *             and see the {@value InitParameters#URL_SAFE_SCHEMES}
      *             configuration property
@@ -617,7 +622,8 @@ public class Page implements Serializable {
      *            the URI to show
      * @throws IllegalArgumentException
      *             if {@code uri} is {@code null}, or if the URI uses a scheme
-     *             that is not considered safe; call
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; call
      *             {@code openUnsafe(uri.toString(), "_self")} to bypass scheme
      *             validation, and see the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;
@@ -482,6 +483,11 @@ public class Page implements Serializable {
      *
      * @param url
      *            the URL to open.
+     * @throws IllegalArgumentException
+     *             if {@code url} is {@code null}, or if the URL uses a scheme
+     *             that is not considered safe; see {@link #openUnsafe(String)}
+     *             and the {@value InitParameters#URL_SAFE_SCHEMES}
+     *             configuration property
      */
     public void open(String url) {
         open(url, "_blank");
@@ -519,8 +525,64 @@ public class Page implements Serializable {
      *            the URL to open.
      * @param windowName
      *            the name of the window.
+     * @throws IllegalArgumentException
+     *             if {@code url} is {@code null}, or if the URL uses a scheme
+     *             that is not considered safe; see
+     *             {@link #openUnsafe(String, String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void open(String url, String windowName) {
+        if (url == null) {
+            throw new IllegalArgumentException("URL must not be null");
+        }
+        if (!UrlUtil.isSafeUrl(url)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "URL", url, "openUnsafe(String, String)"));
+        }
+        openInternal(url, windowName);
+    }
+
+    /**
+     * Opens the given url in a new tab without validating its scheme.
+     * <p>
+     * Unlike {@link #open(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #open(String)
+     *
+     * @param url
+     *            the URL to open.
+     */
+    public void openUnsafe(String url) {
+        openInternal(url, "_blank");
+    }
+
+    /**
+     * Opens the given URL in a window with the given name without validating
+     * its scheme.
+     * <p>
+     * Unlike {@link #open(String, String)}, this method does not reject URLs
+     * based on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use
+     * it only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #open(String, String)
+     *
+     * @param url
+     *            the URL to open.
+     * @param windowName
+     *            the name of the window.
+     */
+    public void openUnsafe(String url, String windowName) {
+        openInternal(url, windowName);
+    }
+
+    private void openInternal(String url, String windowName) {
         // The vaadin-redirect-pending event might be useful to block other
         // client side
         // reload/redirection triggered by other components, for example Vite.
@@ -536,6 +598,12 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @throws IllegalArgumentException
+     *             if {@code uri} is {@code null}, or if the URI uses a scheme
+     *             that is not considered safe; call
+     *             {@code openUnsafe(uri, "_self")} to bypass scheme validation,
+     *             and see the {@value InitParameters#URL_SAFE_SCHEMES}
+     *             configuration property
      */
     public void setLocation(String uri) {
         open(uri, "_self");
@@ -547,6 +615,13 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @throws IllegalArgumentException
+     *             if {@code uri} is {@code null}, or if the URI uses a scheme
+     *             that is not considered safe; call
+     *             {@code openUnsafe(uri.toString(), "_self")} to bypass scheme
+     *             validation, and see the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setLocation(URI uri) {
         setLocation(uri.toString());

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -280,8 +280,9 @@ public interface DeploymentConfiguration
      * <p>
      * Concrete implementations read this from the
      * {@link InitParameters#URL_SAFE_SCHEMES} property; the default returns
-     * @code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses
-     * the validation and allows all URLs.
+     * 
+     * @code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses the
+     *       validation and allows all URLs.
      *
      * @return the set of safe URL schemes, never {@code null}
      */

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -271,6 +272,21 @@ public interface DeploymentConfiguration
                         POLYFILLS_DEFAULT_VALUE).split("[, ]+"))
                 .stream().filter(polyfill -> !polyfill.isEmpty())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the set of URL schemes considered safe in URLs set on components
+     * such as {@code Anchor}, {@code IFrame} and in
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)}.
+     * <p>
+     * Concrete implementations read this from the
+     * {@link InitParameters#URL_SAFE_SCHEMES} property; the default returns
+     * {@link Constants#DEFAULT_URL_SAFE_SCHEMES}.
+     *
+     * @return the set of safe URL schemes, never {@code null}
+     */
+    default Set<String> getUrlSafeSchemes() {
+        return Constants.DEFAULT_URL_SAFE_SCHEMES;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -43,7 +43,6 @@ import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_POLYFILLS;
  */
 public interface DeploymentConfiguration
         extends AbstractConfiguration, Serializable {
-
     /**
      * Returns whether the server provides timing info to the client.
      *
@@ -281,12 +280,13 @@ public interface DeploymentConfiguration
      * <p>
      * Concrete implementations read this from the
      * {@link InitParameters#URL_SAFE_SCHEMES} property; the default returns
-     * {@link Constants#DEFAULT_URL_SAFE_SCHEMES}.
+     * @code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses
+     * the validation and allows all URLs.
      *
      * @return the set of safe URL schemes, never {@code null}
      */
     default Set<String> getUrlSafeSchemes() {
-        return Constants.DEFAULT_URL_SAFE_SCHEMES;
+        return Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -280,9 +280,13 @@ public interface DeploymentConfiguration
      * <p>
      * Concrete implementations read this from the
      * {@link InitParameters#URL_SAFE_SCHEMES} property; the default returns
-     * 
-     * @code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses the
-     *       validation and allows all URLs.
+     * {@code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses the
+     * validation and allows all URLs.
+     * <p>
+     * <strong>Note:</strong> the default changes in future Flow versions.
+     * Starting from Flow 25.2, the default safe schemes are "http", "https",
+     * "mailto", "tel", "ftp". Script-capable schemes such as {@code javascript}
+     * and {@code data} will be intentionally excluded.
      *
      * @return the set of safe URL schemes, never {@code null}
      */

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -20,8 +20,18 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * Internal utility class for URL handling.
@@ -236,5 +246,145 @@ public class UrlUtil {
             return ".";
         }
         return ret.substring(0, ret.length() - 1);
+    }
+
+    /**
+     * Checks whether the scheme of the given URL is considered safe by the
+     * current deployment configuration.
+     * <p>
+     * The set of safe schemes is read from the current {@link VaadinService}'s
+     * {@link DeploymentConfiguration#getUrlSafeSchemes()}, falling back to
+     * {@link Constants#DEFAULT_URL_SAFE_SCHEMES} when no {@link VaadinService}
+     * is available. Relative URLs (without a scheme) are always considered
+     * safe, whereas URLs containing control characters are rejected as they can
+     * be used to obfuscate the scheme. A {@code null} URL is considered unsafe.
+     *
+     * @param url
+     *            the URL to check, may be {@code null}
+     * @return {@code true} if the URL is safe, {@code false} otherwise
+     */
+    public static boolean isSafeUrl(String url) {
+        VaadinService service = VaadinService.getCurrent();
+        Set<String> safeSchemes;
+        if (service == null) {
+            if (getLogger().isDebugEnabled()) {
+                getLogger()
+                        .debug("No VaadinService available on current thread; "
+                                + "falling back to default safe URL schemes. "
+                                + "Any custom {} configuration will not apply "
+                                + "here.", InitParameters.URL_SAFE_SCHEMES);
+            }
+            safeSchemes = Constants.DEFAULT_URL_SAFE_SCHEMES;
+        } else {
+            safeSchemes = service.getDeploymentConfiguration()
+                    .getUrlSafeSchemes();
+        }
+        return isSafeUrl(url, safeSchemes);
+    }
+
+    /**
+     * Builds the message for the {@link IllegalArgumentException} that a
+     * validating URL setter throws when given a URL whose scheme is not
+     * considered safe. The message points to both the
+     * {@link InitParameters#URL_SAFE_SCHEMES} configuration property and the
+     * setter that bypasses validation.
+     *
+     * @param type
+     *            the kind of URL being set, for example {@code "href"},
+     *            {@code "src"} or {@code "path"}
+     * @param url
+     *            the rejected URL
+     * @param unsafeMethod
+     *            the signature of the method that bypasses validation, for
+     *            example {@code "setUnsafeHref(String)"}
+     * @return the exception message
+     */
+    public static String getUnsafeUrlMessage(String type, String url,
+            String unsafeMethod) {
+        return String.format(
+                "The %s \"%s\" uses a scheme that is not considered safe. "
+                        + "Configure the safe schemes with the \"%s\" property, "
+                        + "or use %s if this URL is intentional and trusted.",
+                type, url, InitParameters.URL_SAFE_SCHEMES, unsafeMethod);
+    }
+
+    /**
+     * Checks whether the scheme of the given URL is part of the given set of
+     * safe schemes. See {@link #isSafeUrl(String)} for the validation rules. A
+     * {@code null} URL is considered unsafe.
+     *
+     * @param url
+     *            the URL to check, may be {@code null}
+     * @param safeSchemes
+     *            the set of safe lower-case schemes, or a set containing
+     *            {@link Constants#URL_SAFE_SCHEMES_WILDCARD} to treat any
+     *            scheme as safe
+     * @return {@code true} if the URL is safe, {@code false} otherwise
+     */
+    static boolean isSafeUrl(String url, Set<String> safeSchemes) {
+        if (url == null) {
+            return false;
+        }
+        // A wildcard entry treats every scheme as safe, keeping the behaviour
+        // fully backwards compatible for applications that opt out.
+        if (safeSchemes.contains(Constants.URL_SAFE_SCHEMES_WILDCARD)) {
+            return true;
+        }
+        String trimmed = url.trim();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        // Reject control characters which browsers may strip, allowing a
+        // different URL to be acted upon than the one validated here (for
+        // example "java\tscript:alert(1)").
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (Character.isISOControl(trimmed.charAt(i))) {
+                return false;
+            }
+        }
+        String scheme = extractScheme(trimmed);
+        if (scheme == null) {
+            // Relative URLs have no scheme and cannot trigger scheme-based
+            // script execution.
+            return true;
+        }
+        return safeSchemes.contains(scheme.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Extracts the scheme from the given URL, or returns {@code null} if the
+     * URL is relative (has no scheme). The scheme is determined according to
+     * RFC 3986: a letter followed by any number of letters, digits,
+     * {@code '+'}, {@code '-'} or {@code '.'}, terminated by a {@code ':'} that
+     * occurs before any {@code '/'}, {@code '?'} or {@code '#'}.
+     * <p>
+     * The scheme is extracted without parsing the whole URL so that valid
+     * relative URLs containing characters that a strict URI parser would reject
+     * (such as spaces) are not falsely flagged.
+     */
+    private static String extractScheme(String url) {
+        for (int i = 0; i < url.length(); i++) {
+            char c = url.charAt(i);
+            if (c == ':') {
+                return i == 0 ? null : url.substring(0, i);
+            }
+            boolean validSchemeChar = (i == 0) ? isAlpha(c)
+                    : (isAlpha(c) || (c >= '0' && c <= '9') || c == '+'
+                            || c == '-' || c == '.');
+            if (!validSchemeChar) {
+                // The ':' (if any) belongs to the path or query, so there is no
+                // scheme and the URL is relative.
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isAlpha(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(UrlUtil.class);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.server.VaadinService;
  * @since 2.0
  */
 public class UrlUtil {
+    static final Set<String> ALLOW_ALL_URL_SAFE_SCHEMES = Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD);
 
     private static final Pattern PERCENT_ENCODED = Pattern
             .compile("%([0-9A-Fa-f]{2})");
@@ -254,10 +255,11 @@ public class UrlUtil {
      * <p>
      * The set of safe schemes is read from the current {@link VaadinService}'s
      * {@link DeploymentConfiguration#getUrlSafeSchemes()}, falling back to
-     * {@link Constants#DEFAULT_URL_SAFE_SCHEMES} when no {@link VaadinService}
-     * is available. Relative URLs (without a scheme) are always considered
-     * safe, whereas URLs containing control characters are rejected as they can
-     * be used to obfuscate the scheme. A {@code null} URL is considered unsafe.
+     * {@code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses
+     * the validation and allows all URLs when no {@link VaadinService} is
+     * available. Relative URLs (without a scheme) are always considered safe,
+     * whereas URLs containing control characters are rejected as they can be
+     * used to obfuscate the scheme. A {@code null} URL is considered unsafe.
      *
      * @param url
      *            the URL to check, may be {@code null}
@@ -270,11 +272,11 @@ public class UrlUtil {
             if (getLogger().isDebugEnabled()) {
                 getLogger()
                         .debug("No VaadinService available on current thread; "
-                                + "falling back to default safe URL schemes. "
+                                + "bypassing URL scheme validation. "
                                 + "Any custom {} configuration will not apply "
                                 + "here.", InitParameters.URL_SAFE_SCHEMES);
             }
-            safeSchemes = Constants.DEFAULT_URL_SAFE_SCHEMES;
+            safeSchemes = ALLOW_ALL_URL_SAFE_SCHEMES;
         } else {
             safeSchemes = service.getDeploymentConfiguration()
                     .getUrlSafeSchemes();

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -42,7 +42,8 @@ import com.vaadin.flow.server.VaadinService;
  * @since 2.0
  */
 public class UrlUtil {
-    static final Set<String> ALLOW_ALL_URL_SAFE_SCHEMES = Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD);
+    static final Set<String> ALLOW_ALL_URL_SAFE_SCHEMES = Set
+            .of(Constants.URL_SAFE_SCHEMES_WILDCARD);
 
     private static final Pattern PERCENT_ENCODED = Pattern
             .compile("%([0-9A-Fa-f]{2})");
@@ -255,8 +256,8 @@ public class UrlUtil {
      * <p>
      * The set of safe schemes is read from the current {@link VaadinService}'s
      * {@link DeploymentConfiguration#getUrlSafeSchemes()}, falling back to
-     * {@code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses
-     * the validation and allows all URLs when no {@link VaadinService} is
+     * {@code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses the
+     * validation and allows all URLs when no {@link VaadinService} is
      * available. Relative URLs (without a scheme) are always considered safe,
      * whereas URLs containing control characters are rejected as they can be
      * used to obfuscate the scheme. A {@code null} URL is considered unsafe.

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -15,7 +15,10 @@
  */
 package com.vaadin.flow.server;
 
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
@@ -30,6 +33,8 @@ import com.vaadin.flow.function.DeploymentConfiguration;
  */
 public abstract class AbstractDeploymentConfiguration extends
         AbstractPropertyConfiguration implements DeploymentConfiguration {
+
+    private volatile Set<String> urlSafeSchemes;
 
     /**
      * Creates a new configuration based on {@code properties}.
@@ -50,6 +55,32 @@ public abstract class AbstractDeploymentConfiguration extends
     @Override
     public String getClassLoaderName() {
         return getStringProperty("ClassLoader", null);
+    }
+
+    @Override
+    public Set<String> getUrlSafeSchemes() {
+        Set<String> cached = urlSafeSchemes;
+        if (cached == null) {
+            cached = parseUrlSafeSchemes(
+                    getStringProperty(InitParameters.URL_SAFE_SCHEMES, null));
+            urlSafeSchemes = cached;
+        }
+        return cached;
+    }
+
+    private static Set<String> parseUrlSafeSchemes(String configured) {
+        if (configured == null || configured.isBlank()) {
+            return Constants.DEFAULT_URL_SAFE_SCHEMES;
+        }
+        Set<String> schemes = new HashSet<>();
+        for (String scheme : configured.split(",")) {
+            String trimmed = scheme.trim();
+            if (!trimmed.isEmpty()) {
+                schemes.add(trimmed.toLowerCase(Locale.ROOT));
+            }
+        }
+        return schemes.isEmpty() ? Constants.DEFAULT_URL_SAFE_SCHEMES
+                : Set.copyOf(schemes);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -67,7 +67,10 @@ public abstract class AbstractDeploymentConfiguration extends
                 configured = getStringProperty(
                         InitParameters.URL_SAFE_SCHEMES_LEGACY, null);
             }
-            cached = parseUrlSafeSchemes(configured);
+            final Set<String> parsed = parseUrlSafeSchemes(configured);
+            cached = parsed != null
+                    ? parsed
+                    : DeploymentConfiguration.super.getUrlSafeSchemes();
             urlSafeSchemes = cached;
         }
         return cached;
@@ -75,7 +78,7 @@ public abstract class AbstractDeploymentConfiguration extends
 
     private static Set<String> parseUrlSafeSchemes(String configured) {
         if (configured == null || configured.isBlank()) {
-            return Constants.DEFAULT_URL_SAFE_SCHEMES;
+            return null;
         }
         Set<String> schemes = new HashSet<>();
         for (String scheme : configured.split(",")) {
@@ -84,8 +87,7 @@ public abstract class AbstractDeploymentConfiguration extends
                 schemes.add(trimmed.toLowerCase(Locale.ROOT));
             }
         }
-        return schemes.isEmpty() ? Constants.DEFAULT_URL_SAFE_SCHEMES
-                : Set.copyOf(schemes);
+        return schemes.isEmpty() ? null : Set.copyOf(schemes);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -63,10 +63,6 @@ public abstract class AbstractDeploymentConfiguration extends
         if (cached == null) {
             String configured = getStringProperty(
                     InitParameters.URL_SAFE_SCHEMES, null);
-            if (configured == null) {
-                configured = getStringProperty(
-                        InitParameters.URL_SAFE_SCHEMES_LEGACY, null);
-            }
             final Set<String> parsed = parseUrlSafeSchemes(configured);
             cached = parsed != null ? parsed
                     : DeploymentConfiguration.super.getUrlSafeSchemes();

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -68,8 +68,7 @@ public abstract class AbstractDeploymentConfiguration extends
                         InitParameters.URL_SAFE_SCHEMES_LEGACY, null);
             }
             final Set<String> parsed = parseUrlSafeSchemes(configured);
-            cached = parsed != null
-                    ? parsed
+            cached = parsed != null ? parsed
                     : DeploymentConfiguration.super.getUrlSafeSchemes();
             urlSafeSchemes = cached;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -61,8 +61,13 @@ public abstract class AbstractDeploymentConfiguration extends
     public Set<String> getUrlSafeSchemes() {
         Set<String> cached = urlSafeSchemes;
         if (cached == null) {
-            cached = parseUrlSafeSchemes(
-                    getStringProperty(InitParameters.URL_SAFE_SCHEMES, null));
+            String configured = getStringProperty(
+                    InitParameters.URL_SAFE_SCHEMES, null);
+            if (configured == null) {
+                configured = getStringProperty(
+                        InitParameters.URL_SAFE_SCHEMES_LEGACY, null);
+            }
+            cached = parseUrlSafeSchemes(configured);
             urlSafeSchemes = cached;
         }
         return cached;

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server;
 
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * Constants used by the server side framework.
@@ -430,6 +431,24 @@ public final class Constants implements Serializable {
      * maximum number of files allowed per multipart stream upload requests.
      */
     public static final long DEFAULT_FILE_COUNT_MAX = 10000;
+
+    /**
+     * Default set of URL schemes considered safe when no custom set is
+     * configured through {@link InitParameters#URL_SAFE_SCHEMES}.
+     * <p>
+     * Script-capable schemes such as {@code javascript} and {@code data} are
+     * intentionally excluded as they can be used to execute scripts in the
+     * browser when used as a link or frame target.
+     */
+    public static final Set<String> DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
+            "https", "mailto", "tel", "ftp");
+
+    /**
+     * Special {@link InitParameters#URL_SAFE_SCHEMES} entry that marks every
+     * scheme as safe, disabling scheme validation. Mixing this entry with other
+     * schemes still disables validation.
+     */
+    public static final String URL_SAFE_SCHEMES_WILDCARD = "*";
 
     private Constants() {
         // prevent instantiation constants class only

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -441,9 +441,9 @@ public final class Constants implements Serializable {
      * intentionally excluded as they can be used to execute scripts in the
      * browser when used as a link or frame target.
      * <p>
-     * Important: in this version, the actual default is {@code Set.of("*")},
-     * URL validation is disabled by default. This constant is provided as a
-     * reference for future defaults.
+     * <strong>Note:</strong> in this version, the actual default is
+     * {@code Set.of("*")}, URL validation is disabled by default. This constant
+     * is provided as a reference for future defaults.
      */
     public static final Set<String> DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
             "https", "mailto", "tel", "ftp");

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.server;
 
 import java.io.Serializable;
-import java.util.Set;
 
 /**
  * Constants used by the server side framework.
@@ -431,22 +430,6 @@ public final class Constants implements Serializable {
      * maximum number of files allowed per multipart stream upload requests.
      */
     public static final long DEFAULT_FILE_COUNT_MAX = 10000;
-
-    /**
-     * Future default set of URL schemes considered safe starting from Flow 25.2
-     * and above when no custom set is configured through
-     * {@link InitParameters#URL_SAFE_SCHEMES}.
-     * <p>
-     * Script-capable schemes such as {@code javascript} and {@code data} are
-     * intentionally excluded as they can be used to execute scripts in the
-     * browser when used as a link or frame target.
-     * <p>
-     * <strong>Note:</strong> in this version, the actual default is
-     * {@code Set.of("*")}, URL validation is disabled by default. This constant
-     * is provided as a reference for future defaults.
-     */
-    public static final Set<String> DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
-            "https", "mailto", "tel", "ftp");
 
     /**
      * Special {@link InitParameters#URL_SAFE_SCHEMES} entry that marks every

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -433,17 +433,17 @@ public final class Constants implements Serializable {
     public static final long DEFAULT_FILE_COUNT_MAX = 10000;
 
     /**
-     * Future default set of URL schemes considered safe starting from Flow
-     * 25.2 and above when no custom set is
-     * configured through {@link InitParameters#URL_SAFE_SCHEMES}.
+     * Future default set of URL schemes considered safe starting from Flow 25.2
+     * and above when no custom set is configured through
+     * {@link InitParameters#URL_SAFE_SCHEMES}.
      * <p>
      * Script-capable schemes such as {@code javascript} and {@code data} are
      * intentionally excluded as they can be used to execute scripts in the
      * browser when used as a link or frame target.
      * <p>
      * Important: in this version, the actual default is {@code Set.of("*")},
-     * URL validation is disabled by default.
-     * This constant is provided as a reference for future defaults.
+     * URL validation is disabled by default. This constant is provided as a
+     * reference for future defaults.
      */
     public static final Set<String> DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
             "https", "mailto", "tel", "ftp");

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -433,12 +433,17 @@ public final class Constants implements Serializable {
     public static final long DEFAULT_FILE_COUNT_MAX = 10000;
 
     /**
-     * Default set of URL schemes considered safe when no custom set is
+     * Future default set of URL schemes considered safe starting from Flow
+     * 25.2 and above when no custom set is
      * configured through {@link InitParameters#URL_SAFE_SCHEMES}.
      * <p>
      * Script-capable schemes such as {@code javascript} and {@code data} are
      * intentionally excluded as they can be used to execute scripts in the
      * browser when used as a link or frame target.
+     * <p>
+     * Important: in this version, the actual default is {@code Set.of("*")},
+     * URL validation is disabled by default.
+     * This constant is provided as a reference for future defaults.
      */
     public static final Set<String> DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
             "https", "mailto", "tel", "ftp");

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -347,4 +347,20 @@ public class InitParameters implements Serializable {
      */
     public static final String MINIMUM_FRONTEND_PACKAGE_AGE_DAYS = "npm.minimumFrontendPackageAgeDays";
 
+    /**
+     * Configuration name for the comma-separated list of URL schemes that are
+     * considered safe in URLs set on components such as {@code Anchor},
+     * {@code IFrame} and in
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)}.
+     * <p>
+     * When not set, a built-in default set of safe schemes is used (for example
+     * {@code http}, {@code https}, {@code mailto}, {@code tel} and
+     * {@code ftp}), which excludes script-capable schemes such as
+     * {@code javascript} and {@code data}. Any entry equal to {@code *} marks
+     * every scheme as safe, disabling scheme validation. URLs whose scheme is
+     * not safe can still be set through the dedicated {@code setUnsafe*}
+     * methods.
+     */
+    public static final String URL_SAFE_SCHEMES = "com.vaadin.safeUrlSchemes";
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -363,15 +363,4 @@ public class InitParameters implements Serializable {
      */
     public static final String URL_SAFE_SCHEMES = "safeUrlSchemes";
 
-    /**
-     * Legacy name of the {@link #URL_SAFE_SCHEMES} configuration property, kept
-     * for backwards compatibility with applications configured against Vaadin
-     * 25.2.1. Use {@link #URL_SAFE_SCHEMES} instead; when both are present, the
-     * new name takes precedence.
-     *
-     * @deprecated use {@link #URL_SAFE_SCHEMES} instead
-     */
-    @Deprecated
-    public static final String URL_SAFE_SCHEMES_LEGACY = "com.vaadin.safeUrlSchemes";
-
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -361,6 +361,17 @@ public class InitParameters implements Serializable {
      * not safe can still be set through the dedicated {@code setUnsafe*}
      * methods.
      */
-    public static final String URL_SAFE_SCHEMES = "com.vaadin.safeUrlSchemes";
+    public static final String URL_SAFE_SCHEMES = "safeUrlSchemes";
+
+    /**
+     * Legacy name of the {@link #URL_SAFE_SCHEMES} configuration property, kept
+     * for backwards compatibility with applications configured against Vaadin
+     * 25.2.1. Use {@link #URL_SAFE_SCHEMES} instead; when both are present, the
+     * new name takes precedence.
+     *
+     * @deprecated use {@link #URL_SAFE_SCHEMES} instead
+     */
+    @Deprecated
+    public static final String URL_SAFE_SCHEMES_LEGACY = "com.vaadin.safeUrlSchemes";
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -351,6 +351,95 @@ class PageTest {
     }
 
     @Test
+    void open_unsafeScheme_throws() {
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                return fail("Unsafe URL should not reach the client");
+            }
+        };
+
+        assertThrows(IllegalArgumentException.class,
+                () -> page.open("javascript:alert(1)"));
+        assertThrows(IllegalArgumentException.class,
+                () -> page.open("javascript:alert(1)", "_blank"));
+    }
+
+    @Test
+    void setLocation_unsafeScheme_throws() {
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                return fail("Unsafe URL should not reach the client");
+            }
+        };
+
+        assertThrows(IllegalArgumentException.class,
+                () -> page.setLocation("javascript:alert(1)"));
+    }
+
+    @Test
+    void open_nullUrl_throwsWithUsefulMessage() {
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                return fail("Null URL should not reach the client");
+            }
+        };
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> page.open(null, "_blank"));
+        assertEquals("URL must not be null", ex.getMessage());
+    }
+
+    @Test
+    void openUnsafe_unsafeScheme_opensWithoutValidation() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        List<Object> params = new ArrayList<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                capture.set(expression);
+                params.addAll(Arrays.asList(parameters));
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.openUnsafe("javascript:alert(1)");
+
+        assertTrue(capture.get().contains("window.open"),
+                "Should call window.open");
+        assertEquals("javascript:alert(1)", params.get(0));
+    }
+
+    @Test
+    void openUnsafe_twoArg_opensWithoutValidation() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        List<Object> params = new ArrayList<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                capture.set(expression);
+                params.addAll(Arrays.asList(parameters));
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.openUnsafe("javascript:alert(1)", "_blank");
+
+        assertTrue(capture.get().contains("window.open"),
+                "Should call window.open");
+        assertEquals("javascript:alert(1)", params.get(0));
+        assertEquals("_blank", params.get(1));
+    }
+
+    @Test
     void setColorScheme_setsStyleProperty() {
         AtomicReference<String> capturedExpression = new AtomicReference<>();
         AtomicReference<Object[]> capturedParams = new AtomicReference<>();

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -26,8 +26,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.server.VaadinService;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
@@ -36,8 +34,10 @@ import org.mockito.Mockito;
 import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.tests.util.MockUI;
@@ -50,8 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class PageTest {
-    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
-            "https", "mailto", "tel", "ftp");
+    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = Set
+            .of("http", "https", "mailto", "tel", "ftp");
 
     private class TestUI extends UI {
         @Override
@@ -378,7 +378,7 @@ class PageTest {
             Page page = new Page(new MockUI()) {
                 @Override
                 public PendingJavaScriptResult executeJs(String expression,
-                                                         Object... parameters) {
+                        Object... parameters) {
                     return fail("Unsafe URL should not reach the client");
                 }
             };
@@ -410,7 +410,7 @@ class PageTest {
             Page page = new Page(new MockUI()) {
                 @Override
                 public PendingJavaScriptResult executeJs(String expression,
-                                                         Object... parameters) {
+                        Object... parameters) {
                     return fail("Unsafe URL should not reach the client");
                 }
             };

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -22,12 +22,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import tools.jackson.databind.JsonNode;
 
@@ -38,6 +42,7 @@ import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.tests.util.MockUI;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,6 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class PageTest {
+    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
+            "https", "mailto", "tel", "ftp");
 
     private class TestUI extends UI {
         @Override
@@ -351,33 +358,66 @@ class PageTest {
     }
 
     @Test
-    void open_unsafeScheme_throws() {
-        Page page = new Page(new MockUI()) {
-            @Override
-            public PendingJavaScriptResult executeJs(String expression,
-                    Object... parameters) {
-                return fail("Unsafe URL should not reach the client");
-            }
-        };
-
-        assertThrows(IllegalArgumentException.class,
-                () -> page.open("javascript:alert(1)"));
-        assertThrows(IllegalArgumentException.class,
-                () -> page.open("javascript:alert(1)", "_blank"));
+    void open_unsafeScheme_doesNotThrowByDefault() {
+        assertDoesNotThrow(() -> page.open("javascript:alert(1)"));
+        assertDoesNotThrow(() -> page.open("javascript:alert(1)", "_blank"));
     }
 
     @Test
-    void setLocation_unsafeScheme_throws() {
-        Page page = new Page(new MockUI()) {
-            @Override
-            public PendingJavaScriptResult executeJs(String expression,
-                    Object... parameters) {
-                return fail("Unsafe URL should not reach the client");
-            }
-        };
+    void open_unsafeScheme_throws_withSafeUrlSchemesConfiguration() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
 
-        assertThrows(IllegalArgumentException.class,
-                () -> page.setLocation("javascript:alert(1)"));
+            Page page = new Page(new MockUI()) {
+                @Override
+                public PendingJavaScriptResult executeJs(String expression,
+                                                         Object... parameters) {
+                    return fail("Unsafe URL should not reach the client");
+                }
+            };
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> page.open("javascript:alert(1)"));
+            assertThrows(IllegalArgumentException.class,
+                    () -> page.open("javascript:alert(1)", "_blank"));
+        }
+    }
+
+    @Test
+    void setLocation_unsafeScheme_doesNotThrow() {
+        assertDoesNotThrow(() -> page.setLocation("javascript:alert(1)"));
+    }
+
+    @Test
+    void setLocation_unsafeScheme_throws_withSafeUrlSchemesConfiguration() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+
+            Page page = new Page(new MockUI()) {
+                @Override
+                public PendingJavaScriptResult executeJs(String expression,
+                                                         Object... parameters) {
+                    return fail("Unsafe URL should not reach the client");
+                }
+            };
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> page.setLocation("javascript:alert(1)"));
+        }
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -17,9 +17,15 @@ package com.vaadin.flow.internal;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletService;
 
@@ -203,5 +209,102 @@ class UrlUtilTest {
         String result = UrlUtil.appendQueryParameter("/styles.css", "v-c",
                 null);
         assertEquals("/styles.css", result);
+    }
+
+    @Test
+    void isSafeUrl_safeScheme_returnsTrue() {
+        assertTrue(UrlUtil.isSafeUrl("https://vaadin.com",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_unsafeScheme_returnsFalse() {
+        assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+        assertFalse(UrlUtil.isSafeUrl("data:text/html,<script>",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_schemeMatchIsCaseInsensitive_returnsFalse() {
+        assertFalse(UrlUtil.isSafeUrl("JavaScript:alert(1)",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_relativeUrl_returnsTrue() {
+        assertTrue(UrlUtil.isSafeUrl("/path/to/view",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+        assertTrue(
+                UrlUtil.isSafeUrl("foo", Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_relativeUrlWithSpecialCharacters_returnsTrue() {
+        // A strict URI parser would reject this, but it is a valid relative URL
+        assertTrue(UrlUtil.isSafeUrl("/search?q=a b&x=[1]",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+        // A colon in the path must not be mistaken for a scheme separator
+        assertTrue(UrlUtil.isSafeUrl("/path:with:colon",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_emptyOrBlank_returnsTrue() {
+        assertTrue(UrlUtil.isSafeUrl("", Constants.DEFAULT_URL_SAFE_SCHEMES));
+        assertTrue(
+                UrlUtil.isSafeUrl("   ", Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_null_returnsFalse() {
+        assertFalse(
+                UrlUtil.isSafeUrl(null, Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_controlCharacterObfuscation_returnsFalse() {
+        assertFalse(UrlUtil.isSafeUrl("java\tscript:alert(1)",
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_wildcard_allowsAnyScheme() {
+        assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)",
+                Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)));
+    }
+
+    @Test
+    void isSafeUrl_configuredSchemes_replaceDefaults() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("custom", "https"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+            assertTrue(UrlUtil.isSafeUrl("custom:foo"));
+            assertFalse(UrlUtil.isSafeUrl("mailto:a@b.com"));
+            assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)"));
+        }
+    }
+
+    @Test
+    void isSafeUrl_configuredWildcard_allowsAnyScheme() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+            assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)"));
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -36,6 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UrlUtilTest {
+    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
+            "https", "mailto", "tel", "ftp");
 
     private String encodeURIShouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;,/?:@&=+$-_.!~*'()#";
     private String encodeURIComponentShouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.!~*'()";
@@ -214,58 +216,58 @@ class UrlUtilTest {
     @Test
     void isSafeUrl_safeScheme_returnsTrue() {
         assertTrue(UrlUtil.isSafeUrl("https://vaadin.com",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_unsafeScheme_returnsFalse() {
         assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
         assertFalse(UrlUtil.isSafeUrl("data:text/html,<script>",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_schemeMatchIsCaseInsensitive_returnsFalse() {
         assertFalse(UrlUtil.isSafeUrl("JavaScript:alert(1)",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_relativeUrl_returnsTrue() {
         assertTrue(UrlUtil.isSafeUrl("/path/to/view",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
         assertTrue(
-                UrlUtil.isSafeUrl("foo", Constants.DEFAULT_URL_SAFE_SCHEMES));
+                UrlUtil.isSafeUrl("foo", FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_relativeUrlWithSpecialCharacters_returnsTrue() {
         // A strict URI parser would reject this, but it is a valid relative URL
         assertTrue(UrlUtil.isSafeUrl("/search?q=a b&x=[1]",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
         // A colon in the path must not be mistaken for a scheme separator
         assertTrue(UrlUtil.isSafeUrl("/path:with:colon",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_emptyOrBlank_returnsTrue() {
-        assertTrue(UrlUtil.isSafeUrl("", Constants.DEFAULT_URL_SAFE_SCHEMES));
+        assertTrue(UrlUtil.isSafeUrl("", FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
         assertTrue(
-                UrlUtil.isSafeUrl("   ", Constants.DEFAULT_URL_SAFE_SCHEMES));
+                UrlUtil.isSafeUrl("   ", FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_null_returnsFalse() {
         assertFalse(
-                UrlUtil.isSafeUrl(null, Constants.DEFAULT_URL_SAFE_SCHEMES));
+                UrlUtil.isSafeUrl(null, FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_controlCharacterObfuscation_returnsFalse() {
         assertFalse(UrlUtil.isSafeUrl("java\tscript:alert(1)",
-                Constants.DEFAULT_URL_SAFE_SCHEMES));
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -36,8 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UrlUtilTest {
-    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
-            "https", "mailto", "tel", "ftp");
+    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = Set
+            .of("http", "https", "mailto", "tel", "ftp");
 
     private String encodeURIShouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;,/?:@&=+$-_.!~*'()#";
     private String encodeURIComponentShouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.!~*'()";

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -58,7 +59,6 @@ import com.vaadin.flow.router.RouterTest.CombinedObserverTarget.Enter;
 import com.vaadin.flow.router.RouterTest.CombinedObserverTarget.Leave;
 import com.vaadin.flow.router.internal.DefaultErrorHandler;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
-import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.VaadinService;
@@ -1850,8 +1850,7 @@ public class RouterTest extends RoutingTestBase {
         Mockito.when(service.getRouter()).thenReturn(router);
 
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
-        Mockito.when(configuration.getUrlSafeSchemes())
-                .thenReturn(Constants.DEFAULT_URL_SAFE_SCHEMES);
+        Mockito.when(configuration.getUrlSafeSchemes()).thenReturn(Set.of("*"));
     }
 
     @AfterEach

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -58,6 +58,7 @@ import com.vaadin.flow.router.RouterTest.CombinedObserverTarget.Enter;
 import com.vaadin.flow.router.RouterTest.CombinedObserverTarget.Leave;
 import com.vaadin.flow.router.internal.DefaultErrorHandler;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.VaadinService;
@@ -1849,6 +1850,8 @@ public class RouterTest extends RoutingTestBase {
         Mockito.when(service.getRouter()).thenReturn(router);
 
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
+        Mockito.when(configuration.getUrlSafeSchemes())
+                .thenReturn(Constants.DEFAULT_URL_SAFE_SCHEMES);
     }
 
     @AfterEach

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -27,6 +28,7 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test for {@link AbstractDeploymentConfiguration}
@@ -51,6 +53,31 @@ class AbstractDeploymentConfigurationTest {
         DeploymentConfiguration config = getConfig("ClassLoader", classLoader);
         assertEquals(classLoader, config.getClassLoaderName(),
                 "Unexpected classLoader configuration option value");
+    }
+
+    @Test
+    void getUrlSafeSchemes_propertyNotSet_returnsDefault() {
+        DeploymentConfiguration config = getConfig(null, null);
+        assertEquals(Constants.DEFAULT_URL_SAFE_SCHEMES,
+                config.getUrlSafeSchemes());
+    }
+
+    @Test
+    void getUrlSafeSchemes_commaSeparated_isTrimmedAndLowerCased() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES, " HTTPS , MyApp ");
+        assertEquals(Set.of("https", "myapp"), config.getUrlSafeSchemes());
+    }
+
+    @Test
+    void getUrlSafeSchemes_memoizedAcrossCalls() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES, "custom");
+        Set<String> first = config.getUrlSafeSchemes();
+        Set<String> second = config.getUrlSafeSchemes();
+        assertEquals(Set.of("custom"), first);
+        assertSame(first, second,
+                "Subsequent calls should return the cached instance");
     }
 
     private DeploymentConfiguration getConfig(String property, String value) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -70,22 +70,6 @@ class AbstractDeploymentConfigurationTest {
     }
 
     @Test
-    void getUrlSafeSchemes_legacyPropertyName_stillSupported() {
-        DeploymentConfiguration config = getConfig(
-                InitParameters.URL_SAFE_SCHEMES_LEGACY, " HTTPS , MyApp ");
-        assertEquals(Set.of("https", "myapp"), config.getUrlSafeSchemes());
-    }
-
-    @Test
-    void getUrlSafeSchemes_newPropertyNameTakesPrecedenceOverLegacy() {
-        Properties props = new Properties();
-        props.put(InitParameters.URL_SAFE_SCHEMES, "current");
-        props.put(InitParameters.URL_SAFE_SCHEMES_LEGACY, "legacy");
-        DeploymentConfiguration config = new DeploymentConfigImpl(props);
-        assertEquals(Set.of("current"), config.getUrlSafeSchemes());
-    }
-
-    @Test
     void getUrlSafeSchemes_memoizedAcrossCalls() {
         DeploymentConfiguration config = getConfig(
                 InitParameters.URL_SAFE_SCHEMES, "custom");

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -58,7 +58,7 @@ class AbstractDeploymentConfigurationTest {
     @Test
     void getUrlSafeSchemes_propertyNotSet_returnsDefault() {
         DeploymentConfiguration config = getConfig(null, null);
-        assertEquals(Constants.DEFAULT_URL_SAFE_SCHEMES,
+        assertEquals(Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD),
                 config.getUrlSafeSchemes());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -70,6 +70,22 @@ class AbstractDeploymentConfigurationTest {
     }
 
     @Test
+    void getUrlSafeSchemes_legacyPropertyName_stillSupported() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES_LEGACY, " HTTPS , MyApp ");
+        assertEquals(Set.of("https", "myapp"), config.getUrlSafeSchemes());
+    }
+
+    @Test
+    void getUrlSafeSchemes_newPropertyNameTakesPrecedenceOverLegacy() {
+        Properties props = new Properties();
+        props.put(InitParameters.URL_SAFE_SCHEMES, "current");
+        props.put(InitParameters.URL_SAFE_SCHEMES_LEGACY, "legacy");
+        DeploymentConfiguration config = new DeploymentConfigImpl(props);
+        assertEquals(Set.of("current"), config.getUrlSafeSchemes());
+    }
+
+    @Test
     void getUrlSafeSchemes_memoizedAcrossCalls() {
         DeploymentConfiguration config = getConfig(
                 InitParameters.URL_SAFE_SCHEMES, "custom");


### PR DESCRIPTION
This PR cherry-picks changes from the original PRs #24539 and #24897 to branch 25.1, and also disables the validation by default.

The defaults when "safeUrlSchemes" configuration is missing is adjusted, so that URL validation is disabled by default, and all URLs are considered safe. This avoids unexpected behavior changes for existing users of Flow 25.1 and below.

The URL scheme validation feature could be enabled with configuration when necessary.
