### PR TITLE
fix: downgrade Vite to 8.0

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "8.1.3",
+    "vite": "8.0.16",
     "@vitejs/plugin-react": "6.0.3",
     "@preact/signals-react-transform": "0.8.1",
     "@rollup/plugin-replace": "6.0.3",


### PR DESCRIPTION
Downgrade Vite until rolldown/rolldown#10281 gets fixed.

Related to #24982
