### PR TITLE
refactor: warn about setItems default change in V26

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProvider.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider.HierarchyFormat;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 
@@ -42,7 +43,17 @@ public interface HasHierarchicalDataProvider<T> extends Serializable {
      *
      * @param treeData
      *            the tree data to set
+     * @deprecated This method will change its behavior in Vaadin 26. It will
+     *             create a {@link TreeDataProvider} with
+     *             {@link HierarchyFormat#FLATTENED}, which may affect TreeGrid
+     *             methods whose behavior depends on the hierarchy format, such
+     *             as {@code scrollToIndex}. To preserve the current behavior,
+     *             create a {@link TreeDataProvider} manually with
+     *             {@link HierarchyFormat#NESTED} and set it via
+     *             {@link #setDataProvider(HierarchicalDataProvider)} instead of
+     *             using this shorthand method.
      */
+    @Deprecated(since = "25.3")
     public default void setTreeData(TreeData<T> treeData) {
         setDataProvider(new TreeDataProvider<>(treeData));
     }
@@ -99,7 +110,17 @@ public interface HasHierarchicalDataProvider<T> extends Serializable {
      * @param childItemProvider
      *            the value provider used to recursively populate the given root
      *            items with child items, not {@code null}
+     * @deprecated This method will change its behavior in Vaadin 26. It will
+     *             create a {@link TreeDataProvider} with
+     *             {@link HierarchyFormat#FLATTENED}, which may affect TreeGrid
+     *             methods whose behavior depends on the hierarchy format, such
+     *             as {@code scrollToIndex}. To preserve the current behavior,
+     *             create a {@link TreeDataProvider} manually with
+     *             {@link HierarchyFormat#NESTED} and set it via
+     *             {@link #setDataProvider(HierarchicalDataProvider)} instead of
+     *             using this shorthand method.
      */
+    @Deprecated(since = "25.3")
     public default void setItems(Collection<T> rootItems,
             ValueProvider<T, Collection<T>> childItemProvider) {
         Objects.requireNonNull(rootItems, "Given root items may not be null");
@@ -143,7 +164,17 @@ public interface HasHierarchicalDataProvider<T> extends Serializable {
      * @param childItemProvider
      *            the value provider used to recursively populate the given root
      *            items with child items, not {@code null}
+     * @deprecated This method will change its behavior in Vaadin 26. It will
+     *             create a {@link TreeDataProvider} with
+     *             {@link HierarchyFormat#FLATTENED}, which may affect TreeGrid
+     *             methods whose behavior depends on the hierarchy format, such
+     *             as {@code scrollToIndex}. To preserve the current behavior,
+     *             create a {@link TreeDataProvider} manually with
+     *             {@link HierarchyFormat#NESTED} and set it via
+     *             {@link #setDataProvider(HierarchicalDataProvider)} instead of
+     *             using this shorthand method.
      */
+    @Deprecated(since = "25.3")
     public default void setItems(Stream<T> rootItems,
             ValueProvider<T, Stream<T>> childItemProvider) {
         Objects.requireNonNull(rootItems, "Given root items may not be null");

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -41,11 +41,10 @@ public class TreeDataProvider<T>
      *             {@link HierarchyFormat#NESTED}, but starting from Vaadin 26
      *             it will default to {@link HierarchyFormat#FLATTENED} instead.
      *             This may affect TreeGrid methods whose behavior depends on
-     *             the hierarchy format, such as {@code scrollToIndex}. To avoid
-     *             unexpected changes, switch to
-     *             {@link #TreeDataProvider(TreeData, HierarchyFormat)} and pass
-     *             {@link HierarchyFormat#NESTED} explicitly to keep the current
-     *             default behavior.
+     *             the hierarchy format, such as {@code scrollToIndex}. Switch
+     *             to {@link #TreeDataProvider(TreeData, HierarchyFormat)} and
+     *             pass {@link HierarchyFormat#NESTED} explicitly to preserve
+     *             the current behavior.
      */
     @Deprecated(since = "25.3")
     public TreeDataProvider(TreeData<T> treeData) {


### PR DESCRIPTION
#24908 deprecated the single-argument `TreeDataProvider` constructor because its default `HierarchyFormat` will change from `NESTED` to `FLATTENED` in Vaadin 26.

The `setItems` and `setTreeData` shorthand methods create that provider under the hood, so they will change their behavior in the same way. This deprecates them too, so the change is visible, and points users to `setDataProvider` with an explicit `HierarchyFormat.NESTED` to keep the current behavior.

Follow-up to #24908