### PR TITLE
test: wait for the web component shadow root, not just the bootstrap script

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
@@ -178,18 +178,39 @@ public abstract class AbstractTestBenchTest extends TestBenchHelpers {
         }
     }
 
-    protected void waitForWebComponentsBootstrap() {
-        waitUntil(driver -> driver.findElement(By.cssSelector(
-                "script[src*='web-component/web-component-bootstrap.js']")),
-                // longer timeout to prevent failures during dev-bundle creation
+    protected void waitForWebComponent(String tagName) {
+        // The long timeout also covers on-demand dev-bundle creation triggered
+        // by the first request.
+        waitUntil(d -> getCommandExecutor()
+                .executeScript("return await customElements.whenDefined('"
+                        + tagName + "').then(() => true)"),
                 60);
     }
 
-    protected void waitForWebComponent(String tagName) {
-        waitForWebComponentsBootstrap();
-        waitUntil(d -> getCommandExecutor()
-                .executeScript("return await customElements.whenDefined('"
-                        + tagName + "').then(() => true)"));
+    /**
+     * Waits until the exported web component with the given tag name has been
+     * bootstrapped, i.e. its shadow root has been created and populated by the
+     * client engine. Unlike {@link #waitForWebComponent(String)} (which waits
+     * only for the custom element to be defined), this also covers the client
+     * engine being loaded and having rendered the embedded application, which
+     * happens asynchronously once the engine module has been imported.
+     *
+     * @param tagName
+     *            the tag name of the exported web component to wait for
+     */
+    protected void waitForWebComponentShadowRoot(String tagName) {
+        // The element constructor synchronously attaches a shadow root that
+        // initially holds only a :host <style>; the embedded application
+        // content
+        // is rendered into it asynchronously once the client engine has loaded.
+        // Wait for a non-style element to appear so the wait covers the whole
+        // bootstrap. The long timeout also covers on-demand dev-bundle
+        // creation.
+        waitUntil(d -> Boolean.TRUE.equals(getCommandExecutor().executeScript(
+                "const e = document.querySelector(arguments[0]);"
+                        + "return !!(e && e.shadowRoot"
+                        + " && e.shadowRoot.querySelector(':not(style)'));",
+                tagName)), 60);
     }
 
     /**

--- a/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -59,7 +59,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void embeddedComponent_expressBuild_componentRendered() {
         open();
-        waitForWebComponentsBootstrap();
+        waitForWebComponentShadowRoot("themed-component");
 
         TestBenchElement themedComponent = $("themed-component").waitForFirst();
 
@@ -91,7 +91,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void applicationTheme_GlobalCss_isUsedOnlyInEmbeddedComponent() {
         open();
-        waitForWebComponentsBootstrap();
+        waitForWebComponentShadowRoot("themed-component");
         checkLogsForErrors();
 
         validateEmbeddedComponent($("themed-component").id("first"), "first");
@@ -147,7 +147,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void documentCssFonts_fontsAreAppliedAndAvailable() {
         open();
-        waitForWebComponentsBootstrap();
+        waitForWebComponentShadowRoot("themed-component");
         checkLogsForErrors();
         final TestBenchElement themedComponent = $("themed-component").first();
         final TestBenchElement embeddedComponent = themedComponent
@@ -170,7 +170,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
     public void documentCssFonts_fromLocalCssFile_fontAppliedToDocumentRoot() {
         open();
-        waitForWebComponentsBootstrap();
+        waitForWebComponentShadowRoot("themed-component");
 
         Object ostrichFontStylesFound = getCommandExecutor().executeScript(
                 "let target = document;" + FIND_FONT_FACE_RULE_SCRIPT);
@@ -183,7 +183,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void documentCssFonts_fromLocalCssFile_fontNotAppliedToEmbeddedComponent() {
         open();
-        waitForWebComponentsBootstrap();
+        waitForWebComponentShadowRoot("themed-component");
 
         Object ostrichFontStylesFoundForEmbedded = getCommandExecutor()
                 .executeScript("let target = document.getElementsByTagName"
@@ -198,7 +198,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void documentCssLinkAddedToHead() {
         open();
-        waitForWebComponentsBootstrap();
+        waitForWebComponentShadowRoot("themed-component");
 
         final WebElement documentHead = getDriver()
                 .findElement(By.xpath("/html/head"));

--- a/flow-tests/test-multi-war/deployment/src/test/java/com/vaadin/flow/multiwar/deployment/TwoAppsIT.java
+++ b/flow-tests/test-multi-war/deployment/src/test/java/com/vaadin/flow/multiwar/deployment/TwoAppsIT.java
@@ -55,7 +55,8 @@ public class TwoAppsIT extends ChromeBrowserTest {
     @Test
     public void bothWebComponentsEmbedded() {
         open();
-        waitForWebComponentsBootstrap();
+        waitForWebComponentShadowRoot("hello-war1");
+        waitForWebComponentShadowRoot("hello-war2");
         WebElement hello1 = findElement(By.id("hello1"));
         WebElement hello2 = findElement(By.id("hello2"));
 


### PR DESCRIPTION
Instead of waiting for a script tag and assuming that a custom element is ready, wait for the custom element shadow root.
