### PR TITLE
test: remove real Vaadin components from vaadin-spring-tests

### DIFF
--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -72,10 +72,19 @@
       <artifactId>flow-html-components</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Faux Lumo replacements for the real vaadin-lumo-theme: the Lumo
+         class satisfies Flow's classpath detection for @Theme(name), and
+         test-lumo-theme ships the fake lumo/fake-lumo.css public resource.
+         Neither pulls any Vaadin component npm packages. -->
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-lumo-theme</artifactId>
-      <version>${component.version}</version>
+      <artifactId>flow-test-lumo</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>test-lumo-theme</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/frontend/benchmark.js
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/frontend/benchmark.js
@@ -1,15 +1,5 @@
-import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-
-const globalStyles = css`
+const globalStyles = `
   @keyframes element-rendered {
-  }
-
-  /*
-  * The attribute selector makes sure the element which animates isn't just a tag but an upgraded web component
-  * (button logic adds the role="button" attribute to the host element).
-  */
-  vaadin-button[role='button'] {
-    animation: element-rendered;
   }
 
   button {
@@ -28,7 +18,7 @@ const globalStyles = css`
 `;
 
 const style = document.createElement('style');
-style.textContent = globalStyles.cssText;
+style.textContent = globalStyles;
 document.head.appendChild(style);
 window.layout = window.layout || {};
 

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/UploadIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/UploadIT.java
@@ -24,11 +24,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.WrapsElement;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebElement;
-
-import com.vaadin.testbench.TestBenchElement;
 
 import static com.vaadin.flow.spring.test.UploadView.UPLOAD_ID;
 
@@ -46,9 +41,7 @@ public class UploadIT extends AbstractSpringTest {
 
         File tempFile = createTempFile("foo");
 
-        TestBenchElement input = $(TestBenchElement.class).id(UPLOAD_ID);
-        setLocalFileDetector(input);
-        input.sendKeys(tempFile.getPath());
+        uploadFileToNativeInput(UPLOAD_ID, tempFile);
 
         waitUntil(driver -> isElementPresent(By.className("uploaded-text")));
         WebElement uploadedText = findElement(By.className("uploaded-text"));
@@ -79,23 +72,5 @@ public class UploadIT extends AbstractSpringTest {
         writer.close();
         tempFile.deleteOnExit();
         return tempFile;
-    }
-
-    private void setLocalFileDetector(WebElement element) throws Exception {
-        if (getRunLocallyBrowser() != null) {
-            return;
-        }
-
-        if (element instanceof WrapsElement) {
-            element = ((WrapsElement) element).getWrappedElement();
-        }
-        if (element instanceof RemoteWebElement) {
-            ((RemoteWebElement) element)
-                    .setFileDetector(new LocalFileDetector());
-        } else {
-            throw new IllegalArgumentException(
-                    "Expected argument of type RemoteWebElement, received "
-                            + element.getClass().getName());
-        }
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-helpers/src/main/java/com/vaadin/flow/spring/test/LoanApplicationUpload.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-helpers/src/main/java/com/vaadin/flow/spring/test/LoanApplicationUpload.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.function.Supplier;
+
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.html.H4;
+import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.server.StreamRegistration;
+import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.UploadHandler;
+
+/**
+ * The "upload your loan application" UI shared by the Spring Security test
+ * apps. It uses a native {@code <input type="file">} that posts the selected
+ * file as a raw XHR body with an {@code X-Filename} header to a session-scoped
+ * {@link UploadHandler} (the servlets are not {@code @MultipartConfig}), and on
+ * success shows a confirmation paragraph (id {@code uploadText}) and the
+ * uploaded image (id {@code uploadImage}). It pulls no Vaadin component npm
+ * packages.
+ */
+public final class LoanApplicationUpload {
+
+    private LoanApplicationUpload() {
+    }
+
+    /**
+     * Adds the loan application upload UI to the given view.
+     *
+     * @param view
+     *            the view to add the upload components to
+     * @param uploaderName
+     *            supplies the name shown in the confirmation text, evaluated
+     *            when an upload succeeds
+     */
+    public static void addTo(HasComponents view,
+            Supplier<String> uploaderName) {
+        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
+        UploadHandler uploadHandler = event -> {
+            try (InputStream inputStream = event.getInputStream()) {
+                inputStream.transferTo(imageStream);
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+            event.getUI().access(() -> {
+                Paragraph p = new Paragraph(
+                        "Loan application uploaded by " + uploaderName.get());
+                p.setId("uploadText");
+                view.add(p);
+                Image image = new Image(new StreamResource("image.png",
+                        () -> new ByteArrayInputStream(
+                                imageStream.toByteArray())),
+                        "image");
+                image.setId("uploadImage");
+                view.add(image);
+            });
+        };
+
+        StreamResourceRegistry resourceRegistry = VaadinSession.getCurrent()
+                .getResourceRegistry();
+        StreamRegistration streamRegistration = resourceRegistry
+                .registerResource(uploadHandler);
+        String uploadUrl = resourceRegistry
+                .getTargetURI(streamRegistration.getResource()).toString();
+
+        // The upload posts via fetch(), which does not piggyback Flow's UIDL
+        // sync. Click a hidden button after the response to force a server
+        // roundtrip that pulls down the queued DOM updates.
+        NativeButton uploadSync = new NativeButton("", event -> {
+        });
+        uploadSync.getStyle().set("display", "none");
+
+        Input uploadInput = new Input();
+        uploadInput.setType("file");
+        uploadInput.setId("uploadInput");
+        uploadInput.getElement().executeJs(
+                """
+                        this.addEventListener('change', () => {
+                            const file = this.files[0];
+                            if (!file) return;
+                            fetch($0, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': file.type || 'application/octet-stream',
+                                    'X-Filename': encodeURIComponent(file.name)
+                                },
+                                body: file
+                            }).then(() => $1.click());
+                        });
+                        """,
+                uploadUrl, uploadSync.getElement());
+
+        view.add(new H4("Upload your loan application"), uploadInput,
+                uploadSync);
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-helpers/src/test/java/com/vaadin/flow/spring/test/AbstractSpringTest.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-helpers/src/test/java/com/vaadin/flow/spring/test/AbstractSpringTest.java
@@ -15,11 +15,18 @@
  */
 package com.vaadin.flow.spring.test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsElement;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
+
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
 
 public abstract class AbstractSpringTest extends ChromeBrowserTest {
 
@@ -75,6 +82,44 @@ public abstract class AbstractSpringTest extends ChromeBrowserTest {
         }
         return properties.getProperty(key);
 
+    }
+
+    /**
+     * Selects the given file in the native {@code <input type="file">} located
+     * by id. The file is transferred to the browser first, so this works with
+     * both locally run and remote browsers.
+     *
+     * @param inputId
+     *            the id of the file input element
+     * @param file
+     *            the local file to upload
+     */
+    protected void uploadFileToNativeInput(String inputId, File file) {
+        TestBenchElement input = $(TestBenchElement.class).id(inputId);
+        setLocalFileDetector(input);
+        input.sendKeys(file.getAbsolutePath());
+    }
+
+    /*
+     * A remote browser cannot read a file path typed into the input, so the
+     * local file has to be transferred to it. On a locally run browser this is
+     * a no-op.
+     */
+    private void setLocalFileDetector(WebElement element) {
+        if (getRunLocallyBrowser() != null) {
+            return;
+        }
+        if (element instanceof WrapsElement) {
+            element = ((WrapsElement) element).getWrappedElement();
+        }
+        if (element instanceof RemoteWebElement) {
+            ((RemoteWebElement) element)
+                    .setFileDetector(new LocalFileDetector());
+        } else {
+            throw new IllegalArgumentException(
+                    "Expected argument of type RemoteWebElement, received "
+                            + element.getClass().getName());
+        }
     }
 
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/pom.xml
@@ -65,17 +65,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Test components -->
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-html-components-testbench</artifactId>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.spring.flowsecurity.views;
 
 import jakarta.annotation.security.PermitAll;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.concurrent.Executor;
 
@@ -28,18 +26,14 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H4;
-import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 import com.vaadin.flow.spring.flowsecurity.service.BankService;
+import com.vaadin.flow.spring.test.LoanApplicationUpload;
 
 @Route(value = "private", layout = MainView.class)
 @PageTitle("Private View")
@@ -79,24 +73,8 @@ public class PrivateView extends Div {
         globalRefresh.setId("sendRefresh");
         add(globalRefresh);
 
-        Upload upload = new Upload();
-        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-        upload.setReceiver((filename, mimeType) -> {
-            return imageStream;
-        });
-        upload.addSucceededListener(e -> {
-            Paragraph p = new Paragraph("Loan application uploaded by "
-                    + utils.getAuthenticatedUserInfo().getFullName());
-            p.setId("uploadText");
-            add(p);
-            Image image = new Image(new StreamResource("image.png",
-                    () -> new ByteArrayInputStream(imageStream.toByteArray())),
-                    "image");
-            image.setId("uploadImage");
-            add(image);
-        });
-        add(new H4("Upload your loan application"));
-        add(upload);
+        LoanApplicationUpload.addTo(this,
+                () -> utils.getAuthenticatedUserInfo().getFullName());
     }
 
     @Override

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/pom.xml
@@ -65,17 +65,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Test components -->
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-html-components-testbench</artifactId>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.spring.flowsecurity.views;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.concurrent.Executor;
 
@@ -27,20 +25,16 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H4;
-import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
-import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 import com.vaadin.flow.spring.flowsecurity.service.BankService;
+import com.vaadin.flow.spring.test.LoanApplicationUpload;
 
 @Route(value = "private", layout = MainView.class)
 @RouteAlias(value = "privateAndForbiddenForAll")
@@ -74,24 +68,8 @@ public class PrivateView extends Div {
         globalRefresh.setId("sendRefresh");
         add(globalRefresh);
 
-        Upload upload = new Upload();
-        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-        upload.setReceiver((filename, mimeType) -> {
-            return imageStream;
-        });
-        upload.addSucceededListener(e -> {
-            Paragraph p = new Paragraph("Loan application uploaded by "
-                    + utils.getAuthenticatedUserInfo().getFullName());
-            p.setId("uploadText");
-            add(p);
-            Image image = new Image(new StreamResource("image.png",
-                    () -> new ByteArrayInputStream(imageStream.toByteArray())),
-                    "image");
-            image.setId("uploadImage");
-            add(image);
-        });
-        add(new H4("Upload your loan application"));
-        add(upload);
+        LoanApplicationUpload.addTo(this,
+                () -> utils.getAuthenticatedUserInfo().getFullName());
     }
 
     @Override

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,10 +27,9 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
-import com.vaadin.flow.component.upload.testbench.UploadElement;
 import com.vaadin.flow.spring.flowsecurity.views.PublicView;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -250,15 +248,16 @@ public class AppViewIT extends AbstractIT {
     public void upload_file_in_private_view() throws IOException {
         open("private");
         loginUser();
-        UploadElement upload = $(UploadElement.class).first();
         File tmpFile = File.createTempFile("security-flow-image", ".png");
-        InputStream imageStream = getClass().getClassLoader()
-                .getResourceAsStream("image.png");
-        IOUtils.copyLarge(imageStream, new FileOutputStream(tmpFile));
+        try (InputStream imageStream = getClass().getClassLoader()
+                .getResourceAsStream("image.png")) {
+            IOUtils.copyLarge(imageStream, new FileOutputStream(tmpFile));
+        }
         tmpFile.deleteOnExit();
-        upload.upload(tmpFile, 0);
-        waitForUploads(upload, 60);
 
+        uploadFileToNativeInput("uploadInput", tmpFile);
+
+        waitForElementPresent(By.id("uploadText"));
         TestBenchElement text = $("p").id("uploadText");
         TestBenchElement img = $("img").id("uploadImage");
 
@@ -437,27 +436,6 @@ public class AppViewIT extends AbstractIT {
             }
             return new MenuItem(href, text, available);
         }).collect(Collectors.toList());
-    }
-
-    // Workaround for https://github.com/vaadin/flow-components/issues/3646
-    // The issue causes the upload test to be flaky
-    private void waitForUploads(UploadElement element, int maxSeconds) {
-        WebDriver.Timeouts timeouts = getDriver().manage().timeouts();
-        timeouts.scriptTimeout(Duration.ofSeconds(maxSeconds));
-
-        String script = """
-                var callback = arguments[arguments.length - 1];
-                var upload = arguments[0];
-                let intervalId;
-                intervalId = window.setInterval(function() {
-                  var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;
-                  if (!inProgress) {
-                    window.clearInterval(intervalId);
-                    callback();
-                  }
-                }, 500);
-                """;
-        getCommandExecutor().getDriver().executeAsyncScript(script, element);
     }
 
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/pom.xml
@@ -65,17 +65,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Test components -->
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-html-components-testbench</artifactId>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.spring.flowsecurity.views;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.concurrent.Executor;
 
@@ -27,19 +25,15 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H4;
-import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
-import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 import com.vaadin.flow.spring.flowsecurity.service.BankService;
+import com.vaadin.flow.spring.test.LoanApplicationUpload;
 
 @Route(value = "private", layout = MainView.class)
 @RouteAlias(value = "privateAndForbiddenForAll")
@@ -72,24 +66,8 @@ public class PrivateView extends Div {
         globalRefresh.setId("sendRefresh");
         add(globalRefresh);
 
-        Upload upload = new Upload();
-        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-        upload.setReceiver((filename, mimeType) -> {
-            return imageStream;
-        });
-        upload.addSucceededListener(e -> {
-            Paragraph p = new Paragraph("Loan application uploaded by "
-                    + utils.getAuthenticatedUserInfo().getFullName());
-            p.setId("uploadText");
-            add(p);
-            Image image = new Image(new StreamResource("image.png",
-                    () -> new ByteArrayInputStream(imageStream.toByteArray())),
-                    "image");
-            image.setId("uploadImage");
-            add(image);
-        });
-        add(new H4("Upload your loan application"));
-        add(upload);
+        LoanApplicationUpload.addTo(this,
+                () -> utils.getAuthenticatedUserInfo().getFullName());
     }
 
     @Override

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,10 +27,9 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
-import com.vaadin.flow.component.upload.testbench.UploadElement;
 import com.vaadin.flow.spring.flowsecurity.views.PublicView;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -250,15 +248,16 @@ public class AppViewIT extends AbstractIT {
     public void upload_file_in_private_view() throws IOException {
         open("private");
         loginUser();
-        UploadElement upload = $(UploadElement.class).first();
         File tmpFile = File.createTempFile("security-flow-image", ".png");
-        InputStream imageStream = getClass().getClassLoader()
-                .getResourceAsStream("image.png");
-        IOUtils.copyLarge(imageStream, new FileOutputStream(tmpFile));
+        try (InputStream imageStream = getClass().getClassLoader()
+                .getResourceAsStream("image.png")) {
+            IOUtils.copyLarge(imageStream, new FileOutputStream(tmpFile));
+        }
         tmpFile.deleteOnExit();
-        upload.upload(tmpFile, 0);
-        waitForUploads(upload, 60);
 
+        uploadFileToNativeInput("uploadInput", tmpFile);
+
+        waitForElementPresent(By.id("uploadText"));
         TestBenchElement text = $("p").id("uploadText");
         TestBenchElement img = $("img").id("uploadImage");
 
@@ -402,27 +401,6 @@ public class AppViewIT extends AbstractIT {
             }
             return new MenuItem(href, text, available);
         }).collect(Collectors.toList());
-    }
-
-    // Workaround for https://github.com/vaadin/flow-components/issues/3646
-    // The issue causes the upload test to be flaky
-    private void waitForUploads(UploadElement element, int maxSeconds) {
-        WebDriver.Timeouts timeouts = getDriver().manage().timeouts();
-        timeouts.scriptTimeout(Duration.ofSeconds(maxSeconds));
-
-        String script = """
-                var callback = arguments[arguments.length - 1];
-                var upload = arguments[0];
-                let intervalId;
-                intervalId = window.setInterval(function() {
-                  var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;
-                  if (!inProgress) {
-                    window.clearInterval(intervalId);
-                    callback();
-                  }
-                }, 500);
-                """;
-        getCommandExecutor().getDriver().executeAsyncScript(script, element);
     }
 
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-contextpath/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-contextpath/pom.xml
@@ -31,11 +31,6 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>test-lumo-theme</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>vaadin-test-spring-helpers</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-urlmapping/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-urlmapping/pom.xml
@@ -31,11 +31,6 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>test-lumo-theme</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>vaadin-test-spring-helpers</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/pom.xml
@@ -65,17 +65,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Test components -->
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-html-components-testbench</artifactId>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.spring.flowsecurity.views;
 
 import jakarta.annotation.security.PermitAll;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.concurrent.Executor;
 
@@ -29,19 +27,15 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H4;
-import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 import com.vaadin.flow.spring.flowsecurity.service.BankService;
+import com.vaadin.flow.spring.test.LoanApplicationUpload;
 
 @Route(value = "private", layout = MainView.class)
 @PageTitle("Private View")
@@ -75,24 +69,8 @@ public class PrivateView extends Div {
         globalRefresh.setId("sendRefresh");
         add(globalRefresh);
 
-        Upload upload = new Upload();
-        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-        upload.setReceiver((filename, mimeType) -> {
-            return imageStream;
-        });
-        upload.addSucceededListener(e -> {
-            Paragraph p = new Paragraph("Loan application uploaded by "
-                    + utils.getAuthenticatedUserInfo().getFullName());
-            p.setId("uploadText");
-            add(p);
-            Image image = new Image(new StreamResource("image.png",
-                    () -> new ByteArrayInputStream(imageStream.toByteArray())),
-                    "image");
-            image.setId("uploadImage");
-            add(image);
-        });
-        add(new H4("Upload your loan application"));
-        add(upload);
+        LoanApplicationUpload.addTo(this,
+                () -> utils.getAuthenticatedUserInfo().getFullName());
     }
 
     @Override

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,12 +29,10 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
-import com.vaadin.flow.component.upload.testbench.UploadElement;
 import com.vaadin.flow.spring.flowsecurity.views.AdminView;
 import com.vaadin.flow.spring.flowsecurity.views.PublicView;
 import com.vaadin.testbench.TestBenchElement;
@@ -328,15 +325,16 @@ public class AppViewIT extends AbstractIT {
     public void upload_file_in_private_view() throws IOException {
         open("private");
         loginUser();
-        UploadElement upload = $(UploadElement.class).first();
         File tmpFile = File.createTempFile("security-flow-image", ".png");
-        InputStream imageStream = getClass().getClassLoader()
-                .getResourceAsStream("image.png");
-        IOUtils.copyLarge(imageStream, new FileOutputStream(tmpFile));
+        try (InputStream imageStream = getClass().getClassLoader()
+                .getResourceAsStream("image.png")) {
+            IOUtils.copyLarge(imageStream, new FileOutputStream(tmpFile));
+        }
         tmpFile.deleteOnExit();
-        upload.upload(tmpFile, 0);
-        waitForUploads(upload, 60);
 
+        uploadFileToNativeInput("uploadInput", tmpFile);
+
+        waitForElementPresent(By.id("uploadText"));
         TestBenchElement text = $("p").id("uploadText");
         TestBenchElement img = $("img").id("uploadImage");
 
@@ -509,27 +507,6 @@ public class AppViewIT extends AbstractIT {
             }
             return new MenuItem(href, text, available);
         }).collect(Collectors.toList());
-    }
-
-    // Workaround for https://github.com/vaadin/flow-components/issues/3646
-    // The issue causes the upload test to be flaky
-    private void waitForUploads(UploadElement element, int maxSeconds) {
-        WebDriver.Timeouts timeouts = getDriver().manage().timeouts();
-        timeouts.scriptTimeout(Duration.ofSeconds(maxSeconds));
-
-        String script = """
-                var callback = arguments[arguments.length - 1];
-                var upload = arguments[0];
-                let intervalId;
-                intervalId = window.setInterval(function() {
-                  var inProgress = upload.files.filter(function(file) { return file.uploading;}).length >0;
-                  if (!inProgress) {
-                    window.clearInterval(intervalId);
-                    callback();
-                  }
-                }, 500);
-                """;
-        getCommandExecutor().getDriver().executeAsyncScript(script, element);
     }
 
     /*


### PR DESCRIPTION
The spring test modules pulled real Vaadin platform web components transitively, which dragged the whole @vaadin/* component npm closure into every frontend build. That made the it-tests job fail intermittently under the pnpm minimum-release-age guard whenever those components were freshly published, and it kept the tests dependent on components that Flow itself no longer uses.

Replace the component usages with faux, Flow-owned equivalents that pull no component npm packages:

- Swap the real vaadin-lumo-theme for flow-test-lumo (the stub Lumo class that satisfies Flow's @Theme(name) classpath check) plus test-lumo-theme (the fake-lumo.css public resource). The real dependency also leaked in transitively through vaadin-test-spring-helpers, so the swap lives in the shared parent pom and covers every module at once.
- Replace the vaadin Upload component in the four security-flow modules with a native Input(file) + UploadHandler that posts a raw XHR body with an X-Filename header (the servlets are not @MultipartConfig), matching the existing test-spring-common UploadView.
- Drop the @vaadin/vaadin-themable-mixin import from the reload-time benchmark.js, building the global stylesheet from a plain string instead.
- Remove the benchmark-directory-addons profile that pulled vaadin-core and third-party add-ons, and the now-unused component.version property.

Unify the upload code the security apps duplicated: the loan-application upload UI moves to a shared LoanApplicationUpload helper in test-spring-helpers, and the browser file-transfer logic (setLocalFileDetector) becomes a uploadFileToNativeInput method on the shared AbstractSpringTest base, also reused by the existing test-spring-common UploadIT.
