### PR TITLE
chore: clean up dead code

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringServlet.java
@@ -143,13 +143,6 @@ public class SpringServlet extends VaadinServlet {
         Properties properties = new Properties();
         properties.putAll(initParameters);
         PROPERTY_NAMES.forEach(property -> setProperty(property, properties));
-        // transfer non-string init parameters (such as
-        // DeploymentConfigurationFactory.FALLBACK_CHUNK)
-        initParameters.forEach((key, value) -> {
-            if (!(key instanceof String)) {
-                properties.put(key, value);
-            }
-        });
         return properties;
     }
 


### PR DESCRIPTION
Removed loop and stale comment.

DeploymentConfigurationFactory.FALLBACK_CHUNK
 was deleted in #16592.

Third-party non-String keys was a no-op
because putAll on line 144 already
copies them and setProperty only
writes String keys.
