### PR TITLE
fix: skip vaadinBuildFrontend in development mode

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -90,6 +90,26 @@ class VaadinSmokeTest : AbstractGradleTest() {
     }
 
     @Test
+    fun `vaadinBuildFrontend is skipped in development mode when explicitly required`() {
+        // Some projects wire vaadinBuildFrontend into the build graph, e.g.
+        // jar.dependsOn('vaadinBuildFrontend'). In development mode the task
+        // must be skipped rather than failing the build (the production-only
+        // token service is not registered) or writing a production token.
+        // See https://github.com/vaadin/flow/issues/25000
+        testProject.buildFile.appendText("""
+            tasks.named('jar') {
+                dependsOn('vaadinBuildFrontend')
+            }
+        """.trimIndent())
+
+        val result: BuildResult = testProject.build("jar", checkTasksSuccessful = false)
+        result.expectTaskOutcome("vaadinBuildFrontend", TaskOutcome.SKIPPED)
+
+        val build = File(testProject.dir, "build/resources/main/META-INF/VAADIN/webapp/VAADIN/build")
+        expect(false, build.toString()) { build.exists() }
+    }
+
+    @Test
     fun testBuildFrontendInProductionMode() {
         val result: BuildResult = testProject.build("-Pvaadin.productionMode", "vaadinBuildFrontend")
         // vaadinBuildFrontend is self-contained in production mode and

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -151,6 +151,18 @@ public abstract class VaadinBuildFrontendTask : DefaultTask() {
     internal fun configure(config: PluginEffectiveConfiguration) {
         adapter.set(GradlePluginAdapter(this, config, false))
 
+        // vaadinBuildFrontend builds the optimized production bundle and
+        // writes a flow-build-info.json token with productionMode=true; it
+        // is only meaningful for production builds. Skip it in development
+        // mode so that an explicit dependency on the task (e.g.
+        // jar.dependsOn('vaadinBuildFrontend')) cannot overwrite the
+        // development token and make the running application behave as in
+        // production, and so the build does not fail because the
+        // production-only token build service is not registered (the
+        // service is registered by FlowPlugin only in production mode).
+        val productionMode = config.productionMode
+        onlyIf("Vaadin production mode is enabled") { productionMode.get() }
+
         // Track user-written frontend source files, excluding the
         // generated/ subdirectory (modified by this task) and index.html
         // (may be created by this task when missing; tracked as an output


### PR DESCRIPTION
The Gradle vaadinBuildFrontend task is now skipped when Vaadin production
mode is not enabled. This prevents development and multi-module builds from
failing when the task is part of the build graph, and avoids producing a
production configuration while running in development mode.

Fixes #25000