### PR TITLE
fix: Shortcuts should not leak over popover or modal boundary

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -67,6 +67,8 @@ public class ShortcutRegistration implements Registration, Serializable {
     private boolean allowDefaultBehavior = false;
     private boolean allowEventPropagation = false;
 
+    private boolean allowEventsFromNestedModals = false;
+
     private boolean resetFocusOnActiveElement = false;
 
     static final String LISTEN_ON_INITIALIZED = "_initialized_listen_on_for_component";
@@ -262,6 +264,25 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
+     * Allow the shortcut to trigger for keyboard events that originate from a
+     * modal or popover nested inside the shortcut's listening scope.
+     * <p>
+     * By default the shortcut does not trigger for such events. This restores
+     * behavior where a shortcut bound to a parent overlay would react to a
+     * keydown coming from a nested dialog/overlay that has focus.
+     *
+     * @return this <code>ShortcutRegistration</code>
+     * @see #setEventsFromNestedModalsAllowed(boolean)
+     */
+    public ShortcutRegistration allowEventsFromNestedModals() {
+        if (!allowEventsFromNestedModals) {
+            allowEventsFromNestedModals = true;
+            prepareForClientResponse();
+        }
+        return this;
+    }
+
+    /**
      * Reset focus on active element before triggering shortcut event handler.
      *
      * @return this <code>ShortcutRegistration</code>
@@ -448,6 +469,36 @@ public class ShortcutRegistration implements Registration, Serializable {
     public void setEventPropagationAllowed(boolean eventPropagationAllowed) {
         if (allowEventPropagation != eventPropagationAllowed) {
             allowEventPropagation = eventPropagationAllowed;
+            prepareForClientResponse();
+        }
+    }
+
+    /**
+     * Checks if the shortcut triggers for keyboard events originating from a
+     * modal or popover nested inside the shortcut's listening scope. The
+     * default value is {@code false}.
+     *
+     * @return {@code true} if events from nested modals are allowed to trigger
+     *         the shortcut
+     */
+    public boolean isEventsFromNestedModalsAllowed() {
+        return allowEventsFromNestedModals;
+    }
+
+    /**
+     * Sets whether the shortcut triggers for keyboard events that originate
+     * from a modal or popover nested inside the shortcut's listening scope. The
+     * default value is {@code false}, meaning a keydown coming from a nested
+     * dialog/overlay does not trigger a shortcut bound to a parent scope.
+     *
+     * @param eventsFromNestedModalsAllowed
+     *            {@code true} to allow events from nested modals to trigger the
+     *            shortcut
+     */
+    public void setEventsFromNestedModalsAllowed(
+            boolean eventsFromNestedModalsAllowed) {
+        if (allowEventsFromNestedModals != eventsFromNestedModalsAllowed) {
+            allowEventsFromNestedModals = eventsFromNestedModalsAllowed;
             prepareForClientResponse();
         }
     }
@@ -686,6 +737,16 @@ public class ShortcutRegistration implements Registration, Serializable {
 
                 String filterText = filterText();
                 /*
+                 * Ignore keydown events that originate from a modal/popover
+                 * nested inside the listening element (#24974). The guard runs
+                 * before the preventDefault/stopPropagation side effects so
+                 * that those events are left untouched for the nested overlay.
+                 */
+                if (!allowEventsFromNestedModals) {
+                    filterText += " && "
+                            + generateNestedModalOriginFilter("element");
+                }
+                /*
                  * Due to https://github.com/vaadin/flow/issues/4871 we are not
                  * able to use setEventData for these values, so we hack the
                  * filter.
@@ -872,6 +933,30 @@ public class ShortcutRegistration implements Registration, Serializable {
                 + ".indexOf(event.key) !== -1)";
     }
 
+    /**
+     * Builds a JS boolean expression that is {@code true} when the event does
+     * <em>not</em> originate from a modal or popover nested inside the boundary
+     * element, i.e. when the shortcut is allowed to fire.
+     * <p>
+     * It walks {@code event.composedPath()} from the event target up to the
+     * boundary element (the element the listener is bound to) and looks for an
+     * open popover or modal element in between. Such an element means the
+     * keydown came from a nested overlay that shadows the shortcut's scope.
+     *
+     * @param boundaryExpr
+     *            JS expression evaluating to the element the listener is bound
+     *            to (e.g. {@code "element"} or {@code "delegate"})
+     * @return the guard expression
+     */
+    private static String generateNestedModalOriginFilter(String boundaryExpr) {
+        return "!(function(){" + "var p=event.composedPath();"
+                + "var b=p.indexOf(" + boundaryExpr + ");"
+                + "if(b<0){return false;}" + "for(var i=0;i<b;i++){"
+                + "var n=p[i];" + "if(n&&n.nodeType===1&&n.matches&&"
+                + "(n.matches(':popover-open')||n.matches(':modal'))){"
+                + "return true;}" + "}" + "return false;" + "})()";
+    }
+
     /*
      * #7799, vaadin/vaadin-dialog#229 This could be changed to use a generic
      * feature for DOM events by either using existing DOM event handling or by
@@ -883,7 +968,15 @@ public class ShortcutRegistration implements Registration, Serializable {
         if (elementLocatorJs != null) {
             // #10362 only prevent default when key filter matches to not block
             // typing or existing shortcuts
-            final String filterText = filterText();
+            String filterText = filterText();
+            // #24974 ignore keydown events bubbling from a modal/popover nested
+            // inside the delegate element (e.g. a nested dialog overlay). The
+            // delegate re-dispatches a clone that loses the origin, so the
+            // guard must run on the original event here, before the clone.
+            if (!allowEventsFromNestedModals) {
+                filterText += " && "
+                        + generateNestedModalOriginFilter("delegate");
+            }
             final String focusJs = resetFocusOnActiveElement
                     ? "window.Vaadin.Flow.resetFocus();"
                     : "";

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -972,20 +972,25 @@ public class ShortcutRegistration implements Registration, Serializable {
         //@formatter:off
         return """
                 !(function() {
-                    var path = event.composedPath();
-                    var boundary = path.indexOf(%s);
-                    if (boundary < 0) {
+                    try {
+                        var path = event.composedPath();
+                        var boundary = path.indexOf(%s);
+                        if (boundary < 0) {
+                            return false;
+                        }
+                        for (var i = 0; i < boundary; i++) {
+                            var node = path[i];
+                            if (node && node.nodeType === 1 && node.matches
+                                    && (node.matches(':popover-open')
+                                            || node.matches(':modal'))) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    } catch (e) {
+                        // Fail open: never let guard evaluation kill the shortcut
                         return false;
                     }
-                    for (var i = 0; i < boundary; i++) {
-                        var node = path[i];
-                        if (node && node.nodeType === 1 && node.matches
-                                && (node.matches(':popover-open')
-                                        || node.matches(':modal'))) {
-                            return true;
-                        }
-                    }
-                    return false;
                 })()""".formatted(boundaryExpr);
         //@formatter:on
     }
@@ -1008,22 +1013,27 @@ public class ShortcutRegistration implements Registration, Serializable {
         //@formatter:off
         return """
                 !(function() {
-                    var path = event.composedPath();
-                    var scope = null;
-                    for (var i = 0; i < path.length; i++) {
-                        var node = path[i];
-                        if (node && node.nodeType === 1 && node.matches
-                                && (node.matches(':popover-open')
-                                        || node.matches(':modal'))) {
-                            scope = node;
-                            break;
+                    try {
+                        var path = event.composedPath();
+                        var scope = null;
+                        for (var i = 0; i < path.length; i++) {
+                            var node = path[i];
+                            if (node && node.nodeType === 1 && node.matches
+                                    && (node.matches(':popover-open')
+                                            || node.matches(':modal'))) {
+                                scope = node;
+                                break;
+                            }
                         }
-                    }
-                    if (!scope) {
+                        if (!scope) {
+                            return false;
+                        }
+                        var owner = document.querySelector('[%s~="%s"]');
+                        return !(owner && scope.contains(owner));
+                    } catch (e) {
+                        // Fail open: never let guard evaluation kill the shortcut
                         return false;
                     }
-                    var owner = document.querySelector('[%s~="%s"]');
-                    return !(owner && scope.contains(owner));
                 })()""".formatted(SHORTCUT_OWNER_ATTRIBUTE, ownerToken);
         //@formatter:on
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.internal.UIInternals;
@@ -64,15 +64,14 @@ public class ShortcutRegistration implements Registration, Serializable {
 
     private boolean allowEventsFromNestedModals = false;
 
-    private static final AtomicInteger OWNER_TOKEN_GENERATOR = new AtomicInteger();
-
     // Marker attribute set on the lifecycle owner element so the client-side
     // origin guard can locate it within the event's popover/modal scope
-    // (#24974). Unique per registration to avoid matching a different
-    // shortcut's owner.
+    // (#24974). The token is a UUID rather than a JVM-local counter so it stays
+    // unique across session serialization/deserialization onto another JVM,
+    // where a counter would restart and new shortcuts could reuse a restored
+    // token.
     static final String SHORTCUT_OWNER_ATTRIBUTE = "data-vaadin-shortcut-owner";
-    private final String ownerToken = "sc"
-            + OWNER_TOKEN_GENERATOR.incrementAndGet();
+    private final String ownerToken = "sc-" + UUID.randomUUID();
 
     private boolean resetFocusOnActiveElement = false;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,21 +53,11 @@ import com.vaadin.flow.shared.Registration;
 public class ShortcutRegistration implements Registration, Serializable {
     static final String LISTEN_ON_COMPONENTS_SHOULD_NOT_CONTAIN_NULL = "listenOnComponents should not contain null!";
     static final String LISTEN_ON_COMPONENTS_SHOULD_NOT_HAVE_DUPLICATE_ENTRIES = "listenOnComponents should not have duplicate entries!";
-    static final String ELEMENT_LOCATOR_JS = //@formatter:off
-            "const listenOn=this;" // this is the listenOn component's element
-                    + "const delegate=%1$s;" // the output of the JsLocator
-                    + "if (delegate) {"
-                    + "delegate.addEventListener('keydown', function(event) {"
-                    + "if (%2$s) {" // the filter text to match the key
-                    + "%3$s" // allow reset focus on active element if desired
-                    + "const new_event = new event.constructor(event.type, event);"
-                    + "listenOn.dispatchEvent(new_event);"
-                    + "%4$s" // the new event allows default if desired
-                    + "event.stopPropagation();}" // the new event bubbles if desired
-                    + "});" // end matches filter
-                    + "} else {"
-                    + "throw \"Shortcut listenOn element not found with JS locator string '%1$s'\""
-                    + "}";//@formatter:on
+
+    // Client helper resource lazily loaded per UI (see initShortcutClient),
+    // holding the origin guards and the keydown delegate (#24974).
+    static final String SHORTCUT_CLIENT_JS = "META-INF/frontend/FlowShortcut.js";
+    static final String SHORTCUT_CLIENT_INITIALIZED = "_shortcut_client_initialized";
 
     private boolean allowDefaultBehavior = false;
     private boolean allowEventPropagation = false;
@@ -144,6 +136,11 @@ public class ShortcutRegistration implements Registration, Serializable {
                 initListenOnComponent();
                 addListenOnDetachListeners();
             }
+
+            // Load the client helpers before the shortcut listeners/filters
+            // that reference them are queued for this response.
+            lifecycleOwner.getUI()
+                    .ifPresent(ShortcutRegistration.this::initShortcutClient);
 
             for (int i = 0; i < listenOnComponents.length; i++) {
                 updateHandlerListenerRegistration(i);
@@ -762,8 +759,18 @@ public class ShortcutRegistration implements Registration, Serializable {
                  * owner's own popover/modal scope, not the listener element. It
                  * runs before the preventDefault/stopPropagation side effects
                  * so that non-matching events are left untouched.
+                 *
+                 * Skipped when this listenOn has an element-locator delegate:
+                 * that delegate evaluates its own boundary guard on the
+                 * original event and then re-dispatches a cloned event to
+                 * listenOn. The clone's composedPath no longer reflects the
+                 * real origin, so the composedPath-based owner-scope guard must
+                 * not run on it.
                  */
-                if (!allowEventsFromNestedModals) {
+                final boolean hasEventDelegate = ComponentUtil.getData(
+                        listenOnComponents[listenOnIndex],
+                        Shortcuts.ELEMENT_LOCATOR_JS_KEY) != null;
+                if (!allowEventsFromNestedModals && !hasEventDelegate) {
                     filterText += " && " + generateOwnerScopeFilter();
                 }
                 /*
@@ -954,45 +961,23 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
-     * Builds a JS boolean expression that is {@code true} when the event does
-     * <em>not</em> originate from a modal or popover nested inside the boundary
-     * element, i.e. when the shortcut is allowed to fire.
-     * <p>
-     * It walks {@code event.composedPath()} from the event target up to the
-     * boundary element (the element the listener is bound to) and looks for an
-     * open popover or modal element in between. Such an element means the
-     * keydown came from a nested overlay that shadows the shortcut's scope.
+     * Builds a JS boolean expression that is {@code true} when the event is
+     * allowed to fire the shortcut, delegating to
+     * {@code window.Vaadin.Flow.shortcutEventWithinBoundary}. That helper walks
+     * {@code event.composedPath()} up to the boundary element and suppresses
+     * the shortcut when an open popover/modal shadows the boundary.
      *
      * @param boundaryExpr
      *            JS expression evaluating to the element the listener is bound
-     *            to (e.g. {@code "element"} or {@code "delegate"})
+     *            to (e.g. {@code "delegate"})
      * @return the guard expression
      */
     private static String generateNestedModalOriginFilter(String boundaryExpr) {
-        //@formatter:off
-        return """
-                !(function() {
-                    try {
-                        var path = event.composedPath();
-                        var boundary = path.indexOf(%s);
-                        if (boundary < 0) {
-                            return false;
-                        }
-                        for (var i = 0; i < boundary; i++) {
-                            var node = path[i];
-                            if (node && node.nodeType === 1 && node.matches
-                                    && (node.matches(':popover-open')
-                                            || node.matches(':modal'))) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    } catch (e) {
-                        // Fail open: never let guard evaluation kill the shortcut
-                        return false;
-                    }
-                })()""".formatted(boundaryExpr);
-        //@formatter:on
+        // Delegate path: the boundary element is the listener element the
+        // delegate re-dispatches to. Evaluated on the original event, so its
+        // composedPath is correct. Helper defined in FlowShortcut.js.
+        return "window.Vaadin.Flow.shortcut.eventWithinBoundary(event, "
+                + boundaryExpr + ")";
     }
 
     /**
@@ -1010,51 +995,11 @@ public class ShortcutRegistration implements Registration, Serializable {
      * @return the guard expression
      */
     private String generateOwnerScopeFilter() {
-        //@formatter:off
-        return """
-                !(function() {
-                    try {
-                        // Nearest open popover/modal ancestor in the flattened
-                        // (composed) tree, so slotted light-DOM content is
-                        // matched to the overlay in the component's shadow root.
-                        var scopeOf = function(node) {
-                            while (node) {
-                                if (node.nodeType === 1 && node.matches
-                                        && (node.matches(':popover-open')
-                                                || node.matches(':modal'))) {
-                                    return node;
-                                }
-                                node = node.assignedSlot || node.parentNode
-                                        || node.host || null;
-                            }
-                            return null;
-                        };
-                        var path = event.composedPath();
-                        var eventScope = null;
-                        for (var i = 0; i < path.length; i++) {
-                            var node = path[i];
-                            if (node && node.nodeType === 1 && node.matches
-                                    && (node.matches(':popover-open')
-                                            || node.matches(':modal'))) {
-                                eventScope = node;
-                                break;
-                            }
-                        }
-                        var owner = document.querySelector('[%s~="%s"]');
-                        if (!owner) {
-                            // Owner not locatable: fail open (fire).
-                            return false;
-                        }
-                        // Fire only when the event and the owner share the same
-                        // popover/modal scope; a deeper or foreign scope means
-                        // the event came from a nested/other overlay.
-                        return eventScope !== scopeOf(owner);
-                    } catch (e) {
-                        // Fail open: never let guard evaluation kill the shortcut
-                        return false;
-                    }
-                })()""".formatted(SHORTCUT_OWNER_ATTRIBUTE, ownerToken);
-        //@formatter:on
+        // Normal path: locate the owner element via its marker attribute and
+        // fire only when it shares the event's popover/modal scope. Helper
+        // defined in FlowShortcut.js.
+        return "window.Vaadin.Flow.shortcut.eventInOwnerScope(event, '["
+                + SHORTCUT_OWNER_ATTRIBUTE + "~=\"" + ownerToken + "\"]')";
     }
 
     /**
@@ -1128,14 +1073,15 @@ public class ShortcutRegistration implements Registration, Serializable {
                 filterText += " && "
                         + generateNestedModalOriginFilter("delegate");
             }
-            final String focusJs = resetFocusOnActiveElement
-                    ? "window.Vaadin.Flow.resetFocus();"
-                    : "";
-            // enable default actions if desired
-            final String preventDefault = allowDefaultBehavior ? ""
-                    : "event.preventDefault();";
-            final String jsExpression = String.format(ELEMENT_LOCATOR_JS,
-                    elementLocatorJs, filterText, focusJs, preventDefault);
+            // Relay keydown events via the client helper. 'this' is the
+            // listenOn element, elementLocatorJs resolves the delegate element,
+            // and the matcher receives (event, delegate).
+            final String jsExpression = String.format(
+                    "window.Vaadin.Flow.shortcut.registerKeydownDelegate("
+                            + "this, %1$s, function(event, delegate) {"
+                            + " return %2$s; }, %3$b, %4$b)",
+                    elementLocatorJs, filterText, resetFocusOnActiveElement,
+                    allowDefaultBehavior);
 
             final String expressionHash = StringUtil.getHash(jsExpression);
             final Set<String> expressions = getOrInitListenData(listenOn);
@@ -1144,6 +1090,32 @@ public class ShortcutRegistration implements Registration, Serializable {
             }
             expressions.add(expressionHash);
             listenOn.getElement().executeJs(jsExpression);
+        }
+    }
+
+    /**
+     * Lazily loads the shortcut client helpers ({@code FlowShortcut.js}) into
+     * the given UI, once per UI, mirroring how {@code WebPush} loads its client
+     * code. The helpers back the popover/modal origin guards and the keydown
+     * delegate, so they must be present before the shortcut listeners that
+     * reference them run on the client.
+     */
+    private void initShortcutClient(UI ui) {
+        if (ComponentUtil.getData(ui, SHORTCUT_CLIENT_INITIALIZED) != null) {
+            return;
+        }
+        ComponentUtil.setData(ui, SHORTCUT_CLIENT_INITIALIZED, Boolean.TRUE);
+        try (InputStream stream = ShortcutRegistration.class.getClassLoader()
+                .getResourceAsStream(SHORTCUT_CLIENT_JS)) {
+            ui.getPage().executeJs(
+                    StringUtil.removeComments(StringUtil.toUTF8String(stream)));
+        } catch (IOException e) {
+            // Loading failed: clear the flag so a later registration retries.
+            ComponentUtil.setData(ui, SHORTCUT_CLIENT_INITIALIZED, null);
+            throw new IllegalStateException(
+                    "Could not load shortcut client code from "
+                            + SHORTCUT_CLIENT_JS,
+                    e);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -321,8 +321,9 @@ public class ShortcutRegistration implements Registration, Serializable {
      * @return this <code>ShortcutRegistration</code>
      */
     public ShortcutRegistration bindLifecycleTo(Component component) {
-        // this does not require setDirty as the shortcut configuration is
-        // not affected by this change
+        // Changing the lifecycle owner moves the owner marker the origin guard
+        // relies on, so setLifecycleOwner re-runs the client update when the
+        // owner actually changes.
 
         if (component == null) {
             throw new IllegalArgumentException(
@@ -626,7 +627,19 @@ public class ShortcutRegistration implements Registration, Serializable {
             lifecycleRegistration.remove();
         }
 
+        final boolean ownerChanged = lifecycleOwner != null
+                && lifecycleOwner != owner;
+        if (ownerChanged && lifecycleOwner.getElement() != null) {
+            // Drop the marker from the previous owner; the new owner is marked
+            // by updateOwnerMarker on the client update triggered below.
+            removeOwnerToken(lifecycleOwner.getElement());
+        }
+
         registerLifecycleOwner(owner);
+
+        if (ownerChanged) {
+            prepareForClientResponse();
+        }
     }
 
     private void addKey(Key key) {
@@ -768,7 +781,7 @@ public class ShortcutRegistration implements Registration, Serializable {
                  * not run on it.
                  */
                 final boolean hasEventDelegate = ComponentUtil.getData(
-                        listenOnComponents[listenOnIndex],
+                        getComponentEventSource(listenOnIndex),
                         Shortcuts.ELEMENT_LOCATOR_JS_KEY) != null;
                 if (!allowEventsFromNestedModals && !hasEventDelegate) {
                     filterText += " && " + generateOwnerScopeFilter();
@@ -963,9 +976,9 @@ public class ShortcutRegistration implements Registration, Serializable {
     /**
      * Builds a JS boolean expression that is {@code true} when the event is
      * allowed to fire the shortcut, delegating to
-     * {@code window.Vaadin.Flow.shortcutEventWithinBoundary}. That helper walks
-     * {@code event.composedPath()} up to the boundary element and suppresses
-     * the shortcut when an open popover/modal shadows the boundary.
+     * {@code window.Vaadin.Flow.shortcut.eventWithinBoundary}. That helper
+     * walks {@code event.composedPath()} up to the boundary element and
+     * suppresses the shortcut when an open popover/modal shadows the boundary.
      *
      * @param boundaryExpr
      *            JS expression evaluating to the element the listener is bound
@@ -1107,6 +1120,9 @@ public class ShortcutRegistration implements Registration, Serializable {
         ComponentUtil.setData(ui, SHORTCUT_CLIENT_INITIALIZED, Boolean.TRUE);
         try (InputStream stream = ShortcutRegistration.class.getClassLoader()
                 .getResourceAsStream(SHORTCUT_CLIENT_JS)) {
+            if (stream == null) {
+                throw new IOException("resource not found on the classpath");
+            }
             ui.getPage().executeJs(
                     StringUtil.removeComments(StringUtil.toUTF8String(stream)));
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -21,16 +21,19 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomListenerRegistration;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.internal.ExecutionContext;
@@ -68,6 +71,16 @@ public class ShortcutRegistration implements Registration, Serializable {
     private boolean allowEventPropagation = false;
 
     private boolean allowEventsFromNestedModals = false;
+
+    private static final AtomicInteger OWNER_TOKEN_GENERATOR = new AtomicInteger();
+
+    // Marker attribute set on the lifecycle owner element so the client-side
+    // origin guard can locate it within the event's popover/modal scope
+    // (#24974). Unique per registration to avoid matching a different
+    // shortcut's owner.
+    static final String SHORTCUT_OWNER_ATTRIBUTE = "data-vaadin-shortcut-owner";
+    private final String ownerToken = "sc"
+            + OWNER_TOKEN_GENERATOR.incrementAndGet();
 
     private boolean resetFocusOnActiveElement = false;
 
@@ -135,6 +148,8 @@ public class ShortcutRegistration implements Registration, Serializable {
             for (int i = 0; i < listenOnComponents.length; i++) {
                 updateHandlerListenerRegistration(i);
             }
+
+            updateOwnerMarker();
 
             markClean();
         }
@@ -382,6 +397,9 @@ public class ShortcutRegistration implements Registration, Serializable {
         }
         removeAllListenerRegistrations();
 
+        if (lifecycleOwner != null && lifecycleOwner.getElement() != null) {
+            removeOwnerToken(lifecycleOwner.getElement());
+        }
         lifecycleOwner = null;
         listenOnComponents = null;
 
@@ -738,13 +756,15 @@ public class ShortcutRegistration implements Registration, Serializable {
                 String filterText = filterText();
                 /*
                  * Ignore keydown events that originate from a modal/popover
-                 * nested inside the listening element (#24974). The guard runs
-                 * before the preventDefault/stopPropagation side effects so
-                 * that those events are left untouched for the nested overlay.
+                 * nested deeper than the shortcut's lifecycle owner (#24974).
+                 * The listener is often bound to the UI (body) while the owner
+                 * lives inside an overlay, so the guard is anchored on the
+                 * owner's own popover/modal scope, not the listener element. It
+                 * runs before the preventDefault/stopPropagation side effects
+                 * so that non-matching events are left untouched.
                  */
                 if (!allowEventsFromNestedModals) {
-                    filterText += " && "
-                            + generateNestedModalOriginFilter("element");
+                    filterText += " && " + generateOwnerScopeFilter();
                 }
                 /*
                  * Due to https://github.com/vaadin/flow/issues/4871 we are not
@@ -949,12 +969,114 @@ public class ShortcutRegistration implements Registration, Serializable {
      * @return the guard expression
      */
     private static String generateNestedModalOriginFilter(String boundaryExpr) {
-        return "!(function(){" + "var p=event.composedPath();"
-                + "var b=p.indexOf(" + boundaryExpr + ");"
-                + "if(b<0){return false;}" + "for(var i=0;i<b;i++){"
-                + "var n=p[i];" + "if(n&&n.nodeType===1&&n.matches&&"
-                + "(n.matches(':popover-open')||n.matches(':modal'))){"
-                + "return true;}" + "}" + "return false;" + "})()";
+        //@formatter:off
+        return """
+                !(function() {
+                    var path = event.composedPath();
+                    var boundary = path.indexOf(%s);
+                    if (boundary < 0) {
+                        return false;
+                    }
+                    for (var i = 0; i < boundary; i++) {
+                        var node = path[i];
+                        if (node && node.nodeType === 1 && node.matches
+                                && (node.matches(':popover-open')
+                                        || node.matches(':modal'))) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })()""".formatted(boundaryExpr);
+        //@formatter:on
+    }
+
+    /**
+     * Builds a JS boolean expression that is {@code true} when the event does
+     * <em>not</em> originate from a modal/popover nested deeper than the
+     * shortcut's lifecycle owner, i.e. when the shortcut is allowed to fire.
+     * <p>
+     * It finds the nearest open popover/modal ancestor of the event target (the
+     * event's "scope") and fires only if that scope also contains the lifecycle
+     * owner element (located via its {@link #SHORTCUT_OWNER_ATTRIBUTE} marker).
+     * An event outside any popover fires; an event in a popover that does not
+     * contain the owner is treated as originating from a foreign or nested
+     * scope and is ignored.
+     *
+     * @return the guard expression
+     */
+    private String generateOwnerScopeFilter() {
+        //@formatter:off
+        return """
+                !(function() {
+                    var path = event.composedPath();
+                    var scope = null;
+                    for (var i = 0; i < path.length; i++) {
+                        var node = path[i];
+                        if (node && node.nodeType === 1 && node.matches
+                                && (node.matches(':popover-open')
+                                        || node.matches(':modal'))) {
+                            scope = node;
+                            break;
+                        }
+                    }
+                    if (!scope) {
+                        return false;
+                    }
+                    var owner = document.querySelector('[%s~="%s"]');
+                    return !(owner && scope.contains(owner));
+                })()""".formatted(SHORTCUT_OWNER_ATTRIBUTE, ownerToken);
+        //@formatter:on
+    }
+
+    /**
+     * Marks or unmarks the lifecycle owner element so that
+     * {@link #generateOwnerScopeFilter()} can locate it on the client. The
+     * marker is only needed while the origin guard is active.
+     */
+    private void updateOwnerMarker() {
+        if (lifecycleOwner == null) {
+            return;
+        }
+        final Element element = lifecycleOwner.getElement();
+        if (element == null) {
+            return;
+        }
+        if (allowEventsFromNestedModals) {
+            removeOwnerToken(element);
+        } else {
+            addOwnerToken(element);
+        }
+    }
+
+    private void addOwnerToken(Element element) {
+        final String current = element.getAttribute(SHORTCUT_OWNER_ATTRIBUTE);
+        if (current == null || current.isBlank()) {
+            element.setAttribute(SHORTCUT_OWNER_ATTRIBUTE, ownerToken);
+            return;
+        }
+        final Set<String> tokens = new LinkedHashSet<>(
+                Arrays.asList(current.trim().split("\\s+")));
+        if (tokens.add(ownerToken)) {
+            element.setAttribute(SHORTCUT_OWNER_ATTRIBUTE,
+                    String.join(" ", tokens));
+        }
+    }
+
+    private void removeOwnerToken(Element element) {
+        final String current = element.getAttribute(SHORTCUT_OWNER_ATTRIBUTE);
+        if (current == null || current.isBlank()) {
+            return;
+        }
+        final Set<String> tokens = new LinkedHashSet<>(
+                Arrays.asList(current.trim().split("\\s+")));
+        if (tokens.remove(ownerToken)) {
+            if (tokens.isEmpty()) {
+                element.removeAttribute(SHORTCUT_OWNER_ATTRIBUTE);
+            } else {
+                element.setAttribute(SHORTCUT_OWNER_ATTRIBUTE,
+                        String.join(" ", tokens));
+            }
+        }
     }
 
     /*

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -1014,22 +1014,41 @@ public class ShortcutRegistration implements Registration, Serializable {
         return """
                 !(function() {
                     try {
+                        // Nearest open popover/modal ancestor in the flattened
+                        // (composed) tree, so slotted light-DOM content is
+                        // matched to the overlay in the component's shadow root.
+                        var scopeOf = function(node) {
+                            while (node) {
+                                if (node.nodeType === 1 && node.matches
+                                        && (node.matches(':popover-open')
+                                                || node.matches(':modal'))) {
+                                    return node;
+                                }
+                                node = node.assignedSlot || node.parentNode
+                                        || node.host || null;
+                            }
+                            return null;
+                        };
                         var path = event.composedPath();
-                        var scope = null;
+                        var eventScope = null;
                         for (var i = 0; i < path.length; i++) {
                             var node = path[i];
                             if (node && node.nodeType === 1 && node.matches
                                     && (node.matches(':popover-open')
                                             || node.matches(':modal'))) {
-                                scope = node;
+                                eventScope = node;
                                 break;
                             }
                         }
-                        if (!scope) {
+                        var owner = document.querySelector('[%s~="%s"]');
+                        if (!owner) {
+                            // Owner not locatable: fail open (fire).
                             return false;
                         }
-                        var owner = document.querySelector('[%s~="%s"]');
-                        return !(owner && scope.contains(owner));
+                        // Fire only when the event and the owner share the same
+                        // popover/modal scope; a deeper or foreign scope means
+                        // the event came from a nested/other overlay.
+                        return eventScope !== scopeOf(owner);
                     } catch (e) {
                         // Fail open: never let guard evaluation kill the shortcut
                         return false;

--- a/flow-server/src/main/resources/META-INF/frontend/FlowShortcut.js
+++ b/flow-server/src/main/resources/META-INF/frontend/FlowShortcut.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/*
+ * Client-side helpers for keyboard shortcuts. Loaded on demand by
+ * ShortcutRegistration (see initShortcutClient) the same way FlowWebPush.js is
+ * loaded by WebPush. Provides the popover/modal origin guards (#24974) and the
+ * keydown delegate used when a shortcut listens on a browser-only element.
+ */
+window.Vaadin = window.Vaadin || {};
+window.Vaadin.Flow = window.Vaadin.Flow || {};
+
+window.Vaadin.Flow.shortcut = window.Vaadin.Flow.shortcut || {
+  // Nearest open popover/modal ancestor of the given node in the flattened
+  // (composed) tree, so slotted light-DOM content resolves to the overlay in a
+  // component's shadow root.
+  _scopeOf: function (node) {
+    while (node) {
+      if (node.nodeType === 1 && node.matches && (node.matches(':popover-open') || node.matches(':modal'))) {
+        return node;
+      }
+      node = node.assignedSlot || node.parentNode || node.host || null;
+    }
+    return null;
+  },
+
+  // Nearest open popover/modal ancestor of the event target.
+  _eventScope: function (event) {
+    const path = event.composedPath();
+    for (let i = 0; i < path.length; i++) {
+      const node = path[i];
+      if (node && node.nodeType === 1 && node.matches && (node.matches(':popover-open') || node.matches(':modal'))) {
+        return node;
+      }
+    }
+    return null;
+  },
+
+  // Delegate path: suppress when an open popover/modal sits between the event
+  // target and the boundary element the listener is attached to. Returns true
+  // when the shortcut is allowed to fire. Fails open on error.
+  eventWithinBoundary: function (event, boundary) {
+    try {
+      const path = event.composedPath();
+      const boundaryIndex = path.indexOf(boundary);
+      if (boundaryIndex < 0) {
+        return true;
+      }
+      for (let i = 0; i < boundaryIndex; i++) {
+        const node = path[i];
+        if (node && node.nodeType === 1 && node.matches && (node.matches(':popover-open') || node.matches(':modal'))) {
+          return false;
+        }
+      }
+      return true;
+    } catch (e) {
+      return true;
+    }
+  },
+
+  // Normal path: fire only when the event and the shortcut owner (located via
+  // the given attribute selector) share the same popover/modal scope. Returns
+  // true when the shortcut is allowed to fire. Fails open on error.
+  //
+  // A relayed clone (see registerKeydownDelegate) carries the real origin scope
+  // in _vaadinShortcutOriginScope, because its own composedPath points at the
+  // listenOn element and no longer reflects where the keydown happened.
+  eventInOwnerScope: function (event, ownerSelector) {
+    try {
+      const owner = document.querySelector(ownerSelector);
+      if (!owner) {
+        return true;
+      }
+      const eventScope =
+        '_vaadinShortcutOriginScope' in event
+          ? event._vaadinShortcutOriginScope
+          : window.Vaadin.Flow.shortcut._eventScope(event);
+      return eventScope === window.Vaadin.Flow.shortcut._scopeOf(owner);
+    } catch (e) {
+      return true;
+    }
+  },
+
+  // Relays keydown events from a browser-only element (found by the JS locator)
+  // to the listenOn component. When the given matcher accepts the event a clone
+  // is re-dispatched to listenOn so the server-side shortcut listener fires.
+  // (Previously the inline ELEMENT_LOCATOR_JS in ShortcutRegistration.)
+  registerKeydownDelegate: function (listenOn, delegate, matches, resetFocus, allowDefault) {
+    if (!delegate) {
+      throw 'Shortcut listenOn element not found with the given JS locator';
+    }
+    delegate.addEventListener('keydown', function (event) {
+      if (matches(event, delegate)) {
+        if (resetFocus) {
+          window.Vaadin.Flow.resetFocus();
+        }
+        const clone = new event.constructor(event.type, event);
+        // Remember where the keydown actually originated: the clone is
+        // re-targeted at listenOn, so its composedPath can no longer tell a
+        // downstream owner-scope guard that the event came from this overlay.
+        clone._vaadinShortcutOriginScope = window.Vaadin.Flow.shortcut._eventScope(event);
+        listenOn.dispatchEvent(clone);
+        if (!allowDefault) {
+          event.preventDefault();
+        }
+        event.stopPropagation();
+      }
+    });
+  }
+};

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -184,6 +184,7 @@ class ShortcutRegistrationTest {
         registration.setBrowserDefaultAllowed(true);
         registration.setEventPropagationAllowed(true);
         registration.setResetFocusOnActiveElement(true);
+        registration.setEventsFromNestedModalsAllowed(true);
 
         clientResponse();
 
@@ -193,10 +194,13 @@ class ShortcutRegistrationTest {
                 "Allow propagation was not set to true");
         assertTrue(registration.isResetFocusOnActiveElement(),
                 "Reset focus on active element was not set to true");
+        assertTrue(registration.isEventsFromNestedModalsAllowed(),
+                "Allow events from nested modals was not set to true");
 
         registration.setBrowserDefaultAllowed(false);
         registration.setEventPropagationAllowed(false);
         registration.setResetFocusOnActiveElement(false);
+        registration.setEventsFromNestedModalsAllowed(false);
 
         clientResponse();
 
@@ -206,6 +210,8 @@ class ShortcutRegistrationTest {
                 "Allow propagation was not set to false");
         assertFalse(registration.isResetFocusOnActiveElement(),
                 "Reset focus on active element was not set to false");
+        assertFalse(registration.isEventsFromNestedModalsAllowed(),
+                "Allow events from nested modals was not set to false");
     }
 
     @Test
@@ -494,6 +500,12 @@ class ShortcutRegistrationTest {
 
         assertFalse(registration.isEventsFromNestedModalsAllowed());
         registration.allowEventsFromNestedModals();
+        assertTrue(registration.isEventsFromNestedModalsAllowed());
+        // Calling again is a no-op and must keep the value unchanged.
+        registration.allowEventsFromNestedModals();
+        assertTrue(registration.isEventsFromNestedModalsAllowed());
+        // Setting the same value via the bean setter is also a no-op.
+        registration.setEventsFromNestedModalsAllowed(true);
         assertTrue(registration.isEventsFromNestedModalsAllowed());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -463,6 +463,41 @@ class ShortcutRegistrationTest {
     }
 
     @Test
+    void listenOnComponentHasElementLocatorJs_nestedModalGuardPresentByDefault() {
+        final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
+        fixture.createNewShortcut(Key.KEY_A);
+
+        final String expression = fixture.writeResponse().get(0).getInvocation()
+                .getExpression();
+        assertTrue(expression.contains("composedPath()"),
+                "JS execution string should guard against events from nested "
+                        + "modals by default " + expression);
+    }
+
+    @Test
+    void listenOnComponentHasElementLocatorJs_allowEventsFromNestedModals_noGuard() {
+        final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
+        fixture.createNewShortcut(Key.KEY_A).allowEventsFromNestedModals();
+
+        final String expression = fixture.writeResponse().get(0).getInvocation()
+                .getExpression();
+        assertFalse(expression.contains("composedPath()"),
+                "JS execution string should not guard against nested modal "
+                        + "events when explicitly allowed " + expression);
+    }
+
+    @Test
+    void eventsFromNestedModalsAllowedDefaultsToFalse() {
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, event -> {
+                }, Key.KEY_A);
+
+        assertFalse(registration.isEventsFromNestedModalsAllowed());
+        registration.allowEventsFromNestedModals();
+        assertTrue(registration.isEventsFromNestedModalsAllowed());
+    }
+
+    @Test
     void constructedRegistration_lifecycleIsVisibleAndEnabled_shorcutEventIsFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -510,6 +510,38 @@ class ShortcutRegistrationTest {
     }
 
     @Test
+    void ownerScopeGuard_lifecycleOwnerMarkedByDefault() {
+        final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
+        fixture.createNewShortcut(Key.KEY_A);
+
+        fixture.writeResponse();
+
+        assertNotNull(
+                fixture.owner.getElement().getAttribute(
+                        ShortcutRegistration.SHORTCUT_OWNER_ATTRIBUTE),
+                "lifecycle owner should be marked so the origin guard can locate it");
+    }
+
+    @Test
+    void ownerScopeGuard_lifecycleOwnerNotMarkedWhenAllowed() {
+        final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
+        final ShortcutRegistration registration = fixture
+                .createNewShortcut(Key.KEY_A);
+
+        fixture.writeResponse();
+        assertNotNull(fixture.owner.getElement()
+                .getAttribute(ShortcutRegistration.SHORTCUT_OWNER_ATTRIBUTE));
+
+        registration.setEventsFromNestedModalsAllowed(true);
+        fixture.writeResponse();
+
+        assertNull(
+                fixture.owner.getElement().getAttribute(
+                        ShortcutRegistration.SHORTCUT_OWNER_ATTRIBUTE),
+                "owner marker should be removed when nested-modal events are allowed");
+    }
+
+    @Test
     void constructedRegistration_lifecycleIsVisibleAndEnabled_shorcutEventIsFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -64,6 +64,9 @@ class ShortcutRegistrationTest {
     @BeforeEach
     void initTests() {
         ui = mock(UI.class);
+        // initShortcutClient loads the client helper via ui.getPage()
+        when(ui.getPage())
+                .thenReturn(mock(com.vaadin.flow.component.page.Page.class));
         lifecycleOwner = mock(Component.class);
         Arrays.setAll(listenOn, i -> mock(Component.class));
 
@@ -245,7 +248,7 @@ class ShortcutRegistrationTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     void listenOnComponentIsChanged_eventIsPopulatedForANewListenOnComponent() {
-        UI ui = Mockito.spy(UI.class);
+        UI ui = spyUiWithSession();
         Component owner = new FakeComponent();
         Component initialComponentToListenOn = new FakeComponent();
 
@@ -290,7 +293,7 @@ class ShortcutRegistrationTest {
 
     @Test
     void listenOnUIIsClosing_eventIsPopulatedForANewUI() {
-        UI ui = Mockito.spy(UI.class);
+        UI ui = spyUiWithSession();
         Component owner = new FakeComponent();
 
         Component[] components = new Component[] { ui };
@@ -299,7 +302,7 @@ class ShortcutRegistrationTest {
         new ShortcutRegistration(owner, () -> components, event -> {
         }, Key.KEY_A);
 
-        UI newUI = Mockito.spy(UI.class);
+        UI newUI = spyUiWithSession();
         // close the previous UI
         ui.close();
         components[0] = newUI;
@@ -403,34 +406,27 @@ class ShortcutRegistrationTest {
         final Key key = Key.KEY_A;
         fixture.createNewShortcut(key);
 
-        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = fixture
-                .writeResponse();
-
-        final PendingJavaScriptInvocation js = pendingJavaScriptInvocations
-                .get(0);
-        final String expression = js.getInvocation().getExpression();
-        assertTrue(
-                expression.contains(
-                        "const delegate=" + fixture.elementLocatorJs + ";"),
+        final String expression = delegateExpression(fixture.writeResponse());
+        assertTrue(expression.contains(fixture.elementLocatorJs),
                 "element locator string " + fixture.elementLocatorJs
                         + " missing from JS execution string " + expression);
-        assertTrue(expression.contains("event.preventDefault();"),
-                "JS execution string should have event.preventDefault() in it"
-                        + expression);
-        assertTrue(expression.contains("event.stopPropagation();"),
-                "JS execution string should always have event.stopPropagation() in it"
+        assertTrue(expression.contains("registerKeydownDelegate"),
+                "JS execution string should relay via registerKeydownDelegate "
                         + expression);
         assertTrue(expression.contains(key.getKeys().get(0)),
                 "JS execution string missing the key" + key);
-        assertFalse(expression.contains("window.Vaadin.Flow.resetFocus()"),
-                "JS execution string should not have blur() and focus() on active element in it"
+        // resetFocus=false, allowDefault=false by default
+        assertTrue(expression.contains(", false, false)"),
+                "default should not reset focus nor allow browser default "
                         + expression);
 
         fixture.registration.remove();
 
         fixture.createNewShortcut(Key.KEY_X);
 
-        pendingJavaScriptInvocations = fixture.writeResponse();
+        // Locator removed and client already initialized: no more JS scheduled.
+        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = fixture
+                .writeResponse();
         assertEquals(0, pendingJavaScriptInvocations.size());
     }
 
@@ -440,14 +436,10 @@ class ShortcutRegistrationTest {
         final Key key = Key.KEY_A;
         fixture.createNewShortcut(key).allowBrowserDefault();
 
-        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = fixture
-                .writeResponse();
-
-        final PendingJavaScriptInvocation js = pendingJavaScriptInvocations
-                .get(0);
-        final String expression = js.getInvocation().getExpression();
-        assertFalse(expression.contains("event.preventDefault();"),
-                "JS execution string should NOT have event.preventDefault() in it"
+        final String expression = delegateExpression(fixture.writeResponse());
+        // allowDefault (last arg) must be true when browser default is allowed.
+        assertTrue(expression.contains(", false, true)"),
+                "JS execution string should allow browser default "
                         + expression);
     }
 
@@ -457,14 +449,10 @@ class ShortcutRegistrationTest {
         final Key key = Key.KEY_A;
         fixture.createNewShortcut(key).resetFocusOnActiveElement();
 
-        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = fixture
-                .writeResponse();
-
-        final PendingJavaScriptInvocation js = pendingJavaScriptInvocations
-                .get(0);
-        final String expression = js.getInvocation().getExpression();
-        assertTrue(expression.contains("window.Vaadin.Flow.resetFocus()"),
-                "JS execution string should have blur() and focus() on active element in it"
+        final String expression = delegateExpression(fixture.writeResponse());
+        // resetFocus (3rd arg) must be true when focus reset is requested.
+        assertTrue(expression.contains(", true, false)"),
+                "JS execution string should reset focus on active element "
                         + expression);
     }
 
@@ -473,9 +461,8 @@ class ShortcutRegistrationTest {
         final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
         fixture.createNewShortcut(Key.KEY_A);
 
-        final String expression = fixture.writeResponse().get(0).getInvocation()
-                .getExpression();
-        assertTrue(expression.contains("composedPath()"),
+        final String expression = delegateExpression(fixture.writeResponse());
+        assertTrue(expression.contains("eventWithinBoundary(event, delegate)"),
                 "JS execution string should guard against events from nested "
                         + "modals by default " + expression);
     }
@@ -485,9 +472,8 @@ class ShortcutRegistrationTest {
         final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
         fixture.createNewShortcut(Key.KEY_A).allowEventsFromNestedModals();
 
-        final String expression = fixture.writeResponse().get(0).getInvocation()
-                .getExpression();
-        assertFalse(expression.contains("composedPath()"),
+        final String expression = delegateExpression(fixture.writeResponse());
+        assertFalse(expression.contains("eventWithinBoundary"),
                 "JS execution string should not guard against nested modal "
                         + "events when explicitly allowed " + expression);
     }
@@ -740,7 +726,7 @@ class ShortcutRegistrationTest {
 
     @Test
     void reattachComponent_detachListenerIsAddedOnEveryAttach_listenOnUIIsClosing_eventIsPopulatedForANewUI() {
-        UI ui = Mockito.spy(UI.class);
+        UI ui = spyUiWithSession();
         Component owner = new FakeComponent();
 
         Registration registration = Mockito.mock(Registration.class);
@@ -776,7 +762,7 @@ class ShortcutRegistrationTest {
         consumer.accept(mock(ExecutionContext.class));
         assertEquals(2, count.get());
 
-        UI newUI = Mockito.spy(UI.class);
+        UI newUI = spyUiWithSession();
         // close the previous UI
         ui.close();
         components[0] = newUI;
@@ -795,7 +781,7 @@ class ShortcutRegistrationTest {
 
     @Test
     void attachAndDetachComponent_sameRoundTrip_beforeClientResponseListenerRemoved() {
-        UI ui = Mockito.spy(UI.class);
+        UI ui = spyUiWithSession();
         Component owner = new FakeComponent();
 
         List<StateTree.ExecutionRegistration> beforeClientRegistrations = new ArrayList<>();
@@ -920,6 +906,24 @@ class ShortcutRegistrationTest {
 
         // Fake beforeClientExecution call.
         consumer.accept(mock(ExecutionContext.class));
+    }
+
+    private static UI spyUiWithSession() {
+        UI spyUi = Mockito.spy(UI.class);
+        // A locked session lets initShortcutClient's executeJs run.
+        VaadinSession session = mock(VaadinSession.class);
+        when(session.hasLock()).thenReturn(true);
+        spyUi.getInternals().setSession(session);
+        return spyUi;
+    }
+
+    private static String delegateExpression(
+            List<PendingJavaScriptInvocation> invocations) {
+        // Match the delegate CALL, not the FlowShortcut.js definition load.
+        return invocations.stream().map(i -> i.getInvocation().getExpression())
+                .filter(e -> e.contains("registerKeydownDelegate(this,"))
+                .findFirst().orElseThrow(() -> new AssertionError(
+                        "No registerKeydownDelegate call scheduled"));
     }
 
     private boolean hasKeyAInKeyDownExpression(Component component) {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DelegateLeakView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DelegateLeakView.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.Shortcuts;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Reproducer from PR #25044 review for the element-locator delegate leak: the
+ * delegate re-dispatches a clone to the {@code listenOn} element, and that
+ * clone must not leak the shortcut to owners outside the overlay it came from.
+ * <p>
+ * Open the overlay, focus the field, press Alt+S. The owner inside the overlay
+ * ({@code save}, reached through the delegate) must fire; the owner outside any
+ * overlay (listening on the UI) must not, even though it would otherwise catch
+ * the delegate's bubbling clone.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.DelegateLeakView")
+public class DelegateLeakView extends Div {
+
+    public static final String EVENT_LOG_ID = "event-log";
+    public static final String FIELD_ID = "field";
+    public static final String OPEN_ID = "open";
+    public static final String INSIDE_FIRED = "inside owner fired";
+    public static final String OUTSIDE_FIRED = "outside owner fired";
+
+    public DelegateLeakView() {
+        final Div log = new Div();
+        log.setId(EVENT_LOG_ID);
+
+        final Input field = new Input();
+        field.setId(FIELD_ID);
+        final NativeButton save = new NativeButton("Save");
+
+        final Div overlay = new Div(field, save);
+        overlay.setId("overlay");
+        overlay.getElement().setAttribute("popover", "manual");
+
+        // The component the delegate relays keydowns to; outside the overlay.
+        final Div host = new Div(overlay);
+        Shortcuts.setShortcutListenOnElement(
+                "document.getElementById('overlay')", host);
+
+        // (1) owner INSIDE the overlay, reached through the delegate.
+        // Must fire for a keydown in that overlay.
+        Shortcuts.addShortcutListener(save,
+                () -> log.add(new Div(new Text(INSIDE_FIRED))), Key.KEY_S,
+                KeyModifier.ALT).listenOn(host);
+
+        // (2) owner OUTSIDE any overlay, listening on the UI (default).
+        // Must NOT fire for that keydown, off the delegate's clone.
+        Shortcuts.addShortcutListener(this,
+                () -> log.add(new Div(new Text(OUTSIDE_FIRED))), Key.KEY_S,
+                KeyModifier.ALT);
+
+        final NativeButton open = new NativeButton("Open overlay",
+                e -> overlay.getElement().executeJs("this.showPopover();"));
+        open.setId(OPEN_ID);
+
+        add(open, host, log);
+        setId("main-div");
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutView.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.Shortcuts;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Reproduces issue #24974 using the same shortcut wiring as the real
+ * {@code Dialog} component: the shortcut listens on a server-side component
+ * ({@code parentDialog}) while a browser-only overlay element relays keydown
+ * events to it via {@link Shortcuts#setShortcutListenOnElement} (the
+ * {@code ELEMENT_LOCATOR_JS} delegate).
+ * <p>
+ * In Vaadin 25 the nested overlay is a native popover and a real DOM descendant
+ * of the parent overlay (in Vaadin 24 overlays were teleported to be siblings).
+ * A keydown inside the nested overlay therefore bubbles up to the parent
+ * overlay's relay listener, which clones and re-dispatches it to the parent
+ * dialog, firing the parent shortcut even though the nested overlay has focus.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.NestedPopoverShortcutView")
+public class NestedPopoverShortcutView extends Div {
+
+    public static final String EVENT_LOG_ID = "event-log";
+    public static final String OPEN_PARENT_BUTTON = "open-parent";
+    public static final String OPEN_NESTED_BUTTON = "open-nested";
+    public static final String PARENT_OVERLAY_ID = "parent-overlay";
+    public static final String NESTED_OVERLAY_ID = "nested-overlay";
+    public static final String PARENT_INPUT_ID = "parent-input";
+    public static final String NESTED_INPUT_ID = "nested-input";
+
+    // Shortcut fired by the parent dialog, logged with this source label.
+    public static final String PARENT_SHORTCUT = "parent-shortcut";
+
+    public static final Key SHORTCUT_KEY = Key.KEY_S;
+    public static final KeyModifier SHORTCUT_MODIFIER = KeyModifier.ALT;
+
+    private final Div eventLog;
+    private final AtomicInteger eventCounter = new AtomicInteger();
+
+    // Server-side component the shortcut listens on (like <vaadin-dialog>).
+    private final Div parentDialog = new Div();
+    // Top-layer overlay elements (like <vaadin-dialog-overlay>).
+    private final Div parentOverlay;
+    private final Div nestedOverlay;
+
+    public NestedPopoverShortcutView() {
+        eventLog = new Div(new Text("Shortcut events:"));
+        eventLog.setId(EVENT_LOG_ID);
+
+        final Input parentInput = new Input();
+        parentInput.setId(PARENT_INPUT_ID);
+        parentOverlay = new Div(new Text("Parent overlay"), parentInput);
+        parentOverlay.setId(PARENT_OVERLAY_ID);
+        parentOverlay.getElement().setAttribute("popover", "manual");
+
+        final Input nestedInput = new Input();
+        nestedInput.setId(NESTED_INPUT_ID);
+        nestedOverlay = new Div(new Text("Nested overlay"), nestedInput);
+        nestedOverlay.setId(NESTED_OVERLAY_ID);
+        nestedOverlay.getElement().setAttribute("popover", "manual");
+        // Native popover nesting: the nested overlay is a DOM child of the
+        // parent overlay, exactly like a nested dialog in Vaadin 25.
+        parentOverlay.add(nestedOverlay);
+
+        // Relay keydown events from the parent overlay element to parentDialog,
+        // matching how Dialog wires shortcuts to its overlay.
+        Shortcuts.setShortcutListenOnElement(
+                "document.getElementById('" + PARENT_OVERLAY_ID + "')",
+                parentDialog);
+        Shortcuts.addShortcutListener(parentDialog, () -> log(PARENT_SHORTCUT),
+                SHORTCUT_KEY, SHORTCUT_MODIFIER).listenOn(parentDialog);
+
+        final NativeButton openParent = new NativeButton("Open parent overlay",
+                e -> parentOverlay.getElement()
+                        .executeJs("this.showPopover();"));
+        openParent.setId(OPEN_PARENT_BUTTON);
+        final NativeButton openNested = new NativeButton("Open nested overlay",
+                e -> nestedOverlay.getElement()
+                        .executeJs("this.showPopover();"));
+        openNested.setId(OPEN_NESTED_BUTTON);
+
+        add(openParent, openNested, parentDialog, parentOverlay, eventLog);
+        setId("main-div");
+    }
+
+    private void log(String source) {
+        eventLog.addComponentAsFirst(new Div(
+                new Text(eventCounter.getAndIncrement() + "-" + source)));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutView.java
@@ -49,9 +49,13 @@ public class NestedPopoverShortcutView extends Div {
     public static final String NESTED_OVERLAY_ID = "nested-overlay";
     public static final String PARENT_INPUT_ID = "parent-input";
     public static final String NESTED_INPUT_ID = "nested-input";
+    public static final String SYNC_BUTTON = "sync";
 
     // Shortcut fired by the parent dialog, logged with this source label.
     public static final String PARENT_SHORTCUT = "parent-shortcut";
+    // Logged by the sync button; used by tests as an ordered round-trip
+    // barrier.
+    public static final String SYNC = "sync-done";
 
     public static final Key SHORTCUT_KEY = Key.KEY_S;
     public static final KeyModifier SHORTCUT_MODIFIER = KeyModifier.ALT;
@@ -101,7 +105,14 @@ public class NestedPopoverShortcutView extends Div {
                         .executeJs("this.showPopover();"));
         openNested.setId(OPEN_NESTED_BUTTON);
 
-        add(openParent, openNested, parentDialog, parentOverlay, eventLog);
+        // Plain server round-trip used by tests as an ordered barrier: Flow
+        // serializes requests, so once this logs, any earlier shortcut RPC has
+        // already been applied.
+        final NativeButton sync = new NativeButton("Sync", e -> log(SYNC));
+        sync.setId(SYNC_BUTTON);
+
+        add(openParent, openNested, sync, parentDialog, parentOverlay,
+                eventLog);
         setId("main-div");
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopoverOwnerShortcutView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopoverOwnerShortcutView.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Regression view for issue #24974: a shortcut whose lifecycle owner lives
+ * <em>inside</em> a popover must still fire for keydowns originating in that
+ * same popover, even though the shortcut listens on the UI (body) by default.
+ * <p>
+ * Mirrors the reported {@code Popover} case: a Save button inside the popover
+ * with {@code addClickShortcut(ENTER)}. The origin guard must recognise that
+ * the event and the shortcut owner share the same popover scope and let it
+ * fire, rather than treating the popover as a boundary to suppress.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.PopoverOwnerShortcutView")
+public class PopoverOwnerShortcutView extends Div {
+
+    public static final String EVENT_LOG_ID = "event-log";
+    public static final String OPEN_BUTTON = "open-popover";
+    public static final String POPOVER_ID = "popover";
+    public static final String FIELD_ID = "field";
+    public static final String SAVED = "saved";
+
+    private final Div eventLog;
+    private final AtomicInteger counter = new AtomicInteger();
+
+    public PopoverOwnerShortcutView() {
+        eventLog = new Div(new Text("Shortcut events:"));
+        eventLog.setId(EVENT_LOG_ID);
+
+        final Input field = new Input();
+        field.setId(FIELD_ID);
+
+        final NativeButton save = new NativeButton("Save", e -> log(SAVED));
+        // Owner = save button (inside the popover); listenOn = UI by default.
+        save.addClickShortcut(Key.ENTER);
+
+        final Div popover = new Div(new Text("Popover"), field, save);
+        popover.setId(POPOVER_ID);
+        popover.getElement().setAttribute("popover", "manual");
+
+        final NativeButton open = new NativeButton("Open popover",
+                e -> popover.getElement().executeJs("this.showPopover();"));
+        open.setId(OPEN_BUTTON);
+
+        add(open, popover, eventLog);
+        setId("main-div");
+    }
+
+    private void log(String source) {
+        eventLog.addComponentAsFirst(
+                new Div(new Text(counter.getAndIncrement() + "-" + source)));
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DelegateLeakIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DelegateLeakIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * Validates the PR #25044 reviewer reproducer: the element-locator delegate
+ * clone must fire the owner inside the overlay but must not leak the shortcut
+ * to an owner outside it.
+ */
+public class DelegateLeakIT extends ChromeBrowserTest {
+
+    private TestBenchElement eventLog;
+
+    @Before
+    public void init() {
+        open();
+        $(NativeButtonElement.class).id(DelegateLeakView.OPEN_ID).click();
+        eventLog = $(DivElement.class).id(DelegateLeakView.EVENT_LOG_ID);
+    }
+
+    @Test
+    public void altSInOverlay_insideOwnerFires_outsideOwnerDoesNot() {
+        final InputTextElement field = $(InputTextElement.class)
+                .id(DelegateLeakView.FIELD_ID);
+        field.focus();
+        field.sendKeys(Keys.chord(Keys.ALT, "s"));
+
+        // Barrier: the inside owner must fire. Both shortcuts react to the same
+        // keydown in one round-trip, so once the inside entry is logged an
+        // erroneous outside entry would already be present too.
+        waitUntil(driver -> count(DelegateLeakView.INSIDE_FIRED) >= 1);
+        Assert.assertEquals("Owner inside the overlay must fire exactly once",
+                1, count(DelegateLeakView.INSIDE_FIRED));
+        Assert.assertEquals(
+                "Owner outside the overlay must not fire from the delegate clone",
+                0, count(DelegateLeakView.OUTSIDE_FIRED));
+    }
+
+    private long count(String text) {
+        return eventLog.findElements(By.tagName("div")).stream()
+                .filter(e -> e.getText().contains(text)).count();
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * Captures the expected behaviour for issue #24974: the parent overlay's Alt+S
+ * shortcut must not fire while the nested popover has focus.
+ * <p>
+ * A negative assertion ("did not fire") needs a synchronization barrier because
+ * the shortcut fires asynchronously via a client-server round-trip. The test
+ * presses the shortcut in the nested overlay (must not fire) and then in the
+ * parent overlay (must fire). Flow processes RPCs in order, so once the parent
+ * press has been logged, an erroneous nested fire would already be present too;
+ * asserting the shortcut fired exactly once detects the regression.
+ */
+public class NestedPopoverShortcutIT extends ChromeBrowserTest {
+
+    private TestBenchElement eventLog;
+
+    @Before
+    public void init() {
+        open();
+        eventLog = $(DivElement.class)
+                .id(NestedPopoverShortcutView.EVENT_LOG_ID);
+        $(NativeButtonElement.class)
+                .id(NestedPopoverShortcutView.OPEN_PARENT_BUTTON).click();
+        $(NativeButtonElement.class)
+                .id(NestedPopoverShortcutView.OPEN_NESTED_BUTTON).click();
+    }
+
+    @Test
+    public void nestedPopoverFocused_parentShortcutFiresOnlyForParent() {
+        // Must NOT fire the parent shortcut.
+        pressShortcut(NestedPopoverShortcutView.NESTED_INPUT_ID);
+
+        // Barrier: hide the nested overlay and fire the shortcut from the
+        // parent layer, which MUST fire.
+        final DivElement nestedOverlay = $(DivElement.class)
+                .id(NestedPopoverShortcutView.NESTED_OVERLAY_ID);
+        nestedOverlay.getCommandExecutor()
+                .executeScript("arguments[0].hidePopover();", nestedOverlay);
+        pressShortcut(NestedPopoverShortcutView.PARENT_INPUT_ID);
+
+        waitUntil(driver -> countParentShortcut() >= 1);
+        Assert.assertEquals(
+                "Parent shortcut must fire only for the parent-layer keydown, "
+                        + "not for the keydown originating in the nested popover",
+                1, countParentShortcut());
+    }
+
+    private void pressShortcut(String inputId) {
+        final InputTextElement input = $(InputTextElement.class).id(inputId);
+        input.focus();
+        // Send the chord directly to the element so the keydown originates
+        // inside that field, not on the document.
+        input.sendKeys(Keys.chord(Keys.ALT, "s"));
+    }
+
+    private long countParentShortcut() {
+        final List<WebElement> entries = eventLog
+                .findElements(By.tagName("div"));
+        return entries.stream()
+                .filter(e -> e.getText()
+                        .contains(NestedPopoverShortcutView.PARENT_SHORTCUT))
+                .count();
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NestedPopoverShortcutIT.java
@@ -15,14 +15,11 @@
  */
 package com.vaadin.flow.uitest.ui;
 
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.InputTextElement;
@@ -58,22 +55,28 @@ public class NestedPopoverShortcutIT extends ChromeBrowserTest {
 
     @Test
     public void nestedPopoverFocused_parentShortcutFiresOnlyForParent() {
-        // Must NOT fire the parent shortcut.
+        // Press in the nested overlay — must NOT fire the parent shortcut.
         pressShortcut(NestedPopoverShortcutView.NESTED_INPUT_ID);
 
-        // Barrier: hide the nested overlay and fire the shortcut from the
-        // parent layer, which MUST fire.
+        // Hide the nested overlay and press from the parent layer — MUST fire.
         final DivElement nestedOverlay = $(DivElement.class)
                 .id(NestedPopoverShortcutView.NESTED_OVERLAY_ID);
         nestedOverlay.getCommandExecutor()
                 .executeScript("arguments[0].hidePopover();", nestedOverlay);
         pressShortcut(NestedPopoverShortcutView.PARENT_INPUT_ID);
 
-        waitUntil(driver -> countParentShortcut() >= 1);
+        // Ordered barrier: a plain round-trip issued after both keydowns. Flow
+        // serializes requests, so once the sync marker appears, both shortcut
+        // RPCs (including an erroneous one from the nested press) have been
+        // applied and the count is final.
+        $(NativeButtonElement.class).id(NestedPopoverShortcutView.SYNC_BUTTON)
+                .click();
+        waitUntil(driver -> count(NestedPopoverShortcutView.SYNC) >= 1);
+
         Assert.assertEquals(
                 "Parent shortcut must fire only for the parent-layer keydown, "
                         + "not for the keydown originating in the nested popover",
-                1, countParentShortcut());
+                1, count(NestedPopoverShortcutView.PARENT_SHORTCUT));
     }
 
     private void pressShortcut(String inputId) {
@@ -84,12 +87,8 @@ public class NestedPopoverShortcutIT extends ChromeBrowserTest {
         input.sendKeys(Keys.chord(Keys.ALT, "s"));
     }
 
-    private long countParentShortcut() {
-        final List<WebElement> entries = eventLog
-                .findElements(By.tagName("div"));
-        return entries.stream()
-                .filter(e -> e.getText()
-                        .contains(NestedPopoverShortcutView.PARENT_SHORTCUT))
-                .count();
+    private long count(String text) {
+        return eventLog.findElements(By.tagName("div")).stream()
+                .filter(e -> e.getText().contains(text)).count();
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopoverOwnerShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopoverOwnerShortcutIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * Regression test for issue #24974: a shortcut owned by a component inside a
+ * popover must still fire for keydowns originating in that popover.
+ */
+public class PopoverOwnerShortcutIT extends ChromeBrowserTest {
+
+    private TestBenchElement eventLog;
+
+    @Before
+    public void init() {
+        open();
+        $(NativeButtonElement.class).id(PopoverOwnerShortcutView.OPEN_BUTTON)
+                .click();
+        eventLog = $(DivElement.class)
+                .id(PopoverOwnerShortcutView.EVENT_LOG_ID);
+    }
+
+    @Test
+    public void ownerInsidePopoverFocused_shortcutFires() {
+        $(InputTextElement.class).id(PopoverOwnerShortcutView.FIELD_ID).focus();
+        $(InputTextElement.class).id(PopoverOwnerShortcutView.FIELD_ID)
+                .sendKeys(Keys.ENTER);
+
+        waitUntil(driver -> eventLog.findElements(By.tagName("div")).stream()
+                .anyMatch(e -> e.getText()
+                        .contains(PopoverOwnerShortcutView.SAVED)));
+    }
+}


### PR DESCRIPTION
Block shortcut propagation if crossing
a popover-open or modal boundary.

This makes dialog shortcuts not propagate
up from a nested dialog.

Fixes #24974
