### PR TITLE
chore: bump kotlin to 2.4.0 in webpush module

### DIFF
--- a/flow-webpush/pom.xml
+++ b/flow-webpush/pom.xml
@@ -29,6 +29,20 @@
       <groupId>com.interaso</groupId>
       <artifactId>webpush</artifactId>
       <version>1.3.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Overrides 2.3.0 from com.interaso:webpush -->
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>2.4.0</version>
+      <scope>compile</scope>
     </dependency>
 
     <!-- DefaultApplicationConfigurationFactory is declared as an OSGi


### PR DESCRIPTION
References #24962
