### PR TITLE
fix!: restore cached Gradle frontend build outputs

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -886,12 +886,20 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
                 implementation("org.slf4j:slf4j-simple:$slf4jVersion")
             }
+            tasks.register('sourcesJar', Jar) {
+                archiveClassifier = 'sources'
+                from sourceSets.main.allSource
+            }
         """.trimIndent()
         )
 
-        var result = testProject.build("--build-cache", "-Pvaadin.productionMode", "build")
+        var result = testProject.build("--build-cache", "-Pvaadin.productionMode", "build", "sourcesJar")
         result.expectTaskSucceded("vaadinBuildFrontend")
         expectArchiveContainsVaadinBundle(testProject.builtWar, false)
+        expectArchiveDoesntContainVaadinBundle(
+            testProject.folder("build/libs").find("*-sources.jar").first(),
+            false
+        )
 
         File(testProject.dir, "build/vaadin-build-frontend").deleteRecursively()
         File(testProject.dir, "build/cached-flow-build-info.json").delete()
@@ -900,6 +908,27 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         result = testProject.build("--build-cache", "-Pvaadin.productionMode", "build")
         result.expectTaskOutcome("vaadinBuildFrontend", TaskOutcome.FROM_CACHE)
         expectArchiveContainsVaadinBundle(testProject.builtWar, false)
+    }
+
+    @Test
+    fun buildFrontendBuildCacheRestoresProductionBundleForSpringBootJar() {
+        doTestSpringProject()
+
+        var result = testProject.build(
+            "--build-cache", "-Pvaadin.productionMode", "bootJar"
+        )
+        result.expectTaskSucceded("vaadinBuildFrontend")
+        expectArchiveContainsVaadinBundle(testProject.builtJar, true)
+
+        File(testProject.dir, "build/vaadin-build-frontend").deleteRecursively()
+        File(testProject.dir, "build/cached-flow-build-info.json").delete()
+        File(testProject.dir, "build/libs").deleteRecursively()
+
+        result = testProject.build(
+            "--build-cache", "-Pvaadin.productionMode", "bootJar"
+        )
+        result.expectTaskOutcome("vaadinBuildFrontend", TaskOutcome.FROM_CACHE)
+        expectArchiveContainsVaadinBundle(testProject.builtJar, true)
     }
 
     @Test

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -868,6 +868,41 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     @Test
+    fun buildFrontendBuildCacheRestoresProductionBundleForWar() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'war'
+                id 'org.gretty' version '4.0.3'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+            }
+        """.trimIndent()
+        )
+
+        var result = testProject.build("--build-cache", "-Pvaadin.productionMode", "build")
+        result.expectTaskSucceded("vaadinBuildFrontend")
+        expectArchiveContainsVaadinBundle(testProject.builtWar, false)
+
+        File(testProject.dir, "build/vaadin-build-frontend").deleteRecursively()
+        File(testProject.dir, "build/cached-flow-build-info.json").delete()
+        File(testProject.dir, "build/libs").deleteRecursively()
+
+        result = testProject.build("--build-cache", "-Pvaadin.productionMode", "build")
+        result.expectTaskOutcome("vaadinBuildFrontend", TaskOutcome.FROM_CACHE)
+        expectArchiveContainsVaadinBundle(testProject.builtWar, false)
+    }
+
+    @Test
     fun buildFrontendIncrementalBuilds_rerunsOnInputChange() {
         testProject.buildFile.writeText(
             """

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -932,6 +932,222 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     @Test
+    fun buildFrontendBuildCacheRestoresProductionBundleForJar() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            def jettyVersion = "11.0.12"
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
+                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
+            }
+        """.trimIndent()
+        )
+
+        var result = testProject.build("--build-cache", "-Pvaadin.productionMode", "build")
+        result.expectTaskSucceded("vaadinBuildFrontend")
+        expectArchiveContainsVaadinBundle(testProject.builtJar, false)
+
+        File(testProject.dir, "build/vaadin-build-frontend").deleteRecursively()
+        File(testProject.dir, "build/cached-flow-build-info.json").delete()
+        File(testProject.dir, "build/libs").deleteRecursively()
+
+        result = testProject.build("--build-cache", "-Pvaadin.productionMode", "build")
+        result.expectTaskOutcome("vaadinBuildFrontend", TaskOutcome.FROM_CACHE)
+        expectArchiveContainsVaadinBundle(testProject.builtJar, false)
+    }
+
+    /**
+     * Before the frontend output was moved to a task-owned directory, the
+     * production bundle was written into the `main` source set resources, so
+     * every archive task - including custom-named `Jar` tasks - triggered
+     * `vaadinBuildFrontend` and packaged the bundle. Restricting packaging to
+     * a fixed set of well-known task names must not silently drop the bundle
+     * (and the `vaadinBuildFrontend` dependency) from such custom archives.
+     */
+    @Test
+    fun buildFrontend_customArchiveTask_containsProductionBundle() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            def jettyVersion = "11.0.12"
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
+                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
+            }
+            tasks.register('appJar', Jar) {
+                archiveClassifier = 'app'
+                from sourceSets.main.output
+            }
+        """.trimIndent()
+        )
+
+        val result = testProject.build("-Pvaadin.productionMode", "appJar")
+        result.expectTaskSucceded("vaadinBuildFrontend")
+
+        val appJar = testProject.folder("build/libs").find("*-app.jar").first()
+        expectArchiveContainsVaadinBundle(appJar, false)
+    }
+
+    /**
+     * Source and javadoc archives are identified by their classifier and
+     * must never carry the production frontend bundle, even though they are
+     * `Jar` tasks.
+     */
+    @Test
+    fun buildFrontend_sourcesAndJavadocJars_doNotContainProductionBundle() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            java {
+                withSourcesJar()
+                withJavadocJar()
+            }
+            def jettyVersion = "11.0.12"
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
+                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
+            }
+        """.trimIndent()
+        )
+
+        val result = testProject.build("-Pvaadin.productionMode", "build")
+        result.expectTaskSucceded("vaadinBuildFrontend")
+
+        val libs = testProject.folder("build/libs")
+        val mainJar = libs.find("*.jar", 3..3).first {
+            !it.name.endsWith("-sources.jar") &&
+                    !it.name.endsWith("-javadoc.jar")
+        }
+        expectArchiveContainsVaadinBundle(mainJar, false)
+        expectArchiveDoesntContainVaadinBundle(
+            libs.find("*-sources.jar").first(), false
+        )
+        expectArchiveDoesntContainVaadinBundle(
+            libs.find("*-javadoc.jar").first(), false
+        )
+    }
+
+    /**
+     * A custom archive that would be packaged by default can be opted out
+     * via `vaadin.excludeArchiveTasks`. The frontend is still built (the
+     * `jar` task consumes it), but the excluded archive stays frontend-free.
+     */
+    @Test
+    fun buildFrontend_excludedArchiveTask_doesNotContainProductionBundle() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            vaadin {
+                excludeArchiveTasks = ['appJar']
+            }
+            def jettyVersion = "11.0.12"
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
+                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
+            }
+            tasks.register('appJar', Jar) {
+                archiveClassifier = 'app'
+                from sourceSets.main.output
+            }
+        """.trimIndent()
+        )
+
+        val result = testProject.build("-Pvaadin.productionMode", "build", "appJar")
+        result.expectTaskSucceded("vaadinBuildFrontend")
+
+        val appJar = testProject.folder("build/libs").find("*-app.jar").first()
+        expectArchiveDoesntContainVaadinBundle(appJar, false)
+    }
+
+    /**
+     * A `tests`-classified archive is excluded by default, but can be forced
+     * to receive the frontend bundle via `vaadin.includeArchiveTasks`, which
+     * overrides the classifier-based exclusion.
+     */
+    @Test
+    fun buildFrontend_includedArchiveTask_overridesClassifierExclusion() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            vaadin {
+                includeArchiveTasks = ['fixtureJar']
+            }
+            def jettyVersion = "11.0.12"
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
+                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
+            }
+            tasks.register('fixtureJar', Jar) {
+                archiveClassifier = 'tests'
+                from sourceSets.main.output
+            }
+        """.trimIndent()
+        )
+
+        val result = testProject.build("-Pvaadin.productionMode", "fixtureJar")
+        result.expectTaskSucceded("vaadinBuildFrontend")
+
+        val fixtureJar = testProject.folder("build/libs").find("*-tests.jar").first()
+        expectArchiveContainsVaadinBundle(fixtureJar, false)
+    }
+
+    @Test
     fun buildFrontendIncrementalBuilds_rerunsOnInputChange() {
         testProject.buildFile.writeText(
             """

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -969,6 +969,52 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     /**
+     * A custom `frontendOutputDirectory` that does not follow the
+     * `META-INF/VAADIN/webapp` layout cannot be packaged: the frontend outputs
+     * would fall back into the source set resources directory
+     * (`build/resources/main`), which drops the bundle from the archive and,
+     * on Gradle 9, breaks the build with an implicit task-dependency error.
+     * Such a misconfiguration never produced a servable archive, so the plugin
+     * rejects it during configuration with an actionable message.
+     */
+    @Test
+    fun buildFrontend_customFlatFrontendOutputDirectory_failsWithClearError() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            def jettyVersion = "11.0.12"
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
+                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
+            }
+            vaadin {
+                frontendOutputDirectory = layout.buildDirectory.dir("flat-frontend-output").get().asFile
+            }
+        """.trimIndent()
+        )
+
+        // 'help' triggers project configuration (and the production-mode
+        // afterEvaluate validation) without running the frontend build.
+        val result = testProject.buildAndFail("-Pvaadin.productionMode", "help")
+        expect(true, "Build should fail mentioning frontendOutputDirectory, " +
+            "was:\n${result.output}") {
+            result.output.contains("frontendOutputDirectory") &&
+                result.output.contains("META-INF/VAADIN/webapp")
+        }
+    }
+
+    /**
      * Before the frontend output was moved to a task-owned directory, the
      * production bundle was written into the `main` source set resources, so
      * every archive task - including custom-named `Jar` tasks - triggered

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -153,6 +153,7 @@ fun expectArchiveContainsVaadinBundle(
     val isStandaloneJar: Boolean = !isWar && !isSpringBootJar
     val resourcePackaging: String = when {
         isWar -> "WEB-INF/classes/"
+        isSpringBootJar -> "BOOT-INF/classes/"
         else -> ""
     }
     expectArchiveContains(

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -85,7 +85,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
         result.expectTaskNotRan("vaadinPrepareFrontend")
         result.expectTaskNotRan("vaadinBuildFrontend")
 
-        val build = File(testProject.dir, "build/resources/main/META-INF/VAADIN/webapp/VAADIN/build")
+        val build = File(testProject.dir, "build/vaadin-build-frontend/META-INF/VAADIN/webapp/VAADIN/build")
         expect(false, build.toString()) { build.exists() }
     }
 
@@ -97,7 +97,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
         // vaadinPrepareFrontend
         result.expectTaskNotRan("vaadinPrepareFrontend")
 
-        val build = File(testProject.dir, "build/resources/main/META-INF/VAADIN/webapp/VAADIN/build")
+        val build = File(testProject.dir, "build/vaadin-build-frontend/META-INF/VAADIN/webapp/VAADIN/build")
         expect(true, build.toString()) { build.isDirectory }
         expect(true) { build.listFiles()!!.isNotEmpty() }
         build.find("*.br", 4..10)

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/BuildFrontendOutputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/BuildFrontendOutputProperties.kt
@@ -21,6 +21,7 @@ import com.vaadin.flow.plugin.base.BuildFrontendUtil
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 
 /**
@@ -52,6 +53,8 @@ internal class BuildFrontendOutputProperties(
             VaadinBuildFrontendTask.CACHED_BUILD_INFO_FILE)
     private val generatedTsFolder: File =
         BuildFrontendUtil.getGeneratedFrontendDirectory(adapter)
+    private val servletResourceOutputDirectory: File =
+        adapter.servletResourceOutputDirectory()
     private val frontendIndexHtml: File =
         File(BuildFrontendUtil.getFrontendDirectory(adapter),
             FrontendUtils.INDEX_HTML)
@@ -62,6 +65,10 @@ internal class BuildFrontendOutputProperties(
     @OutputFile
     @Optional
     fun getFrontendIndexHtml(): File = frontendIndexHtml
+
+    @OutputDirectory
+    fun getServletResourceOutputDirectory(): File =
+        servletResourceOutputDirectory
 
     @LocalState
     fun getGeneratedTsFolder(): File = generatedTsFolder

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/BuildFrontendTokenService.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/BuildFrontendTokenService.kt
@@ -42,7 +42,11 @@ internal abstract class BuildFrontendTokenService
     : BuildService<BuildFrontendTokenService.Parameters>, AutoCloseable {
 
     interface Parameters : BuildServiceParameters {
-        /** Absolute path to the token file in build/resources/main/. */
+        /**
+         * Absolute path to the production token file, written under the
+         * servlet resource output directory (by default
+         * `build/vaadin-build-frontend/META-INF/VAADIN/config/`).
+         */
         fun getTokenFilePath(): Property<String>
         /** Absolute path to the cached copy in build/. */
         fun getCachedTokenFilePath(): Property<String>

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
@@ -31,6 +31,12 @@ import org.gradle.util.GradleVersion
 public class FlowPlugin : Plugin<Project> {
     public companion object {
         public const val GRADLE_MINIMUM_SUPPORTED_VERSION: String = "8.14"
+
+        // Archive classifiers that never carry the production frontend
+        // bundle (source and javadoc distributions, test fixtures). Any
+        // other Jar/War/BootJar is treated as an application archive.
+        private val NON_APPLICATION_ARCHIVE_CLASSIFIERS =
+            setOf("sources", "javadoc", "test-sources", "tests")
     }
 
     override fun apply(project: Project) {
@@ -83,18 +89,23 @@ public class FlowPlugin : Plugin<Project> {
                 val sourceSetResourcesDirectory =
                     project.getBuildResourcesDir(config.sourceSetName.get())
 
+                val includedArchiveTasks = config.includeArchiveTasks.get().toSet()
+                val excludedArchiveTasks = config.excludeArchiveTasks.get().toSet()
+
                 project.tasks.withType(Jar::class.java) { task: Jar ->
-                    if (task.isVaadinApplicationArchiveTask()) {
+                    if (task.isVaadinApplicationArchiveTask(
+                            includedArchiveTasks, excludedArchiveTasks)) {
                         task.dependsOn("vaadinBuildFrontend")
                         if (vaadinBuildFrontendOutputDirectory != null &&
                             vaadinBuildFrontendOutputDirectory.canonicalFile !=
                             sourceSetResourcesDirectory.canonicalFile
                         ) {
-                            task.from(vaadinBuildFrontendOutputDirectory) {
-                                task.vaadinBuildFrontendResourcesArchivePath()
-                                    ?.let { path ->
-                                        it.into(path)
-                                    }
+                            task.from(vaadinBuildFrontendOutputDirectory) { copySpec ->
+                                val archivePath =
+                                    task.vaadinBuildFrontendResourcesArchivePath()
+                                if (archivePath != null) {
+                                    copySpec.into(archivePath)
+                                }
                             }
                         }
                     }
@@ -164,8 +175,11 @@ public class FlowPlugin : Plugin<Project> {
                 // Ensure close() fires after vaadinBuildFrontend and
                 // all Jar/War packaging tasks have completed.
                 buildFrontendTask.usesService(tokenService)
+                val includedArchiveTasks = config.includeArchiveTasks.get().toSet()
+                val excludedArchiveTasks = config.excludeArchiveTasks.get().toSet()
                 project.tasks.withType(Jar::class.java) { task: Jar ->
-                    if (task.isVaadinApplicationArchiveTask()) {
+                    if (task.isVaadinApplicationArchiveTask(
+                            includedArchiveTasks, excludedArchiveTasks)) {
                         task.usesService(tokenService)
                         // Restore the production token before packaging in
                         // case it was deleted by a previous build's cleanup.
@@ -200,8 +214,25 @@ public class FlowPlugin : Plugin<Project> {
         }
     }
 
-    private fun Jar.isVaadinApplicationArchiveTask(): Boolean =
-        name == JavaPlugin.JAR_TASK_NAME || this is War || isSpringBootJar()
+    // Whether the production frontend bundle should be packaged into this
+    // archive. By default every Jar/War/BootJar qualifies, except source,
+    // javadoc and test-fixture distributions (identified by their archive
+    // classifier). The default can be overridden per task via the
+    // `includeArchiveTasks` / `excludeArchiveTasks` plugin settings, with
+    // `excludeArchiveTasks` taking precedence.
+    private fun Jar.isVaadinApplicationArchiveTask(
+        includedTaskNames: Set<String>,
+        excludedTaskNames: Set<String>
+    ): Boolean {
+        if (name in excludedTaskNames) {
+            return false
+        }
+        if (name in includedTaskNames) {
+            return true
+        }
+        return archiveClassifier.orNull.orEmpty() !in
+                NON_APPLICATION_ARCHIVE_CLASSIFIERS
+    }
 
     private fun Jar.isSpringBootJar(): Boolean =
         generateSequence(javaClass as Class<*>) { it.superclass }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
@@ -21,6 +21,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.bundling.War
 import org.gradle.util.GradleVersion
 
 /**
@@ -72,9 +73,21 @@ public class FlowPlugin : Plugin<Project> {
                 // In production mode, vaadinBuildFrontend is self-contained
                 // and performs its own frontend preparation, so there is no
                 // need for vaadinPrepareFrontend to run beforehand.
+                val buildFrontendTask = project.tasks.getByName("vaadinBuildFrontend")
+                val buildAdapter = GradlePluginAdapter(buildFrontendTask, config, false)
+                val vaadinServletResourcesDirectory =
+                    buildAdapter.servletResourceOutputDirectory()
+                val vaadinBuildFrontendOutputDirectory =
+                    vaadinServletResourcesDirectory.parentFile.parentFile
+
                 // this will also catch the War task since it extends from Jar
                 project.tasks.withType(Jar::class.java) { task: Jar ->
                     task.dependsOn("vaadinBuildFrontend")
+                    task.from(vaadinBuildFrontendOutputDirectory) {
+                        task.vaadinBuildFrontendResourcesArchivePath()?.let { path ->
+                            it.into(path)
+                        }
+                    }
                 }
             } else if (config.alwaysExecutePrepareFrontend.get()) {
                 // In development mode, vaadinPrepareFrontend is not
@@ -164,6 +177,15 @@ public class FlowPlugin : Plugin<Project> {
                 "Vaadin plugin requires Gradle ${GRADLE_MINIMUM_SUPPORTED_VERSION} or later. "
                         + "The current version is ${currentVersion.version}."
             )
+        }
+    }
+
+    private fun Jar.vaadinBuildFrontendResourcesArchivePath(): String? {
+        return when {
+            this is War -> "WEB-INF/classes"
+            javaClass.name == "org.springframework.boot.gradle.tasks.bundling.BootJar" ->
+                "BOOT-INF/classes"
+            else -> null
         }
     }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
@@ -78,14 +78,24 @@ public class FlowPlugin : Plugin<Project> {
                 val vaadinServletResourcesDirectory =
                     buildAdapter.servletResourceOutputDirectory()
                 val vaadinBuildFrontendOutputDirectory =
-                    vaadinServletResourcesDirectory.parentFile.parentFile
+                    vaadinServletResourcesDirectory.parentFile?.parentFile
 
-                // this will also catch the War task since it extends from Jar
+                val sourceSetResourcesDirectory =
+                    project.getBuildResourcesDir(config.sourceSetName.get())
+
                 project.tasks.withType(Jar::class.java) { task: Jar ->
-                    task.dependsOn("vaadinBuildFrontend")
-                    task.from(vaadinBuildFrontendOutputDirectory) {
-                        task.vaadinBuildFrontendResourcesArchivePath()?.let { path ->
-                            it.into(path)
+                    if (task.isVaadinApplicationArchiveTask()) {
+                        task.dependsOn("vaadinBuildFrontend")
+                        if (vaadinBuildFrontendOutputDirectory != null &&
+                            vaadinBuildFrontendOutputDirectory.canonicalFile !=
+                            sourceSetResourcesDirectory.canonicalFile
+                        ) {
+                            task.from(vaadinBuildFrontendOutputDirectory) {
+                                task.vaadinBuildFrontendResourcesArchivePath()
+                                    ?.let { path ->
+                                        it.into(path)
+                                    }
+                            }
                         }
                     }
                 }
@@ -155,13 +165,15 @@ public class FlowPlugin : Plugin<Project> {
                 // all Jar/War packaging tasks have completed.
                 buildFrontendTask.usesService(tokenService)
                 project.tasks.withType(Jar::class.java) { task: Jar ->
-                    task.usesService(tokenService)
-                    // Restore the production token before packaging in
-                    // case it was deleted by a previous build's cleanup.
-                    // Capture the service provider rather than the Project so
-                    // the action stays compatible with the configuration cache.
-                    task.doFirst {
-                        tokenService.get().ensureToken()
+                    if (task.isVaadinApplicationArchiveTask()) {
+                        task.usesService(tokenService)
+                        // Restore the production token before packaging in
+                        // case it was deleted by a previous build's cleanup.
+                        // Capture the service provider rather than the Project so
+                        // the action stays compatible with the configuration cache.
+                        task.doFirst {
+                            tokenService.get().ensureToken()
+                        }
                     }
                 }
             }
@@ -183,9 +195,17 @@ public class FlowPlugin : Plugin<Project> {
     private fun Jar.vaadinBuildFrontendResourcesArchivePath(): String? {
         return when {
             this is War -> "WEB-INF/classes"
-            javaClass.name == "org.springframework.boot.gradle.tasks.bundling.BootJar" ->
-                "BOOT-INF/classes"
+            isSpringBootJar() -> "BOOT-INF/classes"
             else -> null
         }
     }
+
+    private fun Jar.isVaadinApplicationArchiveTask(): Boolean =
+        name == JavaPlugin.JAR_TASK_NAME || this is War || isSpringBootJar()
+
+    private fun Jar.isSpringBootJar(): Boolean =
+        generateSequence(javaClass as Class<*>) { it.superclass }
+            .any {
+                it.name == "org.springframework.boot.gradle.tasks.bundling.BootJar"
+            }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -46,8 +46,6 @@ internal class GradlePluginAdapter private constructor(
 
     private val projectDir = config.projectDir
     private val projectName = config.projectName
-    private val buildResourcesDir: File =
-        project.getBuildResourcesDir(config.sourceSetName.get())
     private val jarProject: Boolean =
         project.tasks.withType(War::class.java).isEmpty()
     private val jarFiles: FileCollection
@@ -241,7 +239,7 @@ internal class GradlePluginAdapter private constructor(
                 Constants.VAADIN_SERVLET_RESOURCES
             )
         }
-        return File(buildResourcesDir, Constants.VAADIN_SERVLET_RESOURCES)
+        return frontendOutputDirectory().parentFile
     }
 
     override fun webpackOutputDirectory(): File = frontendOutputDirectory()

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -23,6 +23,7 @@ import com.vaadin.flow.plugin.base.BuildFrontendUtil
 import com.vaadin.flow.plugin.base.PluginAdapterBuild
 import com.vaadin.flow.server.Constants
 import com.vaadin.flow.server.frontend.scanner.ClassFinder
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
@@ -46,8 +47,6 @@ internal class GradlePluginAdapter private constructor(
 
     private val projectDir = config.projectDir
     private val projectName = config.projectName
-    private val buildResourcesDir =
-        project.getBuildResourcesDir(config.sourceSetName.get())
     private val jarProject: Boolean =
         project.tasks.withType(War::class.java).isEmpty()
     private val jarFiles: FileCollection
@@ -234,8 +233,10 @@ internal class GradlePluginAdapter private constructor(
         //
         // However, after processResources is done, anything generated into
         // build/vaadin-generated would simply be ignored. In such cases,
-        // production resources must either be generated to the task-owned
-        // frontend output tree or to the source set resources directory.
+        // production resources are generated into the task-owned frontend
+        // output tree, next to the webapp bundle, so that the whole
+        // META-INF/VAADIN tree is packaged into the application archive as a
+        // single, task-owned unit.
         if (isBeforeProcessResources) {
             return File(
                 config.resourceOutputDirectory.get(),
@@ -246,7 +247,27 @@ internal class GradlePluginAdapter private constructor(
         if (frontendOutputDirectory.hasVaadinWebappResourcesPath()) {
             return frontendOutputDirectory.parentFile
         }
-        return File(buildResourcesDir, Constants.VAADIN_SERVLET_RESOURCES)
+        // The servlet resources (config, token, stats.json) must sit next to
+        // the webapp bundle so the whole META-INF/VAADIN tree can be packaged
+        // together, which is only possible when frontendOutputDirectory follows
+        // the META-INF/VAADIN/webapp layout. Falling back to the source set
+        // resources directory (build/resources/main) instead would make
+        // vaadinBuildFrontend share outputs with processResources/jar, which
+        // silently drops the bundle from the archive and, on Gradle 9, fails
+        // the build with an implicit task-dependency error. Such a
+        // frontendOutputDirectory is a misconfiguration that never produced a
+        // servable archive, so reject it with an actionable message instead of
+        // producing a broken package.
+        val webappResourcesPath =
+            Constants.VAADIN_WEBAPP_RESOURCES.removeSuffix("/")
+        throw GradleException(
+            "The Vaadin 'frontendOutputDirectory' is set to " +
+            "'${frontendOutputDirectory.path}', which does not end in " +
+            "'$webappResourcesPath'. The production frontend bundle can only " +
+            "be packaged when this directory follows the '$webappResourcesPath' " +
+            "layout. Either leave 'frontendOutputDirectory' at its default or " +
+            "set it to a path ending in '$webappResourcesPath'."
+        )
     }
 
     override fun webpackOutputDirectory(): File = frontendOutputDirectory()
@@ -264,11 +285,6 @@ internal class GradlePluginAdapter private constructor(
 
     override fun generateEmbeddableWebComponents(): Boolean =
         config.generateEmbeddableWebComponents.get()
-
-    private fun File.hasVaadinWebappResourcesPath(): Boolean =
-        path.replace(File.separatorChar, '/').removeSuffix("/").endsWith(
-            Constants.VAADIN_WEBAPP_RESOURCES.removeSuffix("/")
-        )
 
     override fun optimizeBundle(): Boolean = config.optimizeBundle.get()
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -46,6 +46,8 @@ internal class GradlePluginAdapter private constructor(
 
     private val projectDir = config.projectDir
     private val projectName = config.projectName
+    private val buildResourcesDir =
+        project.getBuildResourcesDir(config.sourceSetName.get())
     private val jarProject: Boolean =
         project.tasks.withType(War::class.java).isEmpty()
     private val jarFiles: FileCollection
@@ -231,15 +233,20 @@ internal class GradlePluginAdapter private constructor(
         // generate stuff to build/vaadin-generated.
         //
         // However, after processResources is done, anything generated into
-        // build/vaadin-generated would simply be ignored. In such case we therefore
-        // need to generate stuff directly to build/resources/main.
+        // build/vaadin-generated would simply be ignored. In such cases,
+        // production resources must either be generated to the task-owned
+        // frontend output tree or to the source set resources directory.
         if (isBeforeProcessResources) {
             return File(
                 config.resourceOutputDirectory.get(),
                 Constants.VAADIN_SERVLET_RESOURCES
             )
         }
-        return frontendOutputDirectory().parentFile
+        val frontendOutputDirectory = frontendOutputDirectory()
+        if (frontendOutputDirectory.hasVaadinWebappResourcesPath()) {
+            return frontendOutputDirectory.parentFile
+        }
+        return File(buildResourcesDir, Constants.VAADIN_SERVLET_RESOURCES)
     }
 
     override fun webpackOutputDirectory(): File = frontendOutputDirectory()
@@ -257,6 +264,11 @@ internal class GradlePluginAdapter private constructor(
 
     override fun generateEmbeddableWebComponents(): Boolean =
         config.generateEmbeddableWebComponents.get()
+
+    private fun File.hasVaadinWebappResourcesPath(): Boolean =
+        path.replace(File.separatorChar, '/').removeSuffix("/").endsWith(
+            Constants.VAADIN_WEBAPP_RESOURCES.removeSuffix("/")
+        )
 
     override fun optimizeBundle(): Boolean = config.optimizeBundle.get()
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -46,8 +46,8 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
 
     /**
      * The folder where the frontend build tool should output index.js and other generated
-     * files. Defaults to `null` which will use the auto-detected value of
-     * resoucesDir of the main SourceSet, usually `build/resources/main/META-INF/VAADIN/webapp/`.
+     * files. Defaults to `null` which will use a task-owned build directory,
+     * usually `build/vaadin-build-frontend/META-INF/VAADIN/webapp/`.
      */
     @Deprecated(
         "use frontendOutputDirectory instead",
@@ -57,8 +57,8 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
 
     /**
      * The folder where the frontend build tool should output index.js and other generated
-     * files. Defaults to `null` which will use the auto-detected value of
-     * resoucesDir of the main SourceSet, usually `build/resources/main/META-INF/VAADIN/webapp/`.
+     * files. Defaults to `null` which will use a task-owned build directory,
+     * usually `build/vaadin-build-frontend/META-INF/VAADIN/webapp/`.
      */
     public abstract val frontendOutputDirectory: Property<File>
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -59,6 +59,13 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
      * The folder where the frontend build tool should output index.js and other generated
      * files. Defaults to `null` which will use a task-owned build directory,
      * usually `build/vaadin-build-frontend/META-INF/VAADIN/webapp/`.
+     *
+     * For the production bundle to be packaged into the application archive,
+     * this directory must follow the `META-INF/VAADIN/webapp` layout (as the
+     * default does). A custom value that does not end in `META-INF/VAADIN/webapp`
+     * cannot be packaged (it never produced a servable archive and, on Gradle 9,
+     * fails the build with an implicit task-dependency error), so the plugin
+     * rejects it with an error in production mode.
      */
     public abstract val frontendOutputDirectory: Property<File>
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -242,6 +242,22 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
      */
     public abstract val excludePostinstallPackages: ListProperty<String>
 
+    /**
+     * Names of `Jar`/`War`/`BootJar` tasks that must NOT receive the
+     * production frontend bundle, even though they would be selected by
+     * default. Use this to keep custom archives frontend-free. Takes
+     * precedence over [includeArchiveTasks].
+     */
+    public abstract val excludeArchiveTasks: ListProperty<String>
+
+    /**
+     * Names of `Jar`/`War`/`BootJar` tasks that must receive the production
+     * frontend bundle even when their archive classifier (e.g. `sources`,
+     * `javadoc`) would normally exclude them. [excludeArchiveTasks] takes
+     * precedence over this list.
+     */
+    public abstract val includeArchiveTasks: ListProperty<String>
+
     public val classpathFilter: ClasspathFilter = ClasspathFilter()
 
     /**
@@ -580,6 +596,14 @@ public class PluginEffectiveConfiguration(
         extension.excludePostinstallPackages
             .convention(listOf())
 
+    public val excludeArchiveTasks: ListProperty<String> =
+        extension.excludeArchiveTasks
+            .convention(listOf())
+
+    public val includeArchiveTasks: ListProperty<String> =
+        extension.includeArchiveTasks
+            .convention(listOf())
+
     public val classpathFilter: ClasspathFilter = extension.classpathFilter
 
     public val processResourcesTaskName: Property<String> =
@@ -757,6 +781,8 @@ public class PluginEffectiveConfiguration(
             "projectBuildDir=${projectBuildDir.get()}, " +
             "postinstallPackages=${postinstallPackages.get()}, " +
             "excludePostinstallPackages=${excludePostinstallPackages.get()}, " +
+            "excludeArchiveTasks=${excludeArchiveTasks.get()}, " +
+            "includeArchiveTasks=${includeArchiveTasks.get()}, " +
             "sourceSetName=${sourceSetName.get()}, " +
             "dependencyScope=${dependencyScope.get()}, " +
             "processResourcesTaskName=${processResourcesTaskName.get()}, " +

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -434,12 +434,14 @@ public class PluginEffectiveConfiguration(
         extension.frontendOutputDirectory.convention(
             extension.webpackOutputDirectory
                 .convention(
-                    sourceSetName.map {
-                        File(
-                            project.getBuildResourcesDir(it),
-                            Constants.VAADIN_WEBAPP_RESOURCES
-                        )
-                    }
+                    project.layout.buildDirectory
+                        .dir("vaadin-build-frontend")
+                        .map {
+                            File(
+                                it.asFile,
+                                Constants.VAADIN_WEBAPP_RESOURCES
+                            )
+                        }
                 )
         )
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -17,6 +17,7 @@ package com.vaadin.flow.gradle
 
 
 import java.io.File
+import com.vaadin.flow.server.Constants
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
@@ -81,6 +82,21 @@ internal fun Project.getSourceSet(sourceSetName: String): SourceSet = sourceSets
 internal fun Project.getBuildResourcesDir(sourceSetName: String): File = getSourceSet(sourceSetName).output.resourcesDir!!
 
 internal val Provider<File>.absolutePath: Provider<String> get() = map { it.absolutePath }
+
+/**
+ * Whether this directory follows the standard `META-INF/VAADIN/webapp`
+ * layout that holds the production frontend bundle. When it does, the Vaadin
+ * servlet resources (config, token, `stats.json`) live in the parent
+ * `META-INF/VAADIN` directory, next to the `webapp` bundle, so the whole tree
+ * is a self-contained, task-owned unit that can be packaged into the
+ * application archive. A custom `frontendOutputDirectory` that does not follow
+ * this layout cannot be packaged that way and is rejected by
+ * [GradlePluginAdapter.servletResourceOutputDirectory].
+ */
+internal fun File.hasVaadinWebappResourcesPath(): Boolean =
+    path.replace(File.separatorChar, '/').removeSuffix("/").endsWith(
+        Constants.VAADIN_WEBAPP_RESOURCES.removeSuffix("/")
+    )
 
 /**
  * Passes the value through only when [block] returns `true`, otherwise the


### PR DESCRIPTION
Gradle production builds could produce application archives (JAR/WAR)
without the Vaadin frontend resources when the `vaadinBuildFrontend`
output was restored from Gradle's build cache, causing the packaged
application to fail in production because the client bundle was missing.

The production frontend output is now a declared task output, so it is
correctly restored from the build cache and reliably packaged into the
application archive, including custom archive tasks. The new
`includeArchiveTasks` and `excludeArchiveTasks` options let you control
which archives receive the frontend bundle.

Breaking change: a custom `frontendOutputDirectory` must now follow the `META-INF/VAADIN/webapp` layout (as the default does). A value that does not end in `META-INF/VAADIN/webapp` is rejected with a build error in production mode. Previously it silently produced an archive without the frontend bundle and, on Gradle 9, failed with an implicit task-dependency error.

Fixes #24012