### PR TITLE
fix: reflect RangeInput initial value to the DOM

### DIFF
--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/RangeInputElementIT.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/RangeInputElementIT.java
@@ -35,7 +35,9 @@ public class RangeInputElementIT extends ChromeBrowserTest {
 
     @Test
     public void getSetValue() {
-        Assert.assertNull(input.getValue());
+        // The initial value is explicitly reflected to the DOM so the slider
+        // renders at 0 instead of the browser's midpoint default. See #20576.
+        Assert.assertEquals(0.0, (double) input.getValue(), 0.1);
         input.setValue(5.0);
         Assert.assertEquals(5.0, (double) input.getValue(), 0.1);
         Assert.assertEquals("Value is '5.0'", log.getText());

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
@@ -94,6 +94,12 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
         super("value", 0.0, false);
         setValueChangeMode(valueChangeMode);
         set(typeDescriptor, "range");
+        // Explicitly reflect the initial value to the DOM. A value-less
+        // range input defaults on the client to the midpoint of min and max,
+        // so without this the slider would render in the middle even though
+        // the server-side value is 0. Setting the value through setValue would
+        // be a no-op here because it equals the field's default model value.
+        getElement().setProperty("value", 0.0);
     }
 
     @Override

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RangeInputTest extends ComponentTest {
 
@@ -57,6 +58,16 @@ class RangeInputTest extends ComponentTest {
     @Override
     protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
+    }
+
+    @Test
+    void newRangeInput_valuePropertyReflectedToDom() {
+        // A value-less range input defaults to the midpoint of min/max on the
+        // client, so the initial value must be present on the element.
+        final RangeInput rangeInput = new RangeInput();
+        assertEquals(0.0, rangeInput.getValue());
+        assertTrue(rangeInput.getElement().hasProperty("value"));
+        assertEquals(0.0, rangeInput.getElement().getProperty("value", -1.0));
     }
 
     @Test


### PR DESCRIPTION
A RangeInput created with its default value (0.0)
never rendered at 0 as setting default nothing
writes the value property.

Instead the slider appeared in the middle of
its range — 10 for a 0–20 range etc.

Explicitly set the value property in constructor.

fixes #20576
