### PR TITLE
fix: keep the development frontend token out of production archives

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -583,6 +583,132 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         build.expectTaskNotRan("vaadinBuildFrontend")
     }
 
+    /**
+     * `vaadinPrepareFrontend` writes the development token into
+     * `resourceOutputDirectory`, which is registered as a resources source
+     * folder, so `processResources` consumes its output. Invoking the task
+     * directly together with `build` must not fail on a missing task
+     * dependency.
+     */
+    @Test
+    fun prepareFrontend_developmentMode_invokedWithBuild_succeeds() {
+        testProject.buildFile.writeText(vaadinWarProject())
+
+        val build: BuildResult =
+            testProject.build("vaadinPrepareFrontend", "build")
+
+        build.expectTaskSucceded("vaadinPrepareFrontend")
+        // the development token must still reach the classpath
+        expectArchiveContains("WEB-INF/classes/META-INF/VAADIN/config/flow-build-info.json") {
+            testProject.builtWar
+        }
+    }
+
+    /**
+     * `vaadinPrepareFrontend` is not needed in a production build - since Vaadin
+     * 25 `vaadinBuildFrontend` performs the frontend preparation itself - but
+     * pipelines carried over from earlier versions still invoke it. Doing so
+     * must not corrupt the archive: the production token written by
+     * `vaadinBuildFrontend` has to be the only one packaged, even though
+     * `vaadinPrepareFrontend` also generates one.
+     */
+    @Test
+    fun prepareFrontend_productionMode_invokedWithBuild_keepsProductionToken() {
+        testProject.buildFile.writeText(vaadinWarProject())
+
+        val build: BuildResult = testProject.build(
+            "-Pvaadin.productionMode", "vaadinPrepareFrontend", "build"
+        )
+
+        build.expectTaskSucceded("vaadinPrepareFrontend")
+        build.expectTaskSucceded("vaadinBuildFrontend")
+        val war: File = testProject.builtWar
+        // asserts, among others, that there is exactly one flow-build-info.json
+        expectArchiveContainsVaadinBundle(war, false)
+        expectProductionToken(war, "WEB-INF/classes/")
+    }
+
+    /**
+     * A `resourceOutputDirectory` left behind by an earlier development-mode
+     * `vaadinPrepareFrontend` execution must not be packaged by a later
+     * production build: the token it holds always has `productionMode=false`,
+     * and `vaadinBuildFrontend` contributes its own token, so the archive
+     * would end up with two conflicting copies.
+     */
+    @Test
+    fun prepareFrontend_staleGeneratedResources_productionArchiveKeepsProductionToken() {
+        testProject.buildFile.writeText(vaadinWarProject())
+
+        // development mode run, leaves the token in build/vaadin-generated
+        testProject.build("vaadinPrepareFrontend")
+
+        val build: BuildResult =
+            testProject.build("-Pvaadin.productionMode", "build")
+
+        build.expectTaskSucceded("vaadinBuildFrontend")
+        val war: File = testProject.builtWar
+        expectArchiveContainsVaadinBundle(war, false)
+        expectProductionToken(war, "WEB-INF/classes/")
+    }
+
+    /**
+     * Same as
+     * [prepareFrontend_staleGeneratedResources_productionArchiveKeepsProductionToken],
+     * for Spring Boot packaging: an executable jar keeps the production bundle
+     * at the archive root instead of under `WEB-INF/classes`, so the two source
+     * set contributions are merged differently there.
+     */
+    @Test
+    fun prepareFrontend_staleGeneratedResources_springBootArchiveKeepsProductionToken() {
+        doTestSpringProject()
+
+        // Development mode run, leaves the token in build/vaadin-generated.
+        // Spring Boot projects default to production mode - the convention keys
+        // on the presence of a bootJar task - so development mode is forced.
+        testProject.build("-Pvaadin.productionMode=false", "vaadinPrepareFrontend")
+
+        val build: BuildResult =
+            testProject.build("-Pvaadin.productionMode", "build")
+
+        build.expectTaskSucceded("vaadinBuildFrontend")
+        val jar: File = testProject.builtJar
+        expectArchiveContainsVaadinBundle(jar, true)
+        expectProductionToken(jar, "")
+    }
+
+    private fun vaadinWarProject(): String = """
+            plugins {
+                id 'war'
+                id 'com.vaadin.flow'
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+            }
+        """
+
+    /**
+     * @param resourcePackaging archive prefix the source set resources end up
+     *      under: `WEB-INF/classes/` for a War, empty for a Spring Boot jar.
+     */
+    private fun expectProductionToken(archive: File, resourcePackaging: String) {
+        val token: String? = archive.zipReadEntry(
+            "${resourcePackaging}META-INF/VAADIN/config/flow-build-info.json"
+        )
+        expect(true, "flow-build-info.json missing from $archive") {
+            token != null
+        }
+        expect(true, "expected a production token, was:\n$token") {
+            token!!.contains("\"productionMode\" : true")
+        }
+    }
+
     @Test
     fun testIncludeExclude() {
         testProject.buildFile.writeText("""

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
@@ -62,11 +62,6 @@ public class FlowPlugin : Plugin<Project> {
 
         project.afterEvaluate {
 
-            // add a new source-set folder for generated stuff, by default `vaadin-generated`
-            it.getSourceSet(config.sourceSetName.get()).resources.srcDirs(
-                config.resourceOutputDirectory
-            )
-
             // auto-activate tasks: https://github.com/vaadin/vaadin-gradle-plugin/issues/48
             if (config.productionMode.get()) {
                 // In production mode, vaadinBuildFrontend is self-contained
@@ -99,7 +94,21 @@ public class FlowPlugin : Plugin<Project> {
                         vaadinBuildFrontendOutputDirectory
                     )
                 }
-            } else if (config.alwaysExecutePrepareFrontend.get()) {
+            } else {
+                // Add a new source-set folder for generated stuff, by default
+                // `vaadin-generated`, so that the IDE picks it up and the
+                // application can be run in place, e.g. in IntelliJ with Tomcat.
+                // Development mode only: the flow-build-info.json that
+                // vaadinPrepareFrontend writes there always has
+                // productionMode=false, while in production vaadinBuildFrontend
+                // generates the whole META-INF/VAADIN tree into its own output
+                // directory. Copying the development token through
+                // processResources as well would add a second, conflicting
+                // META-INF/VAADIN/config/flow-build-info.json to the archive.
+                it.getSourceSet(config.sourceSetName.get()).resources.srcDirs(
+                    config.resourceOutputDirectory
+                )
+
                 // In development mode, vaadinPrepareFrontend is not
                 // auto-triggered by default. Since Vaadin 25, the dev
                 // server handles frontend preparation at runtime, so
@@ -109,8 +118,24 @@ public class FlowPlugin : Plugin<Project> {
                 // However, if alwaysExecutePrepareFrontend is set,
                 // restore the old behavior and chain the task to
                 // processResources.
-                project.tasks.getByPath(config.processResourcesTaskName.get()).dependsOn("vaadinPrepareFrontend")
+                if (config.alwaysExecutePrepareFrontend.get()) {
+                    project.tasks
+                        .getByPath(config.processResourcesTaskName.get())
+                        .dependsOn("vaadinPrepareFrontend")
+                }
             }
+
+            // vaadinPrepareFrontend is not part of the build by default, but
+            // when a project invokes it explicitly its outputs are consumed by
+            // these tasks: processResources reads the generated resources
+            // folder, and vaadinBuildFrontend reads package.json and the lock
+            // files. Declare the ordering - not a dependency, which would make
+            // the task execute on every build - so that Gradle does not report
+            // an implicit dependency validation problem.
+            project.tasks.getByPath(config.processResourcesTaskName.get())
+                .mustRunAfter("vaadinPrepareFrontend")
+            project.tasks.getByName("vaadinBuildFrontend")
+                .mustRunAfter("vaadinPrepareFrontend")
 
             val toolsService = project.gradle.sharedServices.registerIfAbsent(
                 "vaadinTools",


### PR DESCRIPTION
vaadinPrepareFrontend writes a development flow-build-info.json into resourceOutputDirectory, and the plugin registered that folder as a resources source folder unconditionally. Invoking the task explicitly then caused two failures:

- processResources consumed the folder without any ordering against the task producing it, so Gradle failed with an implicit dependency validation error.
- In a production build the development token was copied into build/resources/main while vaadinBuildFrontend wrote its own token into its task-owned output directory, so the archive ended up with two conflicting copies of META-INF/VAADIN/config/flow-build-info.json and the jar/war task failed. A folder left behind by an earlier development build was enough to trigger this, without the two tasks ever sharing a task graph.

Register resourceOutputDirectory as a resources source folder only in development mode - in production vaadinBuildFrontend generates the whole META-INF/VAADIN tree into its own output directory - and declare the ordering that processResources and vaadinBuildFrontend need relative to vaadinPrepareFrontend, without adding a dependency that would make the task execute on every build.

Fixes #25070