### PR TITLE
feat: validate URL schemes in Anchor, IFrame and Page#open (CP: 2.13)

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -18,7 +18,10 @@ import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
 
@@ -58,6 +61,13 @@ public class Anchor extends HtmlContainer implements Focusable<Anchor> {
      *            the href to set
      * @param text
      *            the text content to set
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, String text) {
         setHref(href);
@@ -77,6 +87,13 @@ public class Anchor extends HtmlContainer implements Focusable<Anchor> {
      *            the text content to set
      * @param target
      *            the target window, tab or frame
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, String text, AnchorTarget target) {
         setHref(href);
@@ -112,6 +129,13 @@ public class Anchor extends HtmlContainer implements Focusable<Anchor> {
      *            the href to set
      * @param components
      *            the components to add
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, Component... components) {
         setHref(href);
@@ -132,8 +156,42 @@ public class Anchor extends HtmlContainer implements Focusable<Anchor> {
      *
      * @param href
      *            the href to set
+     * @throws IllegalArgumentException
+     *             if the URL uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setHref(String href) {
+        if (href == null) {
+            throw new IllegalArgumentException("Href must not be null");
+        }
+        if (!UrlUtil.isSafeUrl(href)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "href", href, "setUnsafeHref(String)"));
+        }
+        this.href = href;
+        assignHrefAttribute();
+    }
+
+    /**
+     * Sets the URL that this anchor links to without validating its scheme.
+     * <p>
+     * Unlike {@link #setHref(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} or {@code data:} URL. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #setHref(String)
+     *
+     * @param href
+     *            the href to set
+     */
+    public void setUnsafeHref(String href) {
         if (href == null) {
             throw new IllegalArgumentException("Href must not be null");
         }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -12,6 +12,9 @@ import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -116,6 +119,13 @@ public class IFrame extends HtmlComponent {
      *
      * @param src
      *            Source URL
+     * @throws IllegalArgumentException
+     *             if {@code src} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeSrc(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public IFrame(String src) {
         setSrc(src);
@@ -126,8 +136,38 @@ public class IFrame extends HtmlComponent {
      *
      * @param src
      *            Source URL.
+     * @throws IllegalArgumentException
+     *             if the URL uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeSrc(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setSrc(String src) {
+        if (src != null && !UrlUtil.isSafeUrl(src)) {
+            throw new IllegalArgumentException(UrlUtil
+                    .getUnsafeUrlMessage("src", src, "setUnsafeSrc(String)"));
+        }
+        set(srcDescriptor, src);
+    }
+
+    /**
+     * Sets the source of the iframe without validating its scheme.
+     * <p>
+     * Unlike {@link #setSrc(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe, such as
+     * a hard-coded {@code javascript:} or {@code data:} URL. Passing untrusted
+     * input here can expose the application to cross-site scripting (XSS)
+     * attacks.
+     *
+     * @see #setSrc(String)
+     *
+     * @param src
+     *            Source URL.
+     */
+    public void setUnsafeSrc(String src) {
         set(srcDescriptor, src);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 
 /**
@@ -89,6 +90,10 @@ public class Image extends HtmlContainer implements ClickNotifier<Image> {
 
     /**
      * Sets the image URL.
+     * <p>
+     * Unlike {@link Anchor#setHref(String)} and {@link IFrame#setSrc(String)},
+     * image URLs are not validated against the
+     * {@value InitParameters#URL_SAFE_SCHEMES} configuration.
      *
      * @param src
      *            the image URL

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -233,6 +233,40 @@ public class AnchorTest extends ComponentTest {
         Assert.assertNotEquals(href, anchor.getHref());
     }
 
+    @Test
+    public void setHref_unsafeScheme_throws() {
+        Anchor anchor = new Anchor();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> anchor.setHref("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeHref_unsafeScheme_setsHrefWithoutValidation() {
+        Anchor anchor = new Anchor();
+        anchor.setUnsafeHref("javascript:alert(1)");
+        Assert.assertEquals("javascript:alert(1)",
+                anchor.getElement().getAttribute("href"));
+    }
+
+    @Test
+    public void constructor_stringHrefStringText_unsafeScheme_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)", "Click"));
+    }
+
+    @Test
+    public void constructor_stringHrefStringTextTarget_unsafeScheme_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)", "Click",
+                        AnchorTarget.BLANK));
+    }
+
+    @Test
+    public void constructor_stringHrefComponents_unsafeScheme_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)"));
+    }
+
     private void mockUI() {
         ui = new UI();
         UI.setCurrent(ui);

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
@@ -17,19 +17,26 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 
 public abstract class ComponentTest {
 
@@ -37,6 +44,28 @@ public abstract class ComponentTest {
     private List<ComponentProperty> properties = new ArrayList<>();
 
     private Set<String> WHITE_LIST = new HashSet<>();
+
+    private static MockedStatic<VaadinService> vaadinServiceMockedStatic;
+
+    @BeforeClass
+    public static void init() {
+        // Mock strict Flow 25.2+ safe URL scheme validation configuration
+        // for feature validation in component tests (AnchorTest, IFrameTest)
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes()).thenReturn(new HashSet<>(
+                Arrays.asList("http", "https", "mailto", "tel", "ftp")));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMockedStatic = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMockedStatic.when(VaadinService::getCurrent)
+                .thenReturn(service);
+    }
+
+    @AfterClass
+    public static void clean() {
+        vaadinServiceMockedStatic.close();
+    }
 
     @Before
     public void setup() throws IntrospectionException, InstantiationException,

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -222,6 +222,16 @@ public class HtmlComponentSmokeTest {
             return true;
         }
 
+        if (method.getDeclaringClass() == IFrame.class
+                && method.getName().equals("setUnsafeSrc")) {
+            return true;
+        }
+
+        if (method.getDeclaringClass() == Anchor.class
+                && method.getName().equals("setUnsafeHref")) {
+            return true;
+        }
+
         return false;
     }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -8,6 +8,9 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 public class IFrameTest extends ComponentTest {
 
     // Actual test methods in super class
@@ -27,5 +30,25 @@ public class IFrameTest extends ComponentTest {
                 new IFrame.SandboxType[] { IFrame.SandboxType.ALLOW_POPUPS,
                         IFrame.SandboxType.ALLOW_MODALS },
                 true, true);
+    }
+
+    @Test
+    public void setSrc_unsafeScheme_throws() {
+        IFrame iframe = new IFrame();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> iframe.setSrc("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeSrc_unsafeScheme_setsSrcWithoutValidation() {
+        IFrame iframe = new IFrame();
+        iframe.setUnsafeSrc("javascript:alert(1)");
+        Assert.assertEquals("javascript:alert(1)", iframe.getSrc());
+    }
+
+    @Test
+    public void constructor_unsafeSrc_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new IFrame("javascript:alert(1)"));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -31,8 +31,10 @@ import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;
@@ -460,6 +462,13 @@ public class Page implements Serializable {
      *
      * @param url
      *            the URL to open.
+     * @throws IllegalArgumentException
+     *             if {@code url} is {@code null}, or if the URL uses a scheme
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #openUnsafe(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void open(String url) {
         open(url, "_blank");
@@ -502,8 +511,68 @@ public class Page implements Serializable {
      *            the URL to open.
      * @param windowName
      *            the name of the window.
+     * @throws IllegalArgumentException
+     *             if {@code url} is {@code null}, or if the URL uses a scheme
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #openUnsafe(String, String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void open(String url, String windowName) {
+        if (url == null) {
+            throw new IllegalArgumentException("URL must not be null");
+        }
+        if (!UrlUtil.isSafeUrl(url)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "URL", url, "openUnsafe(String, String)"));
+        }
+        openInternal(url, windowName);
+    }
+
+    /**
+     * Opens the given url in a new tab without validating its scheme.
+     * <p>
+     * Unlike {@link #open(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #open(String)
+     *
+     * @param url
+     *            the URL to open.
+     */
+    public void openUnsafe(String url) {
+        openInternal(url, "_blank");
+    }
+
+    /**
+     * Opens the given URL in a window with the given name without validating
+     * its scheme.
+     * <p>
+     * Unlike {@link #open(String, String)}, this method does not reject URLs
+     * based on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use
+     * it only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #open(String, String)
+     *
+     * @param url
+     *            the URL to open.
+     * @param windowName
+     *            the name of the window.
+     */
+    public void openUnsafe(String url, String windowName) {
+        openInternal(url, windowName);
+    }
+
+    private void openInternal(String url, String windowName) {
+        // The vaadin-redirect-pending event might be useful to block other
+        // client side
+        // reload/redirection triggered by other components, for example Vite.
         executeJs(
                 "if ($1 == '_self') this.stopApplication(); window.open($0, $1)",
                 url, windowName);
@@ -515,6 +584,13 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @throws IllegalArgumentException
+     *             if {@code uri} is {@code null}, or if the URI uses a scheme
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; call
+     *             {@code openUnsafe(uri, "_self")} to bypass scheme validation,
+     *             and see the {@value InitParameters#URL_SAFE_SCHEMES}
+     *             configuration property
      */
     public void setLocation(String uri) {
         open(uri, "_self");
@@ -526,6 +602,14 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @throws IllegalArgumentException
+     *             if {@code uri} is {@code null}, or if the URI uses a scheme
+     *             that is not considered safe according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; call
+     *             {@code openUnsafe(uri.toString(), "_self")} to bypass scheme
+     *             validation, and see the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setLocation(URI uri) {
         setLocation(uri.toString());

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -11,8 +11,10 @@ package com.vaadin.flow.function;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 
 import com.vaadin.flow.server.Constants;
@@ -429,6 +431,27 @@ public interface DeploymentConfiguration extends Serializable {
     default boolean reuseDevServer() {
         return getBooleanProperty(
                 InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER, true);
+    }
+
+    /**
+     * Returns the set of URL schemes considered safe in URLs set on components
+     * such as {@code Anchor}, {@code IFrame} and in
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)}.
+     * <p>
+     * Concrete implementations read this from the
+     * {@link InitParameters#URL_SAFE_SCHEMES} property; the default returns
+     * {@code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses the
+     * validation and allows all URLs.
+     * <p>
+     * <strong>Note:</strong> the default changes in future Flow versions.
+     * Starting from Flow 25.2, the default safe schemes are "http", "https",
+     * "mailto", "tel", "ftp". Script-capable schemes such as {@code javascript}
+     * and {@code data} will be intentionally excluded.
+     *
+     * @return the set of safe URL schemes, never {@code null}
+     */
+    default Set<String> getUrlSafeSchemes() {
+        return Collections.singleton(Constants.URL_SAFE_SCHEMES_WILDCARD);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -13,6 +13,19 @@ import com.vaadin.flow.shared.ApplicationConstants;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * Internal utility class for URL handling.
@@ -23,6 +36,8 @@ import java.nio.charset.StandardCharsets;
  * @since 2.0
  */
 public class UrlUtil {
+    static final Set<String> ALLOW_ALL_URL_SAFE_SCHEMES = Collections
+            .singleton(Constants.URL_SAFE_SCHEMES_WILDCARD);
 
     private UrlUtil() {
     }
@@ -97,4 +112,144 @@ public class UrlUtil {
         }
     }
 
+    /**
+     * Checks whether the scheme of the given URL is considered safe by the
+     * current deployment configuration.
+     * <p>
+     * The set of safe schemes is read from the current {@link VaadinService}'s
+     * {@link DeploymentConfiguration#getUrlSafeSchemes()}, falling back to
+     * {@code Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)}, which bypasses the
+     * validation and allows all URLs when no {@link VaadinService} is
+     * available. Relative URLs (without a scheme) are always considered safe,
+     * whereas URLs containing control characters are rejected as they can be
+     * used to obfuscate the scheme. A {@code null} URL is considered unsafe.
+     *
+     * @param url
+     *            the URL to check, may be {@code null}
+     * @return {@code true} if the URL is safe, {@code false} otherwise
+     */
+    public static boolean isSafeUrl(String url) {
+        VaadinService service = VaadinService.getCurrent();
+        Set<String> safeSchemes;
+        if (service == null) {
+            if (getLogger().isDebugEnabled()) {
+                getLogger()
+                        .debug("No VaadinService available on current thread; "
+                                + "bypassing URL scheme validation. "
+                                + "Any custom {} configuration will not apply "
+                                + "here.", InitParameters.URL_SAFE_SCHEMES);
+            }
+            safeSchemes = ALLOW_ALL_URL_SAFE_SCHEMES;
+        } else {
+            safeSchemes = service.getDeploymentConfiguration()
+                    .getUrlSafeSchemes();
+        }
+        return isSafeUrl(url, safeSchemes);
+    }
+
+    /**
+     * Builds the message for the {@link IllegalArgumentException} that a
+     * validating URL setter throws when given a URL whose scheme is not
+     * considered safe. The message points to both the
+     * {@link InitParameters#URL_SAFE_SCHEMES} configuration property and the
+     * setter that bypasses validation.
+     *
+     * @param type
+     *            the kind of URL being set, for example {@code "href"},
+     *            {@code "src"} or {@code "path"}
+     * @param url
+     *            the rejected URL
+     * @param unsafeMethod
+     *            the signature of the method that bypasses validation, for
+     *            example {@code "setUnsafeHref(String)"}
+     * @return the exception message
+     */
+    public static String getUnsafeUrlMessage(String type, String url,
+            String unsafeMethod) {
+        return String.format(
+                "The %s \"%s\" uses a scheme that is not considered safe. "
+                        + "Configure the safe schemes with the \"%s\" property, "
+                        + "or use %s if this URL is intentional and trusted.",
+                type, url, InitParameters.URL_SAFE_SCHEMES, unsafeMethod);
+    }
+
+    /**
+     * Checks whether the scheme of the given URL is part of the given set of
+     * safe schemes. See {@link #isSafeUrl(String)} for the validation rules. A
+     * {@code null} URL is considered unsafe.
+     *
+     * @param url
+     *            the URL to check, may be {@code null}
+     * @param safeSchemes
+     *            the set of safe lower-case schemes, or a set containing
+     *            {@link Constants#URL_SAFE_SCHEMES_WILDCARD} to treat any
+     *            scheme as safe
+     * @return {@code true} if the URL is safe, {@code false} otherwise
+     */
+    static boolean isSafeUrl(String url, Set<String> safeSchemes) {
+        if (url == null) {
+            return false;
+        }
+        // A wildcard entry treats every scheme as safe, keeping the behaviour
+        // fully backwards compatible for applications that opt out.
+        if (safeSchemes.contains(Constants.URL_SAFE_SCHEMES_WILDCARD)) {
+            return true;
+        }
+        String trimmed = url.trim();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        // Reject control characters which browsers may strip, allowing a
+        // different URL to be acted upon than the one validated here (for
+        // example "java\tscript:alert(1)").
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (Character.isISOControl(trimmed.charAt(i))) {
+                return false;
+            }
+        }
+        String scheme = extractScheme(trimmed);
+        if (scheme == null) {
+            // Relative URLs have no scheme and cannot trigger scheme-based
+            // script execution.
+            return true;
+        }
+        return safeSchemes.contains(scheme.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Extracts the scheme from the given URL, or returns {@code null} if the
+     * URL is relative (has no scheme). The scheme is determined according to
+     * RFC 3986: a letter followed by any number of letters, digits,
+     * {@code '+'}, {@code '-'} or {@code '.'}, terminated by a {@code ':'} that
+     * occurs before any {@code '/'}, {@code '?'} or {@code '#'}.
+     * <p>
+     * The scheme is extracted without parsing the whole URL so that valid
+     * relative URLs containing characters that a strict URI parser would reject
+     * (such as spaces) are not falsely flagged.
+     */
+    private static String extractScheme(String url) {
+        for (int i = 0; i < url.length(); i++) {
+            char c = url.charAt(i);
+            if (c == ':') {
+                return i == 0 ? null : url.substring(0, i);
+            }
+            boolean validSchemeChar = (i == 0) ? isAlpha(c)
+                    : (isAlpha(c) || (c >= '0' && c <= '9') || c == '+'
+                            || c == '-' || c == '.');
+            if (!validSchemeChar) {
+                // The ':' (if any) belongs to the path or query, so there is no
+                // scheme and the URL is relative.
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isAlpha(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(UrlUtil.class);
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -8,6 +8,11 @@
  */
 package com.vaadin.flow.server;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
 
@@ -22,6 +27,8 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 public abstract class AbstractDeploymentConfiguration
         implements DeploymentConfiguration {
 
+    private volatile Set<String> urlSafeSchemes;
+
     @Override
     public String getUIClassName() {
         return getStringProperty(InitParameters.UI_PARAMETER,
@@ -31,6 +38,34 @@ public abstract class AbstractDeploymentConfiguration
     @Override
     public String getClassLoaderName() {
         return getStringProperty("ClassLoader", null);
+    }
+
+    @Override
+    public Set<String> getUrlSafeSchemes() {
+        Set<String> cached = urlSafeSchemes;
+        if (cached == null) {
+            String configured = getStringProperty(
+                    InitParameters.URL_SAFE_SCHEMES, null);
+            final Set<String> parsed = parseUrlSafeSchemes(configured);
+            cached = parsed != null ? parsed
+                    : DeploymentConfiguration.super.getUrlSafeSchemes();
+            urlSafeSchemes = cached;
+        }
+        return cached;
+    }
+
+    private static Set<String> parseUrlSafeSchemes(String configured) {
+        if (configured == null || configured.trim().isEmpty()) {
+            return null;
+        }
+        Set<String> schemes = new HashSet<>();
+        for (String scheme : configured.split(",")) {
+            String trimmed = scheme.trim();
+            if (!trimmed.isEmpty()) {
+                schemes.add(trimmed.toLowerCase(Locale.ROOT));
+            }
+        }
+        return schemes.isEmpty() ? null : Collections.unmodifiableSet(schemes);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -532,6 +532,13 @@ public final class Constants implements Serializable {
     // Non-default port currently not supported (#7970)
     public static final int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;
 
+    /**
+     * Special {@link InitParameters#URL_SAFE_SCHEMES} entry that marks every
+     * scheme as safe, disabling scheme validation. Mixing this entry with other
+     * schemes still disables validation.
+     */
+    public static final String URL_SAFE_SCHEMES_WILDCARD = "*";
+
     private Constants() {
         // prevent instantiation constants class only
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -270,4 +270,20 @@ public class InitParameters implements Serializable {
      * @since
      */
     public static final String APPLICATION_PARAMETER_DEVMODE_ENABLE_COMPONENT_TRACKER = "devmode.componentTracker.enabled";
+
+    /**
+     * Configuration name for the comma-separated list of URL schemes that are
+     * considered safe in URLs set on components such as {@code Anchor},
+     * {@code IFrame} and in
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)}.
+     * <p>
+     * When not set, a built-in default set of safe schemes is used (for example
+     * {@code http}, {@code https}, {@code mailto}, {@code tel} and
+     * {@code ftp}), which excludes script-capable schemes such as
+     * {@code javascript} and {@code data}. Any entry equal to {@code *} marks
+     * every scheme as safe, disabling scheme validation. URLs whose scheme is
+     * not safe can still be set through the dedicated {@code setUnsafe*}
+     * methods.
+     */
+    public static final String URL_SAFE_SCHEMES = "safeUrlSchemes";
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -14,21 +14,26 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.Page.ExecutionCanceler;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;
@@ -38,6 +43,8 @@ import elemental.json.Json;
 import elemental.json.JsonValue;
 
 public class PageTest {
+    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = new HashSet<>(
+            Arrays.asList("http", "https", "mailto", "tel", "ftp"));
 
     private class TestUI extends UI {
         @Override
@@ -441,5 +448,128 @@ public class PageTest {
 
         Assert.assertThat(capture.get(), CoreMatchers
                 .startsWith("if ($1 == '_self') this.stopApplication();"));
+    }
+
+    @Test
+    public void open_unsafeScheme_doesNotThrowByDefault() {
+        page.open("javascript:alert(1)");
+        page.open("javascript:alert(1)", "_blank");
+    }
+
+    @Test
+    public void open_unsafeScheme_throws_withSafeUrlSchemesConfiguration() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                throw new AssertionError(
+                        "Unsafe URL should not reach the client");
+            }
+        };
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> page.open("javascript:alert(1)"));
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> page.open("javascript:alert(1)", "_blank"));
+        }
+    }
+
+    @Test
+    public void setLocation_unsafeScheme_doesNotThrow() {
+        page.setLocation("javascript:alert(1)");
+    }
+
+    @Test
+    public void setLocation_unsafeScheme_throws_withSafeUrlSchemesConfiguration() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                throw new AssertionError(
+                        "Unsafe URL should not reach the client");
+            }
+        };
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> page.setLocation("javascript:alert(1)"));
+        }
+    }
+
+    @Test
+    public void open_nullUrl_throwsWithUsefulMessage() {
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                throw new AssertionError(
+                        "Null URL should not reach the client");
+            }
+        };
+
+        IllegalArgumentException ex = Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> page.open(null, "_blank"));
+        Assert.assertEquals("URL must not be null", ex.getMessage());
+    }
+
+    @Test
+    public void openUnsafe_unsafeScheme_opensWithoutValidation() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        List<Object> params = new ArrayList<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                capture.set(expression);
+                params.addAll(Arrays.asList(parameters));
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.openUnsafe("javascript:alert(1)");
+
+        Assert.assertTrue("Should call window.open",
+                capture.get().contains("window.open"));
+        Assert.assertEquals("javascript:alert(1)", params.get(0));
+    }
+
+    @Test
+    public void openUnsafe_twoArg_opensWithoutValidation() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        List<Object> params = new ArrayList<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                capture.set(expression);
+                params.addAll(Arrays.asList(parameters));
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.openUnsafe("javascript:alert(1)", "_blank");
+
+        Assert.assertTrue("Should call window.open",
+                capture.get().contains("window.open"));
+        Assert.assertEquals("javascript:alert(1)", params.get(0));
+        Assert.assertEquals("_blank", params.get(1));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -8,10 +8,23 @@
  */
 package com.vaadin.flow.internal;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.VaadinService;
 
 public class UrlUtilTest {
+    private static final Set<String> FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES = new HashSet<>(
+            Arrays.asList("http", "https", "mailto", "tel", "ftp"));
 
     private String encodeURIShouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;,/?:@&=+$-_.!~*'()#";
     private String encodeURIComponentShouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.!~*'()";
@@ -73,6 +86,104 @@ public class UrlUtilTest {
                 continue;
             }
             Assert.assertNotEquals(UrlUtil.encodeURIComponent(s), s);
+        }
+    }
+
+    @Test
+    public void isSafeUrl_safeScheme_returnsTrue() {
+        Assert.assertTrue(UrlUtil.isSafeUrl("https://vaadin.com",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_unsafeScheme_returnsFalse() {
+        Assert.assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+        Assert.assertFalse(UrlUtil.isSafeUrl("data:text/html,<script>",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_schemeMatchIsCaseInsensitive_returnsFalse() {
+        Assert.assertFalse(UrlUtil.isSafeUrl("JavaScript:alert(1)",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_relativeUrl_returnsTrue() {
+        Assert.assertTrue(UrlUtil.isSafeUrl("/path/to/view",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+        Assert.assertTrue(
+                UrlUtil.isSafeUrl("foo", FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_relativeUrlWithSpecialCharacters_returnsTrue() {
+        // A strict URI parser would reject this, but it is a valid relative URL
+        Assert.assertTrue(UrlUtil.isSafeUrl("/search?q=a b&x=[1]",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+        // A colon in the path must not be mistaken for a scheme separator
+        Assert.assertTrue(UrlUtil.isSafeUrl("/path:with:colon",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_emptyOrBlank_returnsTrue() {
+        Assert.assertTrue(
+                UrlUtil.isSafeUrl("", FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+        Assert.assertTrue(
+                UrlUtil.isSafeUrl("   ", FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_null_returnsFalse() {
+        Assert.assertFalse(
+                UrlUtil.isSafeUrl(null, FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_controlCharacterObfuscation_returnsFalse() {
+        Assert.assertFalse(UrlUtil.isSafeUrl("java\tscript:alert(1)",
+                FUTURE_25_2_DEFAULT_URL_SAFE_SCHEMES));
+    }
+
+    @Test
+    public void isSafeUrl_wildcard_allowsAnyScheme() {
+        Assert.assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)",
+                Collections.singleton(Constants.URL_SAFE_SCHEMES_WILDCARD)));
+    }
+
+    @Test
+    public void isSafeUrl_configuredSchemes_replaceDefaults() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(new HashSet<>(Arrays.asList("custom", "https")));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+            Assert.assertTrue(UrlUtil.isSafeUrl("custom:foo"));
+            Assert.assertFalse(UrlUtil.isSafeUrl("mailto:a@b.com"));
+            Assert.assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)"));
+        }
+    }
+
+    @Test
+    public void isSafeUrl_configuredWildcard_allowsAnyScheme() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes()).thenReturn(
+                Collections.singleton(Constants.URL_SAFE_SCHEMES_WILDCARD));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+            Assert.assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)"));
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -1688,6 +1688,8 @@ public class RouterTest extends RoutingTestBase {
         Mockito.when(service.getRouter()).thenReturn(router);
 
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
+        Mockito.when(configuration.getUrlSafeSchemes())
+                .thenReturn(Collections.singleton("*"));
     }
 
     @After

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -8,8 +8,12 @@
  */
 package com.vaadin.flow.server;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -42,6 +46,33 @@ public class AbstractDeploymentConfigurationTest {
         DeploymentConfiguration config = getConfig("ClassLoader", classLoader);
         Assert.assertEquals("Unexpected classLoader configuration option value",
                 classLoader, config.getClassLoaderName());
+    }
+
+    @Test
+    public void getUrlSafeSchemes_propertyNotSet_returnsDefault() {
+        DeploymentConfiguration config = getConfig(null, null);
+        Assert.assertEquals(
+                Collections.singleton(Constants.URL_SAFE_SCHEMES_WILDCARD),
+                config.getUrlSafeSchemes());
+    }
+
+    @Test
+    public void getUrlSafeSchemes_commaSeparated_isTrimmedAndLowerCased() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES, " HTTPS , MyApp ");
+        Assert.assertEquals(new HashSet<>(Arrays.asList("https", "myapp")),
+                config.getUrlSafeSchemes());
+    }
+
+    @Test
+    public void getUrlSafeSchemes_memoizedAcrossCalls() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES, "custom");
+        Set<String> first = config.getUrlSafeSchemes();
+        Set<String> second = config.getUrlSafeSchemes();
+        Assert.assertEquals(Collections.singleton("custom"), first);
+        Assert.assertSame("Subsequent calls should return the cached instance",
+                first, second);
     }
 
     private DeploymentConfiguration getConfig(String property, String value) {


### PR DESCRIPTION
This PR cherry-picks changes from the original PRs #24539 and #24897 to branch 25.1, and also disables the validation by default.

The defaults when "safeUrlSchemes" configuration is missing is adjusted, so that URL validation is disabled by default, and all URLs are considered safe. This avoids unexpected behavior changes for existing users of Flow 25.1 and below.

The URL scheme validation feature could be enabled with configuration when necessary.