### PR TITLE
Make VaadinScanPackages serializable and merge scan packages correctly

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinScanPackages.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinScanPackages.java
@@ -1,0 +1,38 @@
+package com.vaadin.flow.spring;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class VaadinScanPackages implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> scanPackages;
+
+    public VaadinScanPackages(String[] scanPackages) {
+        assert scanPackages != null;
+        this.scanPackages = new ArrayList<>(Arrays.asList(scanPackages));
+    }
+
+    public List<String> getScanPackages() {
+        return scanPackages;
+    }
+
+    public static String[] merge(String[] existingPackages,
+                                 String[] newPackages) {
+
+        String[] merged = Arrays.copyOf(existingPackages,
+                existingPackages.length + newPackages.length);
+
+        System.arraycopy(newPackages, 0,
+                merged,
+                existingPackages.length,
+                newPackages.length);
+
+        return merged;
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinScanPackagesRegistrar.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinScanPackagesRegistrar.java
@@ -16,9 +16,6 @@
 package com.vaadin.flow.spring;
 
 import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -38,39 +35,54 @@ import com.vaadin.flow.spring.annotation.EnableVaadin;
  */
 public class VaadinScanPackagesRegistrar
         implements ImportBeanDefinitionRegistrar {
-
-    static class VaadinScanPackages {
-
-        private final List<String> scanPackages;
-
-        private VaadinScanPackages(String[] scanPackages) {
-            assert scanPackages != null;
-            this.scanPackages = Collections
-                    .unmodifiableList(Arrays.asList(scanPackages));
-        }
-
-        List<String> getScanPackages() {
-            return scanPackages;
-        }
-
-    }
-
     @Override
     public void registerBeanDefinitions(AnnotationMetadata annotationMetadata,
-            BeanDefinitionRegistry registry) {
-        String[] packages = getPackages(annotationMetadata, EnableVaadin.class,
-                "value");
-        if (packages.length > 0) {
-            GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+                                        BeanDefinitionRegistry registry) {
+
+        String[] packages = getPackages(annotationMetadata,
+                EnableVaadin.class, "value");
+
+        if (packages.length == 0) {
+            return;
+        }
+
+        String beanName = VaadinScanPackages.class.getName();
+
+        if (registry.containsBeanDefinition(beanName)) {
+
+            BeanDefinition existingBeanDefinition = registry
+                    .getBeanDefinition(beanName);
+
+            Object existingValue = existingBeanDefinition
+                    .getConstructorArgumentValues()
+                    .getIndexedArgumentValue(0, String[].class)
+                    .getValue();
+
+            String[] existingPackages = (String[]) existingValue;
+
+            String[] mergedPackages = VaadinScanPackages.merge(
+                    existingPackages, packages);
+
+            existingBeanDefinition.getConstructorArgumentValues()
+                    .addIndexedArgumentValue(0, mergedPackages);
+
+        } else {
+
+            GenericBeanDefinition beanDefinition =
+                    new GenericBeanDefinition();
+
             beanDefinition.setBeanClass(VaadinScanPackages.class);
+
             beanDefinition.getConstructorArgumentValues()
                     .addIndexedArgumentValue(0, packages);
-            beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
-            registry.registerBeanDefinition(VaadinScanPackages.class.getName(),
+
+            beanDefinition.setRole(
+                    BeanDefinition.ROLE_INFRASTRUCTURE);
+
+            registry.registerBeanDefinition(beanName,
                     beanDefinition);
         }
     }
-
     private <T> T getPackages(Class<T> clazz,
             AnnotationMetadata annotationMetadata,
             Class<? extends Annotation> annotation, String getterName) {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -91,7 +91,7 @@ import com.vaadin.flow.server.startup.VaadinInitializerException;
 import com.vaadin.flow.server.startup.WebComponentConfigurationRegistryInitializer;
 import com.vaadin.flow.server.startup.WebComponentExporterAwareValidator;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
-import com.vaadin.flow.spring.VaadinScanPackagesRegistrar.VaadinScanPackages;
+import com.vaadin.flow.spring.VaadinScanPackages;
 import com.vaadin.flow.spring.io.FilterableResourceResolver;
 import com.vaadin.flow.theme.Theme;
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinScanPackagesRegistrarTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinScanPackagesRegistrarTest.java
@@ -1,0 +1,72 @@
+package com.vaadin.flow.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import com.vaadin.flow.spring.annotation.EnableVaadin;
+
+class VaadinScanPackagesRegistrarTest {
+
+    @Test
+    void multipleEnableVaadinConfigurations_shouldMergeScanPackages() {
+
+        try (AnnotationConfigApplicationContext context =
+                     new AnnotationConfigApplicationContext()) {
+
+            context.register(ServiceAConfiguration.class,
+                    ServiceBConfiguration.class);
+
+            context.refresh();
+
+            VaadinScanPackages scanPackages =
+                    context.getBean(VaadinScanPackages.class);
+
+            assertThat(scanPackages.getScanPackages())
+                    .containsExactly(
+                            "pkg.service.a.views",
+                            "pkg.service.b.views");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableVaadin("pkg.service.a.views")
+    static class ServiceAConfiguration {
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableVaadin("pkg.service.b.views")
+    static class ServiceBConfiguration {
+    }
+
+    @Test
+    void vaadinScanPackagesIsSerializable() throws Exception {
+        VaadinScanPackages original =
+                new VaadinScanPackages(
+                        new String[] { "pkg.views" });
+
+        ByteArrayOutputStream output =
+                new ByteArrayOutputStream();
+
+        ObjectOutputStream objectOutput =
+                new ObjectOutputStream(output);
+
+        objectOutput.writeObject(original);
+
+        ObjectInputStream objectInput =
+                new ObjectInputStream(
+                        new ByteArrayInputStream(output.toByteArray()));
+
+        VaadinScanPackages restored =
+                (VaadinScanPackages) objectInput.readObject();
+
+        assertThat(restored.getScanPackages())
+                .containsExactly("pkg.views");
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
@@ -299,7 +299,7 @@ class VaadinServletContextInitializerTest {
         vaadinServletContextInitializer.onStartup(servletContext);
 
         Mockito.when(applicationContext.getBeanNamesForType(
-                VaadinScanPackagesRegistrar.VaadinScanPackages.class))
+                VaadinScanPackages.class))
                 .thenReturn(new String[] {});
 
         autoConfigurationPackagesMock


### PR DESCRIPTION
## Description

This change extracts scan package handling into `VaadinScanPackages` and makes the class serializable.

Previously, scan package merging logic was handled inside `VaadinScanPackagesRegistrar`. The merge logic is now moved into `VaadinScanPackages` so that scan package handling remains in one place.

This also fixes serialization support required for `VaadinScanPackages`.

## Fixes

Fixes #25022 

## Type of change

- Bugfix

## Checklist

- [x] I have read the contribution guide
- [x] I have added a description following the guideline
- [x] I have referenced the issue
- [x] I have added tests
- [x] New and existing tests are passing locally
- [x] I have performed self-review