### PR TITLE
fix: parse SNAPSHOT versions with extra qualifier segments

### DIFF
--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -238,8 +238,15 @@ function getFiles(files, folder, pattern) {
  */
 function setVersion(newVersion) {
   const pomContent = fs.readFileSync('pom.xml').toString();
-  const current = RegExp(regexVersion.replace('VERSION', '\\d+\\.\\d+\\-SNAPSHOT')).exec(pomContent)[2];
-  if (current && current != newVersion) {
+  // Match any SNAPSHOT version, including extra qualifier segments such as
+  // `25.3.tsclient-SNAPSHOT`, not just the `\d+\.\d+-SNAPSHOT` shape.
+  const match = RegExp(regexVersion.replace('VERSION', '[\\w.\\-]+?-SNAPSHOT')).exec(pomContent);
+  const current = match && match[2];
+  if (!current) {
+    console.log('No SNAPSHOT version found in pom.xml, nothing to replace');
+    return;
+  }
+  if (current != newVersion) {
     const regexChangeVersion = RegExp(regexVersion.replace('VERSION', current), 'g');
     const files = getFiles([], '.', /.*\/pom.*\.xml$/);
     files.forEach(file => {


### PR DESCRIPTION
setVersion only matched the \d+.\d+-SNAPSHOT shape, so a version with an extra qualifier such as 25.3.tsclient-SNAPSHOT produced no match and crashed on null[2], taking down the whole CI matrix computation before any job ran. Broaden the pattern to any -SNAPSHOT version and guard against a missing match so a mismatch degrades gracefully.
