### PR TITLE
chore: use kotlin-test-junit in flow-gradle-plugin build

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -83,7 +83,11 @@ dependencies {
     implementation("com.vaadin:flow-plugin-base:${pom.parent.version}")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:2.4.0")
+    // Use kotlin-test-junit instead of the bare kotlin-test artifact: it
+    // depends on kotlin-test and junit directly via its POM. The bare
+    // kotlin-test relies on Gradle Module Metadata (.module) to wire in JUnit,
+    // which fails to resolve when a repository only serves the POM.
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:2.4.0")
 }
 
 idea {


### PR DESCRIPTION
The bare `kotlin-test` artifact wires in JUnit via Gradle Module Metadata capability selection, which fails to resolve on CI when a repository ahead of Maven Central serves only the POM. `kotlin-test-junit` declares `kotlin-test` and `junit` as plain POM dependencies, avoiding the issue.
