### PR TITLE
fix: expose production frontend bundle on the runtime classpath

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -1015,12 +1015,10 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     /**
-     * Before the frontend output was moved to a task-owned directory, the
-     * production bundle was written into the `main` source set resources, so
-     * every archive task - including custom-named `Jar` tasks - triggered
-     * `vaadinBuildFrontend` and packaged the bundle. Restricting packaging to
-     * a fixed set of well-known task names must not silently drop the bundle
-     * (and the `vaadinBuildFrontend` dependency) from such custom archives.
+     * A custom-named archive task that packages the `main` source set output
+     * receives the production bundle (registered as an extra source set output
+     * directory) and transitively depends on `vaadinBuildFrontend` through the
+     * `builtBy` wiring, without any explicit task dependency.
      */
     @Test
     fun buildFrontend_customArchiveTask_containsProductionBundle() {
@@ -1058,9 +1056,10 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     /**
-     * Source and javadoc archives are identified by their classifier and
-     * must never carry the production frontend bundle, even though they are
-     * `Jar` tasks.
+     * The production bundle is exposed as an extra `main` source set output
+     * directory, so it is packaged only into archives that include the source
+     * set output. Source and javadoc jars package `allSource`/javadoc output
+     * instead, so they must never carry the production frontend bundle.
      */
     @Test
     fun buildFrontend_sourcesAndJavadocJars_doNotContainProductionBundle() {
@@ -1108,16 +1107,26 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     /**
-     * A custom archive that would be packaged by default can be opted out
-     * via `vaadin.excludeArchiveTasks`. The frontend is still built (the
-     * `jar` task consumes it), but the excluded archive stays frontend-free.
+     * The production bundle is registered as an extra `main` source set output
+     * directory, so it is on the runtime classpath. This is what lets an
+     * application served in place during a production build (e.g. gretty
+     * integration tests) run in production mode instead of falling back to the
+     * development bundle. Regression test for the bundle being written to a
+     * task-owned directory that was not on the runtime classpath.
+     *
+     * The check uses `stats.json` rather than `flow-build-info.json` because
+     * the token is intentionally removed from the bundle directory after the
+     * build and only restored while an application archive is being packaged;
+     * `stats.json` is a stable marker of the bundle directory's presence on the
+     * classpath.
      */
     @Test
-    fun buildFrontend_excludedArchiveTask_doesNotContainProductionBundle() {
+    fun buildFrontend_productionBundle_isOnMainRuntimeClasspath() {
         testProject.buildFile.writeText(
             """
             plugins {
-                id 'java'
+                id 'war'
+                id 'org.gretty' version '4.0.3'
                 id("com.vaadin.flow")
             }
             repositories {
@@ -1125,72 +1134,35 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 mavenCentral()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
-            vaadin {
-                excludeArchiveTasks = ['appJar']
-            }
-            def jettyVersion = "11.0.12"
             dependencies {
                 implementation("com.vaadin:flow:$flowVersion")
+                providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
                 implementation("org.slf4j:slf4j-simple:$slf4jVersion")
-                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
-                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
-                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
             }
-            tasks.register('appJar', Jar) {
-                archiveClassifier = 'app'
-                from sourceSets.main.output
+            tasks.register('verifyBundleOnRuntimeClasspath') {
+                dependsOn 'vaadinBuildFrontend'
+                def runtimeClasspath = sourceSets.main.runtimeClasspath
+                doLast {
+                    def stats = runtimeClasspath.files.collect {
+                        new File(it, 'META-INF/VAADIN/config/stats.json')
+                    }.find { it.exists() }
+                    if (stats == null) {
+                        throw new GradleException(
+                            'production bundle (META-INF/VAADIN/config/stats.json) ' +
+                            'not found on main runtime classpath')
+                    }
+                    println 'PRODUCTION_BUNDLE_ON_CLASSPATH=' + stats
+                }
             }
         """.trimIndent()
         )
 
-        val result = testProject.build("-Pvaadin.productionMode", "build", "appJar")
+        val result = testProject.build(
+            "-Pvaadin.productionMode", "verifyBundleOnRuntimeClasspath")
         result.expectTaskSucceded("vaadinBuildFrontend")
-
-        val appJar = testProject.folder("build/libs").find("*-app.jar").first()
-        expectArchiveDoesntContainVaadinBundle(appJar, false)
-    }
-
-    /**
-     * A `tests`-classified archive is excluded by default, but can be forced
-     * to receive the frontend bundle via `vaadin.includeArchiveTasks`, which
-     * overrides the classifier-based exclusion.
-     */
-    @Test
-    fun buildFrontend_includedArchiveTask_overridesClassifierExclusion() {
-        testProject.buildFile.writeText(
-            """
-            plugins {
-                id 'java'
-                id("com.vaadin.flow")
-            }
-            repositories {
-                mavenLocal()
-                mavenCentral()
-                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
-            }
-            vaadin {
-                includeArchiveTasks = ['fixtureJar']
-            }
-            def jettyVersion = "11.0.12"
-            dependencies {
-                implementation("com.vaadin:flow:$flowVersion")
-                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
-                implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
-                implementation("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
-                implementation("org.eclipse.jetty.websocket:websocket-jakarta-server:${"$"}{jettyVersion}")
-            }
-            tasks.register('fixtureJar', Jar) {
-                archiveClassifier = 'tests'
-                from sourceSets.main.output
-            }
-        """.trimIndent()
-        )
-
-        val result = testProject.build("-Pvaadin.productionMode", "fixtureJar")
-        result.expectTaskSucceded("vaadinBuildFrontend")
-
-        val fixtureJar = testProject.folder("build/libs").find("*-tests.jar").first()
-        expectArchiveContainsVaadinBundle(fixtureJar, false)
+        expect(true) {
+            result.output.contains("PRODUCTION_BUNDLE_ON_CLASSPATH=")
+        }
     }
 
     @Test

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -151,11 +151,10 @@ fun expectArchiveContainsVaadinBundle(
 ) {
     val isWar: Boolean = archive.name.endsWith(".war", true)
     val isStandaloneJar: Boolean = !isWar && !isSpringBootJar
-    val resourcePackaging: String = when {
-        isWar -> "WEB-INF/classes/"
-        isSpringBootJar -> "BOOT-INF/classes/"
-        else -> ""
-    }
+    // The bundle is packaged as source set output: a War routes it to
+    // WEB-INF/classes, while a plain or Spring Boot executable jar keeps it at
+    // the archive root. (Spring Boot dependency jars still go to BOOT-INF/lib.)
+    val resourcePackaging: String = if (isWar) "WEB-INF/classes/" else ""
     expectArchiveContains(
             "${resourcePackaging}META-INF/VAADIN/config/flow-build-info.json",
             "${resourcePackaging}META-INF/VAADIN/config/stats.json",
@@ -186,11 +185,9 @@ fun expectArchiveDoesntContainVaadinBundle(archive: File,
                                            isSpringBootJar: Boolean) {
     val isWar: Boolean = archive.name.endsWith(".war", true)
     val isStandaloneJar: Boolean = !isWar && !isSpringBootJar
-    val resourcePackaging: String = when {
-        isWar -> "WEB-INF/classes/"
-        isSpringBootJar -> "BOOT-INF/classes/"
-        else -> ""
-    }
+    // See expectArchiveContainsVaadinBundle: War → WEB-INF/classes, plain and
+    // Spring Boot executable jars keep the bundle at the archive root.
+    val resourcePackaging: String = if (isWar) "WEB-INF/classes/" else ""
     expectArchiveDoesntContain("${resourcePackaging}META-INF/VAADIN/config/flow-build-info.json",
             "${resourcePackaging}META-INF/VAADIN/config/stats.json",
             "${resourcePackaging}META-INF/VAADIN/webapp/VAADIN/build/*.gz",

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
@@ -21,7 +21,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.api.tasks.bundling.War
 import org.gradle.util.GradleVersion
 
 /**
@@ -31,12 +30,6 @@ import org.gradle.util.GradleVersion
 public class FlowPlugin : Plugin<Project> {
     public companion object {
         public const val GRADLE_MINIMUM_SUPPORTED_VERSION: String = "8.14"
-
-        // Archive classifiers that never carry the production frontend
-        // bundle (source and javadoc distributions, test fixtures). Any
-        // other Jar/War/BootJar is treated as an application archive.
-        private val NON_APPLICATION_ARCHIVE_CLASSIFIERS =
-            setOf("sources", "javadoc", "test-sources", "tests")
     }
 
     override fun apply(project: Project) {
@@ -86,29 +79,25 @@ public class FlowPlugin : Plugin<Project> {
                 val vaadinBuildFrontendOutputDirectory =
                     vaadinServletResourcesDirectory.parentFile?.parentFile
 
-                val sourceSetResourcesDirectory =
-                    project.getBuildResourcesDir(config.sourceSetName.get())
-
-                val includedArchiveTasks = config.includeArchiveTasks.get().toSet()
-                val excludedArchiveTasks = config.excludeArchiveTasks.get().toSet()
-
-                project.tasks.withType(Jar::class.java) { task: Jar ->
-                    if (task.isVaadinApplicationArchiveTask(
-                            includedArchiveTasks, excludedArchiveTasks)) {
-                        task.dependsOn("vaadinBuildFrontend")
-                        if (vaadinBuildFrontendOutputDirectory != null &&
-                            vaadinBuildFrontendOutputDirectory.canonicalFile !=
-                            sourceSetResourcesDirectory.canonicalFile
-                        ) {
-                            task.from(vaadinBuildFrontendOutputDirectory) { copySpec ->
-                                val archivePath =
-                                    task.vaadinBuildFrontendResourcesArchivePath()
-                                if (archivePath != null) {
-                                    copySpec.into(archivePath)
-                                }
-                            }
-                        }
-                    }
+                if (vaadinBuildFrontendOutputDirectory != null) {
+                    // Expose the production bundle (a task-owned tree laid out
+                    // as META-INF/VAADIN/...) as an extra output directory of
+                    // the source set. Through standard Gradle wiring this puts
+                    // it on the runtime classpath - so in-place runners (e.g.
+                    // gretty serving during a production build) find the bundle
+                    // and the production flow-build-info.json - and packages it
+                    // into every application archive (WEB-INF/classes for War,
+                    // the archive root for a plain or Spring Boot executable
+                    // jar), while archives that don't consume the source set
+                    // output (sources/javadoc jars) stay frontend-free. builtBy
+                    // wires every consumer to vaadinBuildFrontend, so no
+                    // explicit task dependency is needed. The bundle stays out
+                    // of build/resources/main, so vaadinBuildFrontend keeps its
+                    // own declared output and remains build-cache correct.
+                    project.getSourceSet(config.sourceSetName.get()).output.dir(
+                        mapOf("builtBy" to buildFrontendTask),
+                        vaadinBuildFrontendOutputDirectory
+                    )
                 }
             } else if (config.alwaysExecutePrepareFrontend.get()) {
                 // In development mode, vaadinPrepareFrontend is not
@@ -175,19 +164,14 @@ public class FlowPlugin : Plugin<Project> {
                 // Ensure close() fires after vaadinBuildFrontend and
                 // all Jar/War packaging tasks have completed.
                 buildFrontendTask.usesService(tokenService)
-                val includedArchiveTasks = config.includeArchiveTasks.get().toSet()
-                val excludedArchiveTasks = config.excludeArchiveTasks.get().toSet()
                 project.tasks.withType(Jar::class.java) { task: Jar ->
-                    if (task.isVaadinApplicationArchiveTask(
-                            includedArchiveTasks, excludedArchiveTasks)) {
-                        task.usesService(tokenService)
-                        // Restore the production token before packaging in
-                        // case it was deleted by a previous build's cleanup.
-                        // Capture the service provider rather than the Project so
-                        // the action stays compatible with the configuration cache.
-                        task.doFirst {
-                            tokenService.get().ensureToken()
-                        }
+                    task.usesService(tokenService)
+                    // Restore the production token before packaging in
+                    // case it was deleted by a previous build's cleanup.
+                    // Capture the service provider rather than the Project so
+                    // the action stays compatible with the configuration cache.
+                    task.doFirst {
+                        tokenService.get().ensureToken()
                     }
                 }
             }
@@ -205,38 +189,4 @@ public class FlowPlugin : Plugin<Project> {
             )
         }
     }
-
-    private fun Jar.vaadinBuildFrontendResourcesArchivePath(): String? {
-        return when {
-            this is War -> "WEB-INF/classes"
-            isSpringBootJar() -> "BOOT-INF/classes"
-            else -> null
-        }
-    }
-
-    // Whether the production frontend bundle should be packaged into this
-    // archive. By default every Jar/War/BootJar qualifies, except source,
-    // javadoc and test-fixture distributions (identified by their archive
-    // classifier). The default can be overridden per task via the
-    // `includeArchiveTasks` / `excludeArchiveTasks` plugin settings, with
-    // `excludeArchiveTasks` taking precedence.
-    private fun Jar.isVaadinApplicationArchiveTask(
-        includedTaskNames: Set<String>,
-        excludedTaskNames: Set<String>
-    ): Boolean {
-        if (name in excludedTaskNames) {
-            return false
-        }
-        if (name in includedTaskNames) {
-            return true
-        }
-        return archiveClassifier.orNull.orEmpty() !in
-                NON_APPLICATION_ARCHIVE_CLASSIFIERS
-    }
-
-    private fun Jar.isSpringBootJar(): Boolean =
-        generateSequence(javaClass as Class<*>) { it.superclass }
-            .any {
-                it.name == "org.springframework.boot.gradle.tasks.bundling.BootJar"
-            }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -136,9 +136,17 @@ public abstract class VaadinBuildFrontendTask : DefaultTask() {
 
         // Maven's task run in the LifecyclePhase.PROCESS_CLASSES phase
 
-        // We need access to the produced classes, to be able to analyze e.g.
-        // @CssImport annotations used by the project.
-        dependsOn("classes")
+        // We need access to the produced classes and resources, to analyze
+        // e.g. @CssImport annotations and to pick up frontend resources served
+        // from the classpath (META-INF/resources/frontend). Ordering is
+        // established granularly in configure(): after compilation via the
+        // @Classpath `projectClassesDirs` input, and after resource processing
+        // via an explicit dependency on the processResources task. We avoid
+        // depending on the `classes` lifecycle task because, in production
+        // mode, the bundle produced by this task is registered as an extra
+        // `main` source set output directory (so it reaches the runtime
+        // classpath and application archives), which makes `classes` depend on
+        // this task - depending back on `classes` would form a cycle.
 
         // Make sure to run this task before the `war`/`jar` tasks, so that
         // vite bundle will end up packaged in the war/jar archive. The inclusion
@@ -162,6 +170,15 @@ public abstract class VaadinBuildFrontendTask : DefaultTask() {
         // service is registered by FlowPlugin only in production mode).
         val productionMode = config.productionMode
         onlyIf("Vaadin production mode is enabled") { productionMode.get() }
+
+        // Frontend scanning reads resources served from the classpath (e.g.
+        // META-INF/resources/frontend), so this task must run after the source
+        // set resources have been processed. Compilation ordering is covered
+        // by the @Classpath projectClassesDirs input. Depending on the
+        // processResources task directly (rather than the `classes` lifecycle
+        // task) avoids the production-mode dependency cycle described in the
+        // constructor.
+        dependsOn(config.processResourcesTaskName)
 
         // Track user-written frontend source files, excluding the
         // generated/ subdirectory (modified by this task) and index.html

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -249,22 +249,6 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
      */
     public abstract val excludePostinstallPackages: ListProperty<String>
 
-    /**
-     * Names of `Jar`/`War`/`BootJar` tasks that must NOT receive the
-     * production frontend bundle, even though they would be selected by
-     * default. Use this to keep custom archives frontend-free. Takes
-     * precedence over [includeArchiveTasks].
-     */
-    public abstract val excludeArchiveTasks: ListProperty<String>
-
-    /**
-     * Names of `Jar`/`War`/`BootJar` tasks that must receive the production
-     * frontend bundle even when their archive classifier (e.g. `sources`,
-     * `javadoc`) would normally exclude them. [excludeArchiveTasks] takes
-     * precedence over this list.
-     */
-    public abstract val includeArchiveTasks: ListProperty<String>
-
     public val classpathFilter: ClasspathFilter = ClasspathFilter()
 
     /**
@@ -603,14 +587,6 @@ public class PluginEffectiveConfiguration(
         extension.excludePostinstallPackages
             .convention(listOf())
 
-    public val excludeArchiveTasks: ListProperty<String> =
-        extension.excludeArchiveTasks
-            .convention(listOf())
-
-    public val includeArchiveTasks: ListProperty<String> =
-        extension.includeArchiveTasks
-            .convention(listOf())
-
     public val classpathFilter: ClasspathFilter = extension.classpathFilter
 
     public val processResourcesTaskName: Property<String> =
@@ -788,8 +764,6 @@ public class PluginEffectiveConfiguration(
             "projectBuildDir=${projectBuildDir.get()}, " +
             "postinstallPackages=${postinstallPackages.get()}, " +
             "excludePostinstallPackages=${excludePostinstallPackages.get()}, " +
-            "excludeArchiveTasks=${excludeArchiveTasks.get()}, " +
-            "includeArchiveTasks=${includeArchiveTasks.get()}, " +
             "sourceSetName=${sourceSetName.get()}, " +
             "dependencyScope=${dependencyScope.get()}, " +
             "processResourcesTaskName=${processResourcesTaskName.get()}, " +


### PR DESCRIPTION
The production frontend bundle produced by vaadinBuildFrontend was written to a task-owned directory (build/vaadin-build-frontend) that is not on the runtime classpath. It was copied into application archives with an explicit Jar.from(...), but never exposed on the classpath, so an application served in place from the source set output - gretty during a production build, or an IDE/bootRun launch - no longer found the bundle or the production flow-build-info.json and started in development mode, failing with "There is no dev-bundle ... found".

Register the bundle directory as an extra output of the main source set (output.dir(builtBy: vaadinBuildFrontend)), restoring the behavior that shipped through 25.1.x: the bundle is on the runtime classpath for in-place runs and is packaged into every application archive through standard source-set-output handling (WEB-INF/classes for WAR, the archive root for plain and Spring Boot executable jars). The task-owned output directory introduced in #25001 is kept, so the build-cache fix (#24012) is preserved.

Because output.dir makes the `classes` lifecycle task depend on vaadinBuildFrontend, this task no longer depends on `classes` (which would form a cycle). Ordering after compilation is established by its @Classpath classesDirs input, and ordering after resource processing by an explicit dependency on the processResources task.

The per-archive Jar.from(...) copying, the Spring Boot BOOT-INF/classes special-casing, and the includeArchiveTasks/excludeArchiveTasks options (all introduced in 25.3.0-alpha4, never in a stable release) are no longer needed and are removed. The Spring Boot bundle location returns to the archive root, matching 25.1.x.

Fixes #25021