### PR TITLE
fix: include `/usr/bin` as location for linux tools

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -81,7 +81,7 @@ public class FrontendToolsLocator implements Serializable {
         List<String> candidateLocations = executeCommand(false,
                 isWindows() ? "where" : "which", toolName)
                 .map(this::omitErrorResult).map(CommandResult::getStdout)
-                .orElseGet(() -> Arrays.asList(, 
+                .orElseGet(() -> Arrays.asList(
                         "/usr/bin/" + toolName,
                         // Add most common paths in unix #5611
                         "/usr/local/bin/" + toolName,

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -82,8 +82,8 @@ public class FrontendToolsLocator implements Serializable {
                 isWindows() ? "where" : "which", toolName)
                 .map(this::omitErrorResult).map(CommandResult::getStdout)
                 .orElseGet(() -> Arrays.asList(
-                        "/usr/bin/" + toolName,
                         // Add most common paths in unix #5611
+                        "/usr/bin/" + toolName,
                         "/usr/local/bin/" + toolName,
                         "/opt/local/bin/" + toolName, "/opt/bin/" + toolName));
 

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -81,12 +81,12 @@ public class FrontendToolsLocator implements Serializable {
         List<String> candidateLocations = executeCommand(false,
                 isWindows() ? "where" : "which", toolName)
                 .map(this::omitErrorResult).map(CommandResult::getStdout)
-                .orElseGet(() -> Arrays.asList(
+                .orElseGet(() -> Arrays.asList(, 
+                        "/usr/bin/" + toolName,
                         // Add most common paths in unix #5611
                         "/usr/local/bin/" + toolName,
                         "/opt/local/bin/" + toolName, 
-                        "/opt/bin/" + toolName, 
-                        "/usr/bin/" + toolName
+                        "/opt/bin/" + toolName
                 ));
 
         for (String candidateLocation : candidateLocations) {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -83,8 +83,7 @@ public class FrontendToolsLocator implements Serializable {
                 .map(this::omitErrorResult).map(CommandResult::getStdout)
                 .orElseGet(() -> Arrays.asList(
                         // Add most common paths in unix #5611
-                        "/usr/bin/" + toolName,
-                        "/usr/local/bin/" + toolName,
+                        "/usr/bin/" + toolName, "/usr/local/bin/" + toolName,
                         "/opt/local/bin/" + toolName, "/opt/bin/" + toolName));
 
         for (String candidateLocation : candidateLocations) {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -84,7 +84,10 @@ public class FrontendToolsLocator implements Serializable {
                 .orElseGet(() -> Arrays.asList(
                         // Add most common paths in unix #5611
                         "/usr/local/bin/" + toolName,
-                        "/opt/local/bin/" + toolName, "/opt/bin/" + toolName));
+                        "/opt/local/bin/" + toolName, 
+                        "/opt/bin/" + toolName, 
+                        "/usr/bin/" + toolName
+                ));
 
         for (String candidateLocation : candidateLocations) {
             File candidate = new File(candidateLocation);

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -85,9 +85,7 @@ public class FrontendToolsLocator implements Serializable {
                         "/usr/bin/" + toolName,
                         // Add most common paths in unix #5611
                         "/usr/local/bin/" + toolName,
-                        "/opt/local/bin/" + toolName, 
-                        "/opt/bin/" + toolName
-                ));
+                        "/opt/local/bin/" + toolName, "/opt/bin/" + toolName));
 
         for (String candidateLocation : candidateLocations) {
             File candidate = new File(candidateLocation);


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

When installing nodejs through the package manager it lands in `/usr/bin`

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
