### PR TITLE
chore: add claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,80 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Skip workflow if the comment does not tag claude or the author is not a
+    # maintainer. Having this check here ensures that this scenario does not
+    # even start a runner.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      # Required by actions/checkout
+      contents: read
+      # Required by anthropics/claude-code-action to generate a short-lived
+      # app token (contents/pull_requests/issues: write) that is revoked at the
+      # end of the run. Thus, there should be no need to grant additional write
+      # permissions to the workflow itself.
+      id-token: write
+      # Required by github_ci MCP server, which uses the workflow token instead
+      # of the short-lived app token
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+        with:
+          maven-version: 3.8.7
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24.9.0'
+
+      - name: Install TestBench license
+        if: env.TB_LICENSE != ''
+        env:
+          TB_LICENSE: ${{ secrets.TB_LICENSE }}
+        run: |
+          mkdir -p ~/.vaadin
+          user="${TB_LICENSE%%/*}"
+          key="${TB_LICENSE#*/}"
+          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
+
+      - name: Run Claude Code
+        uses: vaadin/github-actions/claude-code@bfb2659c1efe77731d70b4bb57f1433f5dbf3d90
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          extra-allowed-tools: |
+            Bash(mvn:*)
+            Bash(npm install)
+            Bash(npm ci)
+            Bash(npm test)
+            Bash(npm run:*)
+          upload-execution-log: ${{ vars.CLAUDE_DEBUG }}


### PR DESCRIPTION
Adds a GitHub actions workflow for running Claude Code in CI. This allows to tag `@claude` in a comment on either an issue or PR and assign it an arbitrary task ("investigate this issue", "fix this bug", "implement this", "review this PR"). 

- The workflow triggers for comments on either issues or PRs
- The workflow is skipped, as in it does not even start a runner, when the comment does not tag `@claude` or if the comment author is not a maintainer.
- Grants minimal workflow permissions. It provides `id-token: write`, which the `github-claude-action` uses to create a short-lived GitHub token through the Claude Github app installed in this repo. Claude itself then runs with the GitHub app token rather than the workflow token. The app token is revoked automatically after the workflow.
- Claude is given a restricted set of tools to use. These may not be sufficient for all tasks yet and might need tuning.

Uses the shared `vaadin/github-actions/claude-code` action from https://github.com/vaadin/github-actions/tree/main/claude-code.