### PR TITLE
fix: make configuration init parameters unmodifiable

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -181,6 +181,12 @@ public interface DeploymentConfiguration
     /**
      * Gets the properties configured for the deployment, e.g. as init
      * parameters to the servlet.
+     * <p>
+     * The configuration is not meant to be changed after it has been created,
+     * so the returned properties should be treated as read-only. The
+     * implementations provided by Flow throw an
+     * {@link UnsupportedOperationException} if the returned properties are
+     * modified.
      *
      * @return properties for the application.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UnmodifiableProperties.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UnmodifiableProperties.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link Properties} instance which holds a snapshot of the properties given
+ * to the constructor and rejects all attempts to modify the contents
+ * afterwards.
+ * <p>
+ * Both the mutating methods and the mutating operations of the
+ * {@link #keySet()}, {@link #values()} and {@link #entrySet()} views throw an
+ * {@link UnsupportedOperationException}. Use
+ * {@code new Properties().putAll(properties)} to get a modifiable copy of the
+ * contents.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @author Vaadin Ltd
+ */
+public class UnmodifiableProperties extends Properties {
+
+    /**
+     * Creates a read-only copy of the given properties.
+     *
+     * @param properties
+     *            the properties to copy, not {@code null}
+     */
+    public UnmodifiableProperties(Properties properties) {
+        // The super implementation is used on purpose: the overridden put
+        // rejects modifications
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            super.put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public synchronized Object setProperty(String key, String value) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object put(Object key, Object value) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized void putAll(Map<?, ?> properties) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object putIfAbsent(Object key, Object value) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object remove(Object key) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized boolean remove(Object key, Object value) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized void clear() {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object replace(Object key, Object value) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized boolean replace(Object key, Object oldValue,
+            Object newValue) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized void replaceAll(
+            BiFunction<? super Object, ? super Object, ?> function) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object compute(Object key,
+            BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object computeIfAbsent(Object key,
+            Function<? super Object, ?> mappingFunction) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object computeIfPresent(Object key,
+            BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized Object merge(Object key, Object value,
+            BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized void load(Reader reader) throws IOException {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized void load(InputStream stream) throws IOException {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public synchronized void loadFromXML(InputStream stream)
+            throws IOException {
+        throw modificationNotSupported();
+    }
+
+    @Override
+    public Set<Object> keySet() {
+        return Collections.unmodifiableSet(super.keySet());
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return Collections.unmodifiableCollection(super.values());
+    }
+
+    @Override
+    public Set<Map.Entry<Object, Object>> entrySet() {
+        // The entries are copied into immutable ones so that the values cannot
+        // be changed through Entry::setValue either
+        return super.entrySet().stream()
+                .map(entry -> Map.entry(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private UnsupportedOperationException modificationNotSupported() {
+        return new UnsupportedOperationException(
+                "These properties are read-only and may not be changed!");
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UnmodifiableProperties;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.shared.communication.PushMode;
 
@@ -279,6 +280,14 @@ public class PropertyDeploymentConfiguration
         return PushMode.DISABLED;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The returned properties contain the properties of this configuration
+     * merged with the ones of the parent {@link ApplicationConfiguration}. They
+     * are read-only: every operation which would change the contents throws
+     * {@link UnsupportedOperationException}.
+     */
     @Override
     public Properties getInitParameters() {
         return allProperties;
@@ -340,7 +349,7 @@ public class PropertyDeploymentConfiguration
             result.put(property, config.getStringProperty(property, null));
         }
         result.putAll(properties);
-        return result;
+        return new UnmodifiableProperties(result);
     }
 
     private static Map<String, String> filterStringProperties(

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UnmodifiablePropertiesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UnmodifiablePropertiesTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UnmodifiablePropertiesTest {
+
+    @Test
+    void modifyingOperations_throwExceptionAndKeepValues() {
+        Properties properties = createProperties();
+
+        Map<String, Executable> modifyingOperations = new LinkedHashMap<>();
+        modifyingOperations.put("setProperty",
+                () -> properties.setProperty("foo", "baz"));
+        modifyingOperations.put("put", () -> properties.put("foo", "baz"));
+        modifyingOperations.put("putAll", () -> properties
+                .putAll(Collections.singletonMap("foo", "baz")));
+        modifyingOperations.put("putIfAbsent",
+                () -> properties.putIfAbsent("other", "baz"));
+        modifyingOperations.put("remove", () -> properties.remove("foo"));
+        modifyingOperations.put("clear", properties::clear);
+        modifyingOperations.put("replace",
+                () -> properties.replace("foo", "baz"));
+        modifyingOperations.put("replaceAll",
+                () -> properties.replaceAll((key, value) -> "baz"));
+        modifyingOperations.put("compute",
+                () -> properties.compute("foo", (key, value) -> "baz"));
+        modifyingOperations.put("merge",
+                () -> properties.merge("foo", "baz", (a, b) -> "baz"));
+        modifyingOperations.put("load",
+                () -> properties.load(new StringReader("foo=baz")));
+        modifyingOperations.put("keySet",
+                () -> properties.keySet().remove("foo"));
+        modifyingOperations.put("values",
+                () -> properties.values().remove("bar"));
+        modifyingOperations.put("entrySet",
+                () -> properties.entrySet().iterator().next().setValue("baz"));
+
+        modifyingOperations.forEach((name, operation) -> assertThrows(
+                UnsupportedOperationException.class, operation,
+                "'" + name + "' should not be able to modify the properties"));
+
+        assertEquals("bar", properties.getProperty("foo"));
+        assertEquals(1, properties.size());
+    }
+
+    @Test
+    void copyOfProperties_valuesAreReadableAndModifiable() {
+        Properties properties = createProperties();
+
+        Properties copy = new Properties();
+        copy.putAll(properties);
+        copy.setProperty("foo", "baz");
+
+        assertEquals("baz", copy.getProperty("foo"));
+        assertEquals("bar", properties.getProperty("foo"),
+                "The original properties should not be affected by changes made to a copy");
+    }
+
+    @Test
+    void changesToOriginalProperties_areNotVisible() {
+        Properties original = new Properties();
+        original.setProperty("foo", "bar");
+
+        Properties properties = new UnmodifiableProperties(original);
+        original.setProperty("foo", "baz");
+
+        assertEquals("bar", properties.getProperty("foo"));
+    }
+
+    private Properties createProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("foo", "bar");
+        return new UnmodifiableProperties(properties);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -595,26 +595,31 @@ class DeploymentConfigurationFactoryTest {
         FileUtils.writeLines(tokenFile, Arrays.asList("{",
                 "\"pnpm.enable\": true,", "\"require.home.node\": true", "}"));
 
-        DeploymentConfiguration config = createConfig(Collections
-                .singletonMap(PARAM_TOKEN_FILE, tokenFile.getPath()));
+        Map<String, String> servletConfigParams = new HashMap<>(
+                defaultServletParams);
+        servletConfigParams.put(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
+                Boolean.FALSE.toString());
+        servletConfigParams.put(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE,
+                Boolean.FALSE.toString());
 
-        config.getInitParameters().setProperty(
-                InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
-                Boolean.FALSE.toString());
-        config.getInitParameters().setProperty(
-                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE,
-                Boolean.FALSE.toString());
-        config.getInitParameters().setProperty(
-                InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
-                Boolean.FALSE.toString());
+        DeploymentConfiguration config = createConfig(servletConfigParams);
 
         assertEquals(Boolean.FALSE.toString(), config.getInitParameters()
                 .getProperty(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
         assertEquals(Boolean.FALSE.toString(), config.getInitParameters()
                 .getProperty(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE));
-        assertEquals(Boolean.FALSE.toString(),
-                config.getInitParameters().getProperty(
-                        InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
+    }
+
+    @Test
+    void createDeploymentConfiguration_initParametersAreNotModifiable()
+            throws Exception {
+        DeploymentConfiguration config = createConfig(Collections
+                .singletonMap(PARAM_TOKEN_FILE, tokenFile.getPath()));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> config.getInitParameters().setProperty(
+                        InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
+                        Boolean.FALSE.toString()));
     }
 
     private DeploymentConfiguration createConfig(Map<String, String> map)

--- a/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PropertyDeploymentConfigurationTest {
@@ -57,6 +58,23 @@ class PropertyDeploymentConfigurationTest {
                 properties);
         assertTrue(config.isProductionMode());
         assertEquals(properties, config.getInitParameters());
+    }
+
+    @Test
+    void changingInitialProperty_throwsException() {
+        ApplicationConfiguration appConfig = mockAppConfig();
+        Mockito.when(appConfig.isProductionMode()).thenReturn(false);
+
+        Properties properties = new Properties();
+        properties.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE,
+                Boolean.TRUE.toString());
+        PropertyDeploymentConfiguration config = createConfiguration(appConfig,
+                properties);
+        assertThrows(UnsupportedOperationException.class,
+                () -> config.getInitParameters().setProperty(
+                        InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE,
+                        Boolean.FALSE.toString()),
+                "Changing the initial property values of the configuration should not be possible.");
     }
 
     @Test


### PR DESCRIPTION
Configuration properties should
not accept changes after generation.

Now any tries to change property value
is met with an exception.

Closes #9299
