### PR TITLE
feat: Initial support for async bootstraping

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -19,24 +19,34 @@ import jakarta.servlet.MultipartConfigElement;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.atmosphere.cpr.ApplicationConfig;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.spring.bootstrap.VaadinAsyncInitFutureRegistry;
+import com.vaadin.flow.spring.bootstrap.VaadinDefaultAsyncInitFutureRegistry;
 import com.vaadin.flow.spring.springnative.ClientCallableAotProcessor;
 import com.vaadin.flow.spring.springnative.VaadinBeanFactoryInitializationAotProcessor;
 
@@ -52,6 +62,9 @@ import com.vaadin.flow.spring.springnative.VaadinBeanFactoryInitializationAotPro
 @EnableConfigurationProperties(VaadinConfigurationProperties.class)
 public class SpringBootAutoConfiguration {
 
+    private static final Logger LOG = LoggerFactory
+            .getLogger(SpringBootAutoConfiguration.class);
+
     @Autowired
     private WebApplicationContext context;
 
@@ -65,14 +78,45 @@ public class SpringBootAutoConfiguration {
         return new ClientCallableAotProcessor();
     }
 
+    @Bean
+    @ConditionalOnProperty(name = "vaadin.bootstrap.async")
+    @ConditionalOnMissingBean
+    public VaadinAsyncInitFutureRegistry vaadinWaitForAsyncInitContainer() {
+        return new VaadinDefaultAsyncInitFutureRegistry();
+    }
+
     /**
      * Creates a {@link ServletContextInitializer} instance.
      *
      * @return a custom ServletContextInitializer instance
      */
     @Bean
-    public ServletContextInitializer contextInitializer() {
-        return new VaadinServletContextInitializer(context);
+    @ConditionalOnMissingBean
+    public VaadinServletContextInitializer contextInitializer(
+            Map<String, AsyncTaskExecutor> taskExecutors,
+            Optional<VaadinAsyncInitFutureRegistry> optVaadinAsyncInitFutureRegistry) {
+        Consumer<Runnable> contextInitializedExecutor = optVaadinAsyncInitFutureRegistry
+                .<Consumer<Runnable>> map(reg -> {
+                    final AsyncTaskExecutor asyncTaskExecutor = determineBootstrapExecutor(
+                            taskExecutors);
+                    if (asyncTaskExecutor == null) {
+                        return null;
+                    }
+                    LOG.debug("Will use async bootstrap using {}",
+                            asyncTaskExecutor);
+                    return asyncTaskExecutor::submit;
+                }).orElseGet(() -> Runnable::run);
+        return new VaadinServletContextInitializer(context,
+                contextInitializedExecutor);
+    }
+
+    // NOTE: Based on JpaBaseConfiguration
+    protected @Nullable AsyncTaskExecutor determineBootstrapExecutor(
+            Map<String, AsyncTaskExecutor> taskExecutors) {
+        return taskExecutors.size() == 1
+                ? taskExecutors.values().iterator().next()
+                : taskExecutors.get(
+                        TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
     }
 
     /**
@@ -90,12 +134,13 @@ public class SpringBootAutoConfiguration {
     @ConditionalOnMissingBean(value = SpringServlet.class, parameterizedContainer = ServletRegistrationBean.class)
     public ServletRegistrationBean<SpringServlet> servletRegistrationBean(
             ObjectProvider<MultipartConfigElement> multipartConfig,
-            VaadinConfigurationProperties configurationProperties) {
+            VaadinConfigurationProperties configurationProperties,
+            Optional<VaadinAsyncInitFutureRegistry> optVaadinAsyncInitFutureRegistry) {
         boolean rootMapping = RootMappedCondition
                 .isRootMapping(configurationProperties.getUrlMapping());
         return configureServletRegistrationBean(multipartConfig,
-                configurationProperties,
-                new SpringServlet(context, rootMapping));
+                configurationProperties, new SpringServlet(context, rootMapping,
+                        optVaadinAsyncInitFutureRegistry));
     }
 
     public static ServletRegistrationBean<SpringServlet> configureServletRegistrationBean(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.spring;
 
+import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,6 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -36,6 +38,7 @@ import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.shared.util.SharedUtil;
+import com.vaadin.flow.spring.bootstrap.VaadinAsyncInitFutureRegistry;
 
 /**
  * Spring application context aware Vaadin servlet implementation.
@@ -75,6 +78,7 @@ public class SpringServlet extends VaadinServlet {
 
     private final ApplicationContext context;
     private final boolean rootMapping;
+    private final Optional<VaadinAsyncInitFutureRegistry> optVaadinAsyncInitFutureRegistry;
 
     /**
      * Creates a new Vaadin servlet instance with the application
@@ -91,7 +95,6 @@ public class SpringServlet extends VaadinServlet {
      * mapping which doesn't overlap with any endpoint mapping. In this case use
      * {@code false} for the {@code forwardingEnforced} parameter.
      *
-     *
      * @param context
      *            the Spring application context
      * @param rootMapping
@@ -100,8 +103,45 @@ public class SpringServlet extends VaadinServlet {
      * @since 11.0
      */
     public SpringServlet(ApplicationContext context, boolean rootMapping) {
+        this(context, rootMapping, Optional.empty());
+    }
+
+    /**
+     * Creates a new Vaadin servlet instance with the application
+     * {@code context} provided.
+     * <p>
+     * Use {@code true} as a value for {@code forwardingEnforced} parameter if
+     * your servlet is mapped to the root ({@code "/*"}). In the case of root
+     * mapping a {@link RootMappedCondition} is checked and
+     * {@link VaadinServletConfiguration} is applied conditionally. This
+     * configuration provide a {@link ServletForwardingController} so that other
+     * Spring endpoints may co-exist with Vaadin application (it's required
+     * since root mapping handles any request to the context). This is not
+     * needed if you are using non-root mapping since are you free to use the
+     * mapping which doesn't overlap with any endpoint mapping. In this case use
+     * {@code false} for the {@code forwardingEnforced} parameter.
+     *
+     * @param context
+     *            the Spring application context
+     * @param rootMapping
+     *            the incoming HttpServletRequest is wrapped in
+     *            ForwardingRequestWrapper if {@code true}
+     * @param optVaadinAsyncInitFutureRegistry
+     *            Optional {@link VaadinAsyncInitFutureRegistry}
+     * @since 11.0
+     */
+    public SpringServlet(ApplicationContext context, boolean rootMapping,
+            Optional<VaadinAsyncInitFutureRegistry> optVaadinAsyncInitFutureRegistry) {
         this.context = context;
         this.rootMapping = rootMapping;
+        this.optVaadinAsyncInitFutureRegistry = optVaadinAsyncInitFutureRegistry;
+    }
+
+    @Override
+    public void init(ServletConfig servletConfig) throws ServletException {
+        optVaadinAsyncInitFutureRegistry.ifPresent(
+                VaadinAsyncInitFutureRegistry::waitForAllUntilFinishedAndClose);
+        super.init(servletConfig);
     }
 
     @Override

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
@@ -192,7 +192,7 @@ public class VaadinServletConfiguration {
      */
     @Bean
     public RootExcludeHandler vaadinRootMapping(Environment environment,
-            Controller vaadinForwardingController,
+            @Qualifier("vaadinForwardingController") Controller vaadinForwardingController,
             @Autowired(required = false) @Qualifier("resourceHandlerMapping") HandlerMapping resourceHandlerMapping) {
         return new RootExcludeHandler(getExcludedUrls(environment),
                 vaadinForwardingController, resourceHandlerMapping);
@@ -203,7 +203,7 @@ public class VaadinServletConfiguration {
      *
      * @return a forwarding controller
      */
-    @Bean
+    @Bean(name = "vaadinForwardingController")
     public Controller vaadinForwardingController() {
         ServletForwardingController controller = new ServletForwardingController();
         controller.setServletName(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -113,6 +114,7 @@ public class VaadinServletContextInitializer
 
     private static boolean devModeCachingEnabled;
     private ApplicationContext appContext;
+    private Consumer<Runnable> contextInitializedExecutor;
     private ResourceLoader customLoader;
     private MetadataReaderFactory metadataReaderFactory;
 
@@ -233,17 +235,26 @@ public class VaadinServletContextInitializer
     private static class CompositeServletContextListener
             implements ServletContextListener, Serializable {
         private final List<FailFastServletContextListener> listeners = new ArrayList<>();
+        private final Consumer<Runnable> contextInitializedExecutor;
+
+        public CompositeServletContextListener(
+                Consumer<Runnable> contextInitializedExecutor) {
+            this.contextInitializedExecutor = contextInitializedExecutor;
+        }
 
         @Override
         public void contextInitialized(ServletContextEvent event) {
-            long start = System.nanoTime();
+            contextInitializedExecutor.accept(() -> {
+                long start = System.nanoTime();
 
-            listeners.forEach(listener -> listener.contextInitialized(event));
+                listeners.forEach(
+                        listener -> listener.contextInitialized(event));
 
-            long ms = (System.nanoTime() - start) / 1000000;
-            getLogger().debug(
-                    "Total time for Vaadin Servlet Context Init took {} ms",
-                    ms);
+                long ms = (System.nanoTime() - start) / 1000000;
+                getLogger().debug(
+                        "Total time for Vaadin Servlet Context Init took {} ms",
+                        ms);
+            });
         }
 
         @Override
@@ -728,7 +739,22 @@ public class VaadinServletContextInitializer
      *            the application context
      */
     public VaadinServletContextInitializer(ApplicationContext context) {
+        this(context, Runnable::run);
+    }
+
+    /**
+     * Creates a new {@link ServletContextInitializer} instance with application
+     * {@code context} provided.
+     *
+     * @param context
+     *            the application context
+     * @param contextInitializedExecutor
+     *            execution function for context initialized
+     */
+    public VaadinServletContextInitializer(ApplicationContext context,
+            Consumer<Runnable> contextInitializedExecutor) {
         appContext = context;
+        this.contextInitializedExecutor = contextInitializedExecutor;
 
         String neverScanProperty = appContext.getEnvironment()
                 .getProperty("vaadin.blocked-packages");
@@ -777,9 +803,7 @@ public class VaadinServletContextInitializer
     }
 
     @Override
-    public void onStartup(ServletContext servletContext)
-            throws ServletException {
-
+    public void onStartup(ServletContext servletContext) {
         VaadinServletContext vaadinContext = new VaadinServletContext(
                 servletContext);
         servletContext.addListener(createCompositeListener(vaadinContext));
@@ -823,7 +847,8 @@ public class VaadinServletContextInitializer
 
     private CompositeServletContextListener createCompositeListener(
             VaadinServletContext context) {
-        CompositeServletContextListener compositeListener = new CompositeServletContextListener();
+        CompositeServletContextListener compositeListener = new CompositeServletContextListener(
+                this.contextInitializedExecutor);
 
         compositeListener.addListener(new LookupInitializerListener());
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/bootstrap/VaadinAsyncInitFutureRegistry.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/bootstrap/VaadinAsyncInitFutureRegistry.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.bootstrap;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A registry to register initialization futures.
+ */
+public interface VaadinAsyncInitFutureRegistry {
+    void register(final CompletableFuture<Void> cf);
+
+    void waitForAllUntilFinishedAndClose();
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/bootstrap/VaadinDefaultAsyncInitFutureRegistry.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/bootstrap/VaadinDefaultAsyncInitFutureRegistry.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.bootstrap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VaadinDefaultAsyncInitFutureRegistry
+        implements VaadinAsyncInitFutureRegistry, AutoCloseable {
+    private static final Logger LOG = LoggerFactory
+            .getLogger(VaadinDefaultAsyncInitFutureRegistry.class);
+
+    protected List<CompletableFuture<?>> cfs = new ArrayList<>();
+    protected ReentrantLock lock = new ReentrantLock();
+
+    @Override
+    public void register(final CompletableFuture<Void> cf) {
+        lock.lock();
+        try {
+            throwIfNotUsable();
+
+            cfs.add(cf);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void waitForAllUntilFinishedAndClose() {
+        lock.lock();
+        try {
+            throwIfNotUsable();
+
+            final long startMs = System.currentTimeMillis();
+
+            CompletableFuture.allOf(cfs.toArray(CompletableFuture[]::new))
+                    .join();
+
+            LOG.debug("Waiting for async init({}x futures) took {}ms",
+                    this.cfs.size(), System.currentTimeMillis() - startMs);
+
+            close();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    protected void throwIfNotUsable() {
+        if (cfs == null) {
+            throw new IllegalStateException(
+                    "Registry was closed and is no longer usable");
+        }
+    }
+
+    @Override
+    public void close() {
+        cfs = null;
+    }
+}


### PR DESCRIPTION
## Description

This PR adds initial/rough support for async bootstrapping.
This can be enabled using `vaadin.bootstrap.async`.

The overall code is based on https://github.com/spring-projects/spring-boot/commit/91f4bc94558e161dd9d100fdd9db209a8f55fa8b

Further more it fixes a problem that currently affects 24.3 where Vaadin crashes if another `Controller` is present (I was not able to boot the application I tested against otherwise).

Fixes #24882
Fixes #25007

Please note that this PR serves as a baseline. 
A Vaadin dev should have a look over it and fine tune it before merging.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
  * **Tests are already failing locally on the default branch**
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
  * No Acceptance Criteria were outlined in the corresponding GitHub issue
