### PR TITLE
test: count only stylesheet links in documentCssLinkAddedToHead

### DIFF
--- a/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -202,8 +202,13 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
         final WebElement documentHead = getDriver()
                 .findElement(By.xpath("/html/head"));
+        // Only stylesheet links matter here. The code-split TypeScript client
+        // engine (ApplicationConnection and its theme chunk are loaded lazily
+        // to
+        // stay out of the ES5/HtmlUnit bundle) makes the bundler add
+        // <link rel="modulepreload"> entries that are unrelated to the theme.
         final List<WebElement> links = documentHead
-                .findElements(By.tagName("link"));
+                .findElements(By.cssSelector("link[rel='stylesheet']"));
         Assert.assertEquals(1, links.size());
         String documentCssURL = links.get(0).getAttribute("href");
         Assert.assertTrue(documentCssURL


### PR DESCRIPTION
The test asserted the embedded page's `<head>` contains exactly one `<link>` when it really wants to assert that there is only one stylesheet loaded with a `<link>`

Scope the assertion to stylesheet links so it verifies what it means to -- that the embedded theme's document.css is the single stylesheet added to the head.
