### PR TITLE
feat: add test-support seam for simulating triggers and actions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Action.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Action.java
@@ -17,8 +17,10 @@ package com.vaadin.flow.component.trigger.internal;
 
 import java.io.Serializable;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
@@ -138,5 +140,29 @@ public abstract class Action implements Serializable {
          * @return the input's JS function, not {@code null}
          */
         public abstract JsFunction toJs(Trigger trigger);
+
+        /**
+         * Reproduces on the server the value this input would produce on the
+         * client, for browserless simulation of a trigger firing. Returned as a
+         * {@link JsonNode} — the same wire form the value would take crossing
+         * to the server — so callers decode it as they need.
+         * <p>
+         * Only inputs whose value is observable on the server support this: a
+         * {@link LiteralInput literal}, a {@link PropertyInput synced element
+         * property}, or a {@link HandlerInput value read from the simulated
+         * event}. Inputs backed by genuinely client-only state (e.g. an image
+         * blob) cannot be reproduced and throw
+         * {@link UnsupportedOperationException}.
+         *
+         * @param eventData
+         *            the simulated event payload the firing supplies, or
+         *            {@code null} for inputs that do not read the event
+         * @return the input's value as a {@link JsonNode}, never {@code null}
+         *         (use a JSON null node for an absent value)
+         */
+        public JsonNode evaluate(@Nullable JsonNode eventData) {
+            throw new UnsupportedOperationException(getClass().getSimpleName()
+                    + " cannot be evaluated on the server");
+        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
@@ -145,6 +145,29 @@ public class CallbackAction<T> extends Action {
                 .withArguments("event");
     }
 
+    /**
+     * Delivers a value as if the client had forwarded it from the trigger's
+     * handler scope, running the callback on the calling thread. For
+     * browserless simulation of a trigger firing. Pass {@code null} for the
+     * value-less variant (where the trigger firing is the whole signal); a
+     * value-carrying action rejects a {@code null} exactly as it would a JSON
+     * null from the client.
+     *
+     * @param trigger
+     *            the trigger this action was armed on, not {@code null}
+     * @param value
+     *            the value to forward as a {@link JsonNode}, or {@code null}
+     *            for the value-less variant
+     */
+    public void deliver(Trigger trigger, @Nullable JsonNode value) {
+        Objects.requireNonNull(trigger, "trigger must not be null");
+        ArrayNode args = JacksonUtils.createArrayNode();
+        if (value != null) {
+            args.add(value);
+        }
+        channelFor(trigger.getHost().getNode()).invoke(args);
+    }
+
     private ReturnChannelRegistration channelFor(StateNode hostNode) {
         return channelByNode.computeIfAbsent(hostNode, node -> node
                 .getFeature(ReturnChannelMap.class).registerChannel(dispatch));

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
@@ -61,6 +61,17 @@ public class DomEventTrigger extends Trigger {
     }
 
     /**
+     * The DOM event name this trigger fires on (e.g. {@code "click"}).
+     * Inherited by subclasses such as {@link ClickTrigger} (which reports
+     * {@code "click"}) and {@link DoubleClickTrigger} ({@code "dblclick"}).
+     *
+     * @return the DOM event name, not {@code null}
+     */
+    public String getEventName() {
+        return eventName;
+    }
+
+    /**
      * Returns an {@link Action.Input} that yields {@code event[name]} at fire
      * time, valid in the handler of any trigger that is an instance of
      * {@code ownerClass}. Used by trigger families that expose their event

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
@@ -17,7 +17,11 @@ package com.vaadin.flow.component.trigger.internal;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
 import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
 
 /**
  * Input that reads a property from a trigger handler's {@code event} argument
@@ -72,5 +76,13 @@ public final class HandlerInput<T> extends Action.Input<T> {
         // event = the handler argument the framework passes in.
         return JsFunction.of("return event[$0]", propertyName)
                 .withArguments("event");
+    }
+
+    @Override
+    public JsonNode evaluate(@Nullable JsonNode eventData) {
+        // Reads event[propertyName] from the simulated event payload, mirroring
+        // the client-side `return event[$0]`.
+        return eventData == null ? JacksonUtils.nullNode()
+                : eventData.path(propertyName);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/LiteralInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/LiteralInput.java
@@ -17,7 +17,11 @@ package com.vaadin.flow.component.trigger.internal;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
 import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
 
 /**
  * Input backed by a server-side literal that is captured into the rendered
@@ -66,5 +70,11 @@ public final class LiteralInput<T> extends Action.Input<T> {
         // The value is captured (not stringified into the body), so Jackson
         // handles all encoding — quoting, escaping, nested objects, etc.
         return JsFunction.of("return $0", value);
+    }
+
+    @Override
+    public JsonNode evaluate(@Nullable JsonNode eventData) {
+        // Same Jackson mapping the client would receive for the captured value.
+        return JacksonUtils.writeValue(value);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
@@ -180,6 +180,55 @@ public abstract class PromiseAction<T> extends Action {
                 .withArguments("event");
     }
 
+    /**
+     * Delivers a resolved value as if the client had reported that the action's
+     * promise resolved, running {@code onSuccess} on the calling thread. For
+     * browserless simulation of a trigger firing. A no-op for a fire-and-forget
+     * action, which has no channel and reports nothing.
+     *
+     * @param trigger
+     *            the trigger this action was armed on, not {@code null}
+     * @param value
+     *            the resolved value as a {@link JsonNode}, or {@code null} for
+     *            a promise that resolved with no value
+     */
+    public void deliverSuccess(Trigger trigger, @Nullable JsonNode value) {
+        Objects.requireNonNull(trigger, "trigger must not be null");
+        if (onSuccess == null) {
+            return;
+        }
+        invokeChannel(trigger, new Outcome(true, value, null));
+    }
+
+    /**
+     * Delivers a rejection as if the client had reported that the action's
+     * promise rejected, running {@code onError} on the calling thread. For
+     * browserless simulation of a trigger firing. A no-op for a fire-and-forget
+     * action.
+     *
+     * @param trigger
+     *            the trigger this action was armed on, not {@code null}
+     * @param error
+     *            the rejection to deliver, not {@code null}
+     */
+    public void deliverError(Trigger trigger, Error error) {
+        Objects.requireNonNull(trigger, "trigger must not be null");
+        Objects.requireNonNull(error, "error must not be null");
+        if (onError == null) {
+            return;
+        }
+        invokeChannel(trigger, new Outcome(false, null, error));
+    }
+
+    private void invokeChannel(Trigger trigger, Outcome outcome) {
+        // Serialise the same Outcome record dispatch() reads back, then route
+        // through the genuine return channel so decoding and the callback run
+        // exactly as for a real client message.
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(JacksonUtils.writeValue(outcome));
+        channelFor(trigger.getHost().getNode()).invoke(args);
+    }
+
     private ReturnChannelRegistration channelFor(StateNode hostNode) {
         return channelByNode.computeIfAbsent(hostNode,
                 node -> node.getFeature(ReturnChannelMap.class)

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PropertyInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PropertyInput.java
@@ -15,11 +15,16 @@
  */
 package com.vaadin.flow.component.trigger.internal;
 
+import java.io.Serializable;
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
 
 /**
  * Reads a JavaScript property from a target component's root element at the
@@ -69,5 +74,14 @@ public class PropertyInput<T> extends Action.Input<T> {
         // captures — JsFunction's wire encoding handles Element-to-DOM-ref
         // mapping and JSON-quotes the property name.
         return JsFunction.of("return $0[$1]", target, propertyName);
+    }
+
+    @Override
+    public JsonNode evaluate(@Nullable JsonNode eventData) {
+        // Reads the value synced to the server-side property map, which stands
+        // in for the client-side DOM property the JS would read.
+        Serializable raw = target.getPropertyRaw(propertyName);
+        return raw == null ? JacksonUtils.nullNode()
+                : JacksonUtils.writeValue(raw);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
@@ -153,6 +153,7 @@ public abstract class Trigger implements Serializable {
             registrations.add(Objects.requireNonNull(install(action.toJs(this)),
                     "install must return a Registration"));
         }
+        Triggers.notifyArmed(this, List.of(actions));
     }
 
     /**
@@ -224,5 +225,6 @@ public abstract class Trigger implements Serializable {
     public final void remove() {
         registrations.forEach(Registration::remove);
         registrations.clear();
+        Triggers.notifyDisarmed(this);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Triggers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Triggers.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Observation hub for {@link Trigger} arming.
+ * <p>
+ * <strong>Internal test-support API — not for production use.</strong> Its sole
+ * purpose is to let a browserless test harness discover which triggers (and
+ * actions) are armed on which host, so it can simulate them without a browser.
+ * Nothing in production registers or relies on this. It is not part of the
+ * public API and may be renamed or removed in any release.
+ * <p>
+ * The listener registry is scoped to the {@link VaadinService} — it is stored
+ * as a {@link com.vaadin.flow.server.VaadinContext} attribute on the service —
+ * so a listener registered for one application/service observes only that
+ * service's armings, never another's. This keeps concurrent environments (e.g.
+ * parallel tests, or multiple Vaadin apps in one JVM) isolated, and leaves
+ * nothing behind on a process-global registry once a service is discarded. A
+ * JVM with no listener registered creates no registry at all.
+ *
+ * @since 25.2
+ */
+public final class Triggers {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(Triggers.class);
+
+    /**
+     * Notified when a {@link Trigger} is armed with actions or removed.
+     */
+    public interface ArmingListener {
+
+        /**
+         * Invoked when {@link Trigger#triggers(Action...)} commits actions to a
+         * trigger. Fired once per {@code triggers} call with that call's
+         * actions, in order; a trigger armed by several calls produces several
+         * notifications.
+         *
+         * @param trigger
+         *            the trigger that was armed, not {@code null}
+         * @param actions
+         *            the actions committed in this call, in order, not
+         *            {@code null}
+         */
+        void onArmed(Trigger trigger, List<Action> actions);
+
+        /**
+         * Invoked when {@link Trigger#remove()} detaches a trigger. May fire
+         * for a trigger that was never armed; consumers should ignore triggers
+         * they have not recorded.
+         *
+         * @param trigger
+         *            the trigger that was removed, not {@code null}
+         */
+        default void onDisarmed(Trigger trigger) {
+        }
+    }
+
+    /**
+     * Per-service registry of arming listeners, held as a
+     * {@link com.vaadin.flow.server.VaadinContext} attribute. The list is
+     * {@code transient}: the registry is test-only state that should never ride
+     * a serialized context, so a deserialized instance simply starts empty.
+     */
+    private static final class ArmingListeners implements Serializable {
+
+        private transient List<ArmingListener> listeners = new CopyOnWriteArrayList<>();
+
+        private void readObject(ObjectInputStream in)
+                throws IOException, ClassNotFoundException {
+            in.defaultReadObject();
+            listeners = new CopyOnWriteArrayList<>();
+        }
+    }
+
+    private Triggers() {
+    }
+
+    /**
+     * Registers a listener notified when triggers are armed or removed within
+     * the given service. The listener is stored on the service (as a
+     * {@link com.vaadin.flow.server.VaadinContext} attribute), so it observes
+     * only armings whose host belongs to {@code service}.
+     *
+     * @param service
+     *            the service whose armings to observe, not {@code null}
+     * @param listener
+     *            the listener to add, not {@code null}
+     * @return a registration that removes the listener when
+     *         {@link Registration#remove() removed}
+     */
+    public static Registration addArmingListener(VaadinService service,
+            ArmingListener listener) {
+        Objects.requireNonNull(service, "service must not be null");
+        Objects.requireNonNull(listener, "listener must not be null");
+        service.getContext().getAttribute(ArmingListeners.class,
+                ArmingListeners::new).listeners.add(listener);
+        return new ArmingRegistration(service, listener);
+    }
+
+    /**
+     * Registration for an arming listener. The service and listener are held in
+     * {@code transient} fields so that, should the registration end up
+     * referenced from a serialized {@code VaadinSession}, serialization does
+     * not drag in (and possibly fail on) the listener — which belongs to the
+     * service's registry, not the session. A deserialized registration refers
+     * to nothing, so {@link #remove()} is then a no-op.
+     */
+    private static final class ArmingRegistration implements Registration {
+
+        private final transient @Nullable VaadinService service;
+        private final transient @Nullable ArmingListener listener;
+
+        ArmingRegistration(VaadinService service, ArmingListener listener) {
+            this.service = service;
+            this.listener = listener;
+        }
+
+        @Override
+        public void remove() {
+            if (service == null || listener == null) {
+                return;
+            }
+            ArmingListeners registry = service.getContext()
+                    .getAttribute(ArmingListeners.class);
+            if (registry != null) {
+                registry.listeners.remove(listener);
+            }
+        }
+    }
+
+    static void notifyArmed(Trigger trigger, List<Action> actions) {
+        ArmingListeners registry = registryFor(trigger);
+        if (registry == null) {
+            return;
+        }
+        List<Action> copy = List.copyOf(actions);
+        for (ArmingListener listener : registry.listeners) {
+            try {
+                listener.onArmed(trigger, copy);
+            } catch (RuntimeException e) {
+                LOGGER.error("Trigger arming listener failed", e);
+            }
+        }
+    }
+
+    static void notifyDisarmed(Trigger trigger) {
+        ArmingListeners registry = registryFor(trigger);
+        if (registry == null) {
+            return;
+        }
+        for (ArmingListener listener : registry.listeners) {
+            try {
+                listener.onDisarmed(trigger);
+            } catch (RuntimeException e) {
+                LOGGER.error("Trigger arming listener failed", e);
+            }
+        }
+    }
+
+    private static @Nullable ArmingListeners registryFor(Trigger trigger) {
+        VaadinService service = serviceOf(trigger);
+        // No default supplier: absence means no listener was ever registered
+        // for this service, so there is nothing to notify.
+        return service == null ? null
+                : service.getContext().getAttribute(ArmingListeners.class);
+    }
+
+    private static @Nullable VaadinService serviceOf(Trigger trigger) {
+        // Prefer the host's own service, which is authoritative when the host
+        // is
+        // attached. Fall back to the current service — what a browserless
+        // harness has at arm time, since a trigger is typically armed during
+        // view construction, before the host is attached to a UI.
+        VaadinService hostService = trigger.getHost().getComponent()
+                .flatMap(Component::getUI).map(UI::getSession)
+                .map(VaadinSession::getService).orElse(null);
+        return hostService != null ? hostService : VaadinService.getCurrent();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/WriteToClipboardAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/WriteToClipboardAction.java
@@ -245,4 +245,34 @@ public class WriteToClipboardAction extends PromiseAction<String> {
                 "return window.Vaadin.Flow.clipboard.writePayload($0(event), $1(event), $2(event))",
                 text, html, image).withArguments("event");
     }
+
+    /**
+     * The input producing the {@code text/plain} payload, or {@code null} if
+     * this action writes no plain text. For browserless simulation.
+     *
+     * @return the text input, or {@code null}
+     */
+    public Action.@Nullable Input<String> getTextInput() {
+        return textInput;
+    }
+
+    /**
+     * The input producing the {@code text/html} payload, or {@code null} if
+     * this action writes no HTML. For browserless simulation.
+     *
+     * @return the HTML input, or {@code null}
+     */
+    public Action.@Nullable Input<String> getHtmlInput() {
+        return htmlInput;
+    }
+
+    /**
+     * The input producing the {@code image/png} payload, or {@code null} if
+     * this action writes no image. For browserless simulation.
+     *
+     * @return the image input, or {@code null}
+     */
+    public Action.@Nullable Input<?> getImageInput() {
+        return imageInput;
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerSimulationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerSimulationTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ObjectNode;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.trigger.internal.Action.Input;
+import com.vaadin.flow.component.trigger.internal.PromiseAction.Error;
+import com.vaadin.flow.component.trigger.internal.Triggers.ArmingListener;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.server.MockServletServiceSessionSetup;
+import com.vaadin.flow.server.MockVaadinContext;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the server-side simulation seam (arming observation, event-name
+ * introspection, input evaluation, outcome delivery) that lets a browserless
+ * test harness fire triggers and observe their actions without a browser.
+ */
+class TriggerSimulationTest {
+
+    private record Armed(Trigger trigger, List<Action> actions) {
+    }
+
+    /**
+     * A {@link MockUI} whose service exposes a real attribute-backed
+     * {@link MockVaadinContext}, so the service-scoped arming registry actually
+     * persists (the default mock servlet context does not store attributes).
+     */
+    private static UI uiWithService() throws Exception {
+        MockServletServiceSessionSetup setup = new MockServletServiceSessionSetup();
+        setup.getService().setContext(new MockVaadinContext());
+        return new MockUI(setup.getSession());
+    }
+
+    // 1a — arming observation ------------------------------------------------
+
+    @Test
+    void armingListener_notifiedPerTriggersCall_thenOnRemove()
+            throws Exception {
+        UI ui = uiWithService();
+        VaadinService service = ui.getSession().getService();
+        TagComponent button = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), field.getElement());
+
+        List<Armed> armed = new ArrayList<>();
+        AtomicReference<Trigger> disarmed = new AtomicReference<>();
+        Registration registration = Triggers.addArmingListener(service,
+                new ArmingListener() {
+                    @Override
+                    public void onArmed(Trigger trigger, List<Action> actions) {
+                        armed.add(new Armed(trigger, actions));
+                    }
+
+                    @Override
+                    public void onDisarmed(Trigger trigger) {
+                        disarmed.set(trigger);
+                    }
+                });
+        try {
+            ClickTrigger click = new ClickTrigger(button);
+            Action a = new SetPropertyAction<>(field, "value", "x");
+            Action b = new SetPropertyAction<>(field, "disabled", true);
+            click.triggers(a, b);
+
+            assertEquals(1, armed.size(),
+                    "one notification per triggers() call");
+            assertSame(click, armed.get(0).trigger());
+            assertEquals(List.of(a, b), armed.get(0).actions());
+
+            // A second call on the same trigger notifies again with its batch.
+            Action c = new SetPropertyAction<>(field, "value", "y");
+            click.triggers(c);
+            assertEquals(2, armed.size());
+            assertEquals(List.of(c), armed.get(1).actions());
+
+            click.remove();
+            assertSame(click, disarmed.get());
+        } finally {
+            registration.remove();
+        }
+
+        // After removal the listener no longer fires.
+        int before = armed.size();
+        new ClickTrigger(button)
+                .triggers(new SetPropertyAction<>(field, "value", "z"));
+        assertEquals(before, armed.size());
+    }
+
+    @Test
+    void armingRegistration_serializable_evenWithNonSerializableListener()
+            throws Exception {
+        // ArmingListener is not Serializable, so this anonymous instance is
+        // not either. The registration must still serialize (the service and
+        // listener are held transiently) rather than fail on it.
+        VaadinService service = uiWithService().getSession().getService();
+        Registration registration = Triggers.addArmingListener(service,
+                new ArmingListener() {
+                    @Override
+                    public void onArmed(Trigger trigger, List<Action> actions) {
+                    }
+                });
+        try {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+                out.writeObject(registration);
+            }
+            Registration restored;
+            try (ObjectInputStream in = new ObjectInputStream(
+                    new ByteArrayInputStream(bytes.toByteArray()))) {
+                restored = (Registration) in.readObject();
+            }
+            // A deserialized registration refers to no live listener; removing
+            // it must be a harmless no-op.
+            restored.remove();
+        } finally {
+            registration.remove();
+        }
+    }
+
+    // 1b — event-name introspection -----------------------------------------
+
+    @Test
+    void domEventTrigger_reportsEventName() {
+        TagComponent button = new TagComponent("button");
+        assertEquals("click", new ClickTrigger(button).getEventName());
+        assertEquals("dblclick", new DoubleClickTrigger(button).getEventName());
+        assertEquals("input",
+                new DomEventTrigger(button, "input").getEventName());
+    }
+
+    // 1c — server-side input evaluation -------------------------------------
+
+    @Test
+    void literalInput_evaluatesToItsValue() {
+        assertEquals("hi", new LiteralInput<>("hi").evaluate(null).asString());
+    }
+
+    @Test
+    void propertyInput_evaluatesToSyncedProperty() {
+        TagComponent field = new TagComponent("input");
+        field.getElement().setProperty("value", "abc");
+
+        Input<String> input = new PropertyInput<>(field, "value", String.class);
+        assertEquals("abc", input.evaluate(null).asString());
+    }
+
+    @Test
+    void propertyInput_absentProperty_evaluatesToNull() {
+        TagComponent field = new TagComponent("input");
+        Input<String> input = new PropertyInput<>(field, "value", String.class);
+        assertTrue(input.evaluate(null).isNull());
+    }
+
+    @Test
+    void handlerInput_evaluatesFromEventData() {
+        ObjectNode eventData = JacksonUtils.createObjectNode();
+        eventData.put("screenX", 42);
+        assertEquals(42,
+                ClickTrigger.EventData.screenX.evaluate(eventData).asInt());
+    }
+
+    // 1d — outcome delivery --------------------------------------------------
+
+    @Test
+    void promiseAction_deliverSuccess_runsOnSuccess() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        AtomicReference<String> copied = new AtomicReference<>();
+        AtomicReference<Error> failed = new AtomicReference<>();
+        WriteToClipboardAction action = new WriteToClipboardAction(
+                new LiteralInput<>("ignored"), null, copied::set, failed::set);
+        ClickTrigger click = new ClickTrigger(button);
+        click.triggers(action);
+
+        action.deliverSuccess(click, JacksonUtils.writeValue("hello"));
+        assertEquals("hello", copied.get());
+        assertNull(failed.get());
+    }
+
+    @Test
+    void promiseAction_deliverError_runsOnError() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        AtomicReference<String> copied = new AtomicReference<>();
+        AtomicReference<Error> failed = new AtomicReference<>();
+        WriteToClipboardAction action = new WriteToClipboardAction(
+                new LiteralInput<>("ignored"), null, copied::set, failed::set);
+        ClickTrigger click = new ClickTrigger(button);
+        click.triggers(action);
+
+        action.deliverError(click, new Error("NotAllowedError", "denied"));
+        assertEquals("NotAllowedError", failed.get().name());
+        assertEquals("denied", failed.get().message());
+        assertNull(copied.get());
+    }
+
+    @Test
+    void promiseAction_fireAndForget_deliverIsNoop() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        // No onCopied/onError => no channel; delivering must not throw.
+        WriteToClipboardAction action = new WriteToClipboardAction(
+                new LiteralInput<>("x"), null);
+        ClickTrigger click = new ClickTrigger(button);
+        click.triggers(action);
+
+        action.deliverSuccess(click, JacksonUtils.writeValue("x"));
+        action.deliverError(click, new Error("", ""));
+    }
+
+    @Test
+    void callbackAction_deliver_runsCallback() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        AtomicReference<Integer> received = new AtomicReference<>();
+        CallbackAction<Integer> action = new CallbackAction<>(Integer.class,
+                received::set, ClickTrigger.EventData.screenX);
+        ClickTrigger click = new ClickTrigger(button);
+        click.triggers(action);
+
+        action.deliver(click, JacksonUtils.writeValue(7));
+        assertEquals(7, received.get());
+    }
+
+    @Test
+    void callbackAction_valueless_deliverRunsRunnable() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        AtomicReference<Boolean> ran = new AtomicReference<>(false);
+        CallbackAction<Void> action = new CallbackAction<>(() -> ran.set(true));
+        ClickTrigger click = new ClickTrigger(button);
+        click.triggers(action);
+
+        action.deliver(click, null);
+        assertTrue(ran.get());
+    }
+}

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -207,6 +207,8 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.component\\.template\\.internal\\.ParserData",
                 "com\\.vaadin\\.flow\\.component\\.internal\\.ComponentMetaData(\\$.*)?",
                 "com\\.vaadin\\.flow\\.component\\.internal\\.ComponentTracker",
+                "com\\.vaadin\\.flow\\.component\\.trigger\\.internal\\.Triggers",
+                "com\\.vaadin\\.flow\\.component\\.trigger\\.internal\\.Triggers\\$ArmingListener",
                 "com\\.vaadin\\.flow\\.dom\\.ElementEffect",
                 "com\\.vaadin\\.flow\\.dom\\.ElementFactory",
                 "com\\.vaadin\\.flow\\.dom\\.NodeVisitor",


### PR DESCRIPTION
Expose an internal seam in `com.vaadin.flow.component.trigger.internal`
so test frameworks can reproduce the server-observable effect of
client-side triggers and actions without a browser.

Adds a `VaadinService`-scoped arming-listener registry in `Triggers`,
`DomEventTrigger.getEventName`, `Action.Input.evaluate`, delivery
helpers on `PromiseAction` and `CallbackAction`, and accessors on
`WriteToClipboardAction`. Internal test-support API only.

