### PR TITLE
feat: Unify deletion and add message

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 
 import com.vaadin.flow.internal.BundleUtils;
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.internal.UrlUtil;
@@ -225,7 +226,7 @@ abstract class AbstractUpdateImports implements Runnable {
             if (chunkFolder.exists() && chunkFolder.isDirectory()) {
                 for (File existingChunk : chunkFolder.listFiles()) {
                     if (!outputFiles.containsKey(existingChunk)) {
-                        existingChunk.delete();
+                        FileIOUtils.deleteQuietly(existingChunk);
                     }
                 }
             }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -1005,7 +1005,7 @@ public final class BundleValidationUtil {
                     "Failed to read re-bundle checker result from file", e);
             return true;
         } finally {
-            FileIOUtils.deleteFileQuietly(needsBuildFile);
+            FileIOUtils.deleteQuietly(needsBuildFile);
         }
     }
 

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.internal.FrontendUtils.UnknownVersionException;
@@ -782,7 +783,8 @@ public class FrontendTools {
 
         if (removePnpmLock) {
             // remove pnpm-lock.yaml which contains pnpm as a dependency.
-            if (new File(baseDir, "pnpm-lock.yaml").delete()) {
+            File pnpmLock = new File(baseDir, "pnpm-lock.yaml");
+            if (pnpmLock.exists() && FileIOUtils.deleteQuietly(pnpmLock)) {
                 getLogger().debug(
                         "pnpm-lock.yaml file is removed from " + baseDir);
             }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -410,7 +410,7 @@ public class NodeTasks implements FallibleCommand {
                     Thread.sleep(500);
                 } else {
                     // The process has died without removing the lock file
-                    lockFile.toFile().delete();
+                    FileIOUtils.deleteQuietly(lockFile);
                 }
             } catch (InterruptedException e) {
                 // Restore interrupted state
@@ -451,7 +451,7 @@ public class NodeTasks implements FallibleCommand {
                         pid, lockFile.toFile().getAbsolutePath());
                 return;
             }
-            lockFile.toFile().delete();
+            FileIOUtils.deleteQuietly(lockFile);
         } catch (Exception e) {
             getLogger().error("Error releasing lock file ({})",
                     lockFile.toFile().getAbsolutePath());

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/PnpmWorkspaceFile.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/PnpmWorkspaceFile.java
@@ -26,6 +26,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.JacksonUtils;
 
 /**
@@ -100,7 +101,7 @@ class PnpmWorkspaceFile {
     boolean save() throws IOException {
         if (document.isEmpty()) {
             if (file.isFile()) {
-                Files.delete(file.toPath());
+                FileIOUtils.delete(file);
                 return true;
             }
             return false;

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/ProdBundleUtils.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/ProdBundleUtils.java
@@ -110,7 +110,7 @@ public class ProdBundleUtils {
         File bundleFile = new File(projectDir,
                 Constants.PROD_BUNDLE_COMPRESSED_FILE_LOCATION);
         if (bundleFile.exists()) {
-            bundleFile.delete();
+            FileIOUtils.deleteQuietly(bundleFile);
         } else {
             bundleFile.getParentFile().mkdirs();
         }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
@@ -101,7 +101,7 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
             try {
                 FileIOUtils.delete(file);
             } catch (IOException ioe) {
-                log().warn("{}", ioe.getMessage());
+                log().warn(ioe.getMessage());
                 log().debug("Failed to remove file", ioe);
             }
         }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.server.Constants;
 
@@ -83,9 +84,8 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
         }
         // If hilla is not used clean generated hilla files.
         if (!hillaUsed) {
-            hillaGenerated.forEach(
-                    file -> new File(options.getFrontendGeneratedFolder(), file)
-                            .delete());
+            hillaGenerated.forEach(file -> FileIOUtils.deleteQuietly(
+                    new File(options.getFrontendGeneratedFolder(), file)));
         }
     }
 
@@ -99,14 +99,9 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
         for (File file : filesToRemove) {
             log().debug("Removing file {}", file);
             try {
-                if (file.isDirectory()) {
-                    FrontendUtils.deleteDirectory(file);
-                } else {
-                    file.delete();
-                }
+                FileIOUtils.delete(file);
             } catch (IOException ioe) {
-                log().warn("Could not delete file {} due to {}", file,
-                        ioe.getMessage());
+                log().warn("{}", ioe.getMessage());
                 log().debug("Failed to remove file", ioe);
             }
         }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCompressStaticResources.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCompressStaticResources.java
@@ -36,6 +36,7 @@ import java.util.zip.GZIPOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 
 /**
@@ -178,7 +179,7 @@ public class TaskCompressStaticResources implements FallibleCommand {
                             + "be served uncompressed",
                     e);
         } finally {
-            script.delete();
+            FileIOUtils.deleteQuietly(script);
         }
     }
 
@@ -212,13 +213,13 @@ public class TaskCompressStaticResources implements FallibleCommand {
         }
 
         // Always delete br file if exists as we only remake the gzip
-        Files.deleteIfExists(file.resolveSibling(file.getFileName() + ".br"));
+        FileIOUtils.delete(file.resolveSibling(file.getFileName() + ".br"));
         Path gz = file.resolveSibling(file.getFileName() + ".gz");
         if (size < MIN_SIZE_BYTES) {
             // Remove any variants left by an earlier build where this file was
             // still above the threshold, so no stale compressed variant is
             // served now that it is served uncompressed.
-            Files.deleteIfExists(gz);
+            FileIOUtils.delete(gz);
             return;
         }
         try (InputStream in = Files.newInputStream(file);

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
@@ -127,8 +128,8 @@ public class TaskCopyFrontendFiles
             }
         }
         existingFiles.removeAll(handledFiles);
-        existingFiles.forEach(
-                filename -> new File(targetDirectory, filename).delete());
+        existingFiles.forEach(filename -> FileIOUtils
+                .deleteQuietly(new File(targetDirectory, filename)));
         long ms = (System.nanoTime() - start) / 1000000;
         log().info("Visited {} resources. Took {} ms.",
                 resourceLocations.size(), ms);

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateIndexTs.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateIndexTs.java
@@ -120,7 +120,7 @@ public class TaskGenerateIndexTs extends AbstractTaskClientGenerator {
     }
 
     private void cleanup() {
-        FileIOUtils.deleteFileQuietly(getGeneratedFile());
+        FileIOUtils.deleteQuietly(getGeneratedFile());
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -268,17 +268,17 @@ public class TaskGenerateReactFiles
             File frontendGeneratedFolderRoutesTsx = new File(
                     frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
             File layoutsJson = new File(frontendGeneratedFolder, LAYOUTS_JSON);
-            FileIOUtils.deleteFileQuietly(flowTsx);
-            FileIOUtils.deleteFileQuietly(
+            FileIOUtils.deleteQuietly(flowTsx);
+            FileIOUtils.deleteQuietly(
                     new File(frontendGeneratedFolder, JSX_TRANSFORM_INDEX));
-            FileIOUtils.deleteFileQuietly(new File(frontendGeneratedFolder,
+            FileIOUtils.deleteQuietly(new File(frontendGeneratedFolder,
                     JSX_TRANSFORM_DEV_RUNTIME));
-            FileIOUtils.deleteFileQuietly(
+            FileIOUtils.deleteQuietly(
                     new File(frontendGeneratedFolder, JSX_TRANSFORM_RUNTIME));
-            FileIOUtils.deleteFileQuietly(layoutsJson);
-            FileIOUtils.deleteFileQuietly(vaadinReactTsx);
-            FileIOUtils.deleteFileQuietly(reactAdapterTsx);
-            FileIOUtils.deleteFileQuietly(frontendGeneratedFolderRoutesTsx);
+            FileIOUtils.deleteQuietly(layoutsJson);
+            FileIOUtils.deleteQuietly(vaadinReactTsx);
+            FileIOUtils.deleteQuietly(reactAdapterTsx);
+            FileIOUtils.deleteQuietly(frontendGeneratedFolderRoutesTsx);
 
             File routesTsx = new File(frontendDirectory,
                     FrontendUtils.ROUTES_TSX);
@@ -289,7 +289,7 @@ public class TaskGenerateReactFiles
                         defaultRoutesContent,
                         getFileContent(FrontendUtils.ROUTES_TSX),
                         String::equals)) {
-                    routesTsx.delete();
+                    FileIOUtils.deleteQuietly(routesTsx);
                     log().debug("Default {} file has been removed.",
                             FrontendUtils.ROUTES_TSX);
                 } else {
@@ -298,7 +298,7 @@ public class TaskGenerateReactFiles
                                     FrontendUtils.ROUTES_TSX + ".flowBackup")
                                     .toPath(),
                             StandardCopyOption.REPLACE_EXISTING);
-                    routesTsx.delete();
+                    FileIOUtils.deleteQuietly(routesTsx);
                     log().warn(
                             "Custom {} file has been removed. Backup is created in {}.flowBackup file.",
                             FrontendUtils.ROUTES_TSX, FrontendUtils.ROUTES_TSX);

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -878,7 +878,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             // This feels like cleanup done in the wrong place but is left here
             // for historical reasons
             for (File file : jarResourcesFolder.listFiles()) {
-                file.delete();
+                FileIOUtils.deleteQuietly(file);
             }
         }
     }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 
 import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.ThemeUtils;
 import com.vaadin.flow.theme.ThemeDefinition;
@@ -81,8 +82,8 @@ public class TaskUpdateThemeImport
     public void execute() throws ExecutionFailedException {
         if (theme == null || theme.getName().isEmpty()) {
             if (themeImportFile.exists()) {
-                themeImportFile.delete();
-                themeImportFileDefinition.delete();
+                FileIOUtils.deleteQuietly(themeImportFile);
+                FileIOUtils.deleteQuietly(themeImportFileDefinition);
             }
 
             try {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -417,10 +417,11 @@ public class NodeInstaller {
     }
 
     private static void removeArchiveFile(File archive) {
-        if (!archive.delete()) {
-            getLogger().error("Failed to remove archive file {}. "
-                    + "Please remove it manually and run the application.",
-                    archive.getPath());
+        try {
+            FileIOUtils.delete(archive);
+        } catch (IOException e) {
+            getLogger().error("{} The archive file has to be removed before "
+                    + "the application can be run.", e.getMessage(), e);
         }
     }
 
@@ -515,7 +516,7 @@ public class NodeInstaller {
                             .trim())
                     .findFirst().orElse("-1");
 
-            shaSums.delete();
+            FileIOUtils.deleteQuietly(shaSums);
 
             if (!archiveSHA256.equals(archiveTargetSHA256)) {
                 getLogger().error(

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -350,17 +350,6 @@ class FrontendUtilsTest {
     }
 
     @Test
-    void deleteDirectory_onlyRemovesDirectories() throws IOException {
-        File file = new File(tmpDir, "file.txt");
-        assertTrue(file.createNewFile());
-
-        FrontendUtils.deleteDirectory(file);
-        FrontendUtils.deleteDirectory(new File(tmpDir, "missing"));
-
-        assertTrue(file.exists(), "A plain file should not be removed");
-    }
-
-    @Test
     void deleteNodeModules_throwsIfNotNamedNodeModules() throws IOException {
         File myModules = new File(tmpDir, "my_modules");
         myModules.mkdirs();

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -350,6 +350,17 @@ class FrontendUtilsTest {
     }
 
     @Test
+    void deleteDirectory_onlyRemovesDirectories() throws IOException {
+        File file = new File(tmpDir, "file.txt");
+        assertTrue(file.createNewFile());
+
+        FrontendUtils.deleteDirectory(file);
+        FrontendUtils.deleteDirectory(new File(tmpDir, "missing"));
+
+        assertTrue(file.exists(), "A plain file should not be removed");
+    }
+
+    @Test
     void deleteNodeModules_throwsIfNotNamedNodeModules() throws IOException {
         File myModules = new File(tmpDir, "my_modules");
         myModules.mkdirs();

--- a/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/FrontendConverter.java
+++ b/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/FrontendConverter.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.server.frontend.FrontendTools;
@@ -59,8 +60,8 @@ public class FrontendConverter implements AutoCloseable {
     @Override
     public void close() throws IOException {
         // cleanup by deleting all temp files
-        Files.deleteIfExists(converterTempPath);
-        Files.deleteIfExists(tempDirPath);
+        FileIOUtils.delete(converterTempPath);
+        FileIOUtils.delete(tempDirPath);
     }
 
     public boolean convertFile(Path filePath, boolean useLit1,

--- a/flow-polymer2lit/src/test/java/com/vaadin/flow/polymer2lit/FrontendConverterCloseTest.java
+++ b/flow-polymer2lit/src/test/java/com/vaadin/flow/polymer2lit/FrontendConverterCloseTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.polymer2lit;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.FrontendToolsSettings;
+
+/**
+ * Tests the temporary file handling of {@link FrontendConverter}. The
+ * conversion itself is covered by {@link FrontendConverterTest}, which needs a
+ * Node installation and is therefore tagged as a slow test.
+ */
+class FrontendConverterCloseTest {
+
+    @TempDir
+    File tmpDir;
+
+    @Test
+    void close_removesTempFilesAndIsRepeatable() throws IOException {
+        FrontendToolsSettings settings = new FrontendToolsSettings(
+                tmpDir.getAbsolutePath(), tmpDir::getAbsolutePath);
+        FrontendConverter converter = new FrontendConverter(
+                new FrontendTools(settings));
+
+        // The extracted converter script has to be removed before the temporary
+        // directory holding it, otherwise deleting a non-empty directory would
+        // fail here
+        converter.close();
+
+        // Nothing is left to delete, which has to be a no-op instead of a
+        // failure
+        converter.close();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevBundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevBundleUtils.java
@@ -119,7 +119,7 @@ public class DevBundleUtils {
         File bundleFile = new File(projectDir,
                 Constants.DEV_BUNDLE_COMPRESSED_FILE_LOCATION);
         if (bundleFile.exists()) {
-            bundleFile.delete();
+            FileIOUtils.deleteQuietly(bundleFile);
         } else {
             bundleFile.getParentFile().mkdirs();
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
@@ -25,6 +25,8 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
@@ -56,21 +58,38 @@ public class FileIOUtils {
     }
 
     /**
-     * Deletes file if it exists and eats exceptions.
+     * Deletes a file, or a directory and its contents, logging a warning that
+     * explains how to unblock the deletion if it fails.
      *
      * Note, this is an internal helper method, use only from framework code.
-     * 
+     *
      * @param file
-     *            to be deleted
-     * @return true if succeeded
+     *            the file or directory to delete, may be {@code null}
+     * @return {@code true} if the file was deleted or did not exist
      */
-    public static boolean deleteFileQuietly(File file) {
-        if (file == null) {
+    public static boolean deleteQuietly(File file) {
+        return file != null && deleteQuietly(file.toPath());
+    }
+
+    /**
+     * Deletes a file, or a directory and its contents, logging a warning that
+     * explains how to unblock the deletion if it fails.
+     *
+     * Note, this is an internal helper method, use only from framework code.
+     *
+     * @param path
+     *            the file or directory to delete, may be {@code null}
+     * @return {@code true} if the file was deleted or did not exist
+     */
+    public static boolean deleteQuietly(Path path) {
+        if (path == null) {
             return false;
         }
         try {
-            return file.delete();
-        } catch (final Exception ignored) {
+            delete(path);
+            return true;
+        } catch (IOException | RuntimeException e) {
+            log().warn("{}", e.getMessage(), e);
             return false;
         }
     }
@@ -150,38 +169,129 @@ public class FileIOUtils {
     }
 
     /**
-     * Deletes a file or directory recursively. Throws an exception if the
-     * deletion fails.
+     * Deletes a file, or a directory and its contents, recursively. Does
+     * nothing if the file does not exist.
+     * <p>
+     * Symbolic links and Windows junctions are removed as links, the contents
+     * they point to are left untouched.
      *
      * @param file
      *            the file or directory to delete
      * @throws IOException
-     *             if an I/O error occurs
+     *             if the file or any of its contents could not be deleted, with
+     *             a message describing how the deletion can be unblocked
      */
     public static void delete(File file) throws IOException {
-        if (!file.exists()) {
+        delete(file.toPath());
+    }
+
+    /**
+     * Deletes a file, or a directory and its contents, recursively. Does
+     * nothing if the file does not exist.
+     * <p>
+     * Symbolic links and Windows junctions are removed as links, the contents
+     * they point to are left untouched.
+     *
+     * @param path
+     *            the file or directory to delete
+     * @throws IOException
+     *             if the file or any of its contents could not be deleted, with
+     *             a message describing how the deletion can be unblocked
+     */
+    public static void delete(Path path) throws IOException {
+        BasicFileAttributes attributes;
+        try {
+            attributes = Files.readAttributes(path, BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+        } catch (NoSuchFileException e) {
+            return;
+        } catch (IOException e) {
+            throw deletionFailed(path, e);
+        }
+
+        if (!hasDeletableContents(attributes)) {
+            deleteSingle(path);
             return;
         }
-        Path path = file.toPath();
-        if (Files.isDirectory(path)) {
-            Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
-                @Override
-                public FileVisitResult visitFile(Path file,
-                        BasicFileAttributes attrs) throws IOException {
-                    Files.delete(file);
-                    return FileVisitResult.CONTINUE;
-                }
 
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir,
-                        IOException exc) throws IOException {
-                    Files.delete(dir);
+        Files.walkFileTree(path, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir,
+                    BasicFileAttributes attrs) throws IOException {
+                if (hasDeletableContents(attrs)) {
                     return FileVisitResult.CONTINUE;
                 }
-            });
-        } else {
-            Files.delete(path);
+                // A junction looks like a directory but must be removed as a
+                // link so that the linked contents are not deleted
+                deleteSingle(dir);
+                return FileVisitResult.SKIP_SUBTREE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file,
+                    BasicFileAttributes attrs) throws IOException {
+                deleteSingle(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc)
+                    throws IOException {
+                throw deletionFailed(file, exc);
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                    throws IOException {
+                // A failure to list the contents surfaces as a failure to
+                // delete the then non-empty directory
+                deleteSingle(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    /**
+     * Checks whether the given attributes describe a directory that can be
+     * traversed to delete its contents.
+     * <p>
+     * A symbolic link to a directory is not reported as a directory as the
+     * attributes are read without following links. A Windows junction is
+     * reported as a directory but also as {@code other}, which no real
+     * directory is.
+     */
+    private static boolean hasDeletableContents(
+            BasicFileAttributes attributes) {
+        return attributes.isDirectory() && !attributes.isOther();
+    }
+
+    private static void deleteSingle(Path path) throws IOException {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            throw deletionFailed(path, e);
         }
+    }
+
+    /**
+     * Wraps a deletion failure into an exception that suggests how to unblock
+     * the deletion, as the reported cause is usually another process holding
+     * the file open rather than the actual root cause.
+     */
+    private static IOException deletionFailed(Path path, IOException cause) {
+        String advice = FrontendUtils.isWindows() ? """
+                On Windows this usually means that another process, such as a \
+                running development server, an editor or a virus scanner, is \
+                keeping the file open. Find the process holding it with \
+                'openfiles /query' or with Sysinternals \
+                'handle64 <path>', stop it with 'taskkill /PID <pid> /F' and \
+                then run the build again.""" : """
+                Check that no other process is using the file, for example \
+                with 'lsof <path>', and that you have permission to delete \
+                it, and then run the build again.""";
+        return new IOException("Failed to delete " + path + ". "
+                + advice.replace("<path>", path.toAbsolutePath().toString()),
+                cause);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
@@ -69,7 +69,7 @@ public class FileIOUtils {
      *             directory contents and logs why a deletion failed instead of
      *             failing silently
      */
-    @Deprecated
+    @Deprecated(since = "25.3", forRemoval = true)
     public static boolean deleteFileQuietly(File file) {
         return deleteQuietly(file);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
@@ -58,6 +58,23 @@ public class FileIOUtils {
     }
 
     /**
+     * Deletes file if it exists and eats exceptions.
+     *
+     * Note, this is an internal helper method, use only from framework code.
+     *
+     * @param file
+     *            to be deleted
+     * @return true if succeeded
+     * @deprecated use {@link #deleteQuietly(File)} instead, which also deletes
+     *             directory contents and logs why a deletion failed instead of
+     *             failing silently
+     */
+    @Deprecated
+    public static boolean deleteFileQuietly(File file) {
+        return deleteQuietly(file);
+    }
+
+    /**
      * Deletes a file, or a directory and its contents, logging a warning that
      * explains how to unblock the deletion if it fails.
      *
@@ -89,7 +106,7 @@ public class FileIOUtils {
             delete(path);
             return true;
         } catch (IOException | RuntimeException e) {
-            log().warn("{}", e.getMessage(), e);
+            log().warn(e.getMessage(), e);
             return false;
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/FrontendUtils.java
@@ -19,15 +19,12 @@ import jakarta.servlet.ServletContext;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -1187,83 +1184,11 @@ public class FrontendUtils {
      *             on failure to delete or read any one file
      */
     public static void deleteDirectory(File directory) throws IOException {
-        if (!directory.exists() || !directory.isDirectory()) {
+        if (!directory.isDirectory()) {
             return;
         }
 
-        if (!(Files.isSymbolicLink(directory.toPath())
-                || isJunction(directory.toPath()))) {
-            cleanDirectory(directory);
-        }
-
-        if (!directory.delete()) {
-            String message = "Unable to delete directory " + directory + ".";
-            throw new IOException(message);
-        }
-    }
-
-    /**
-     * Check that directory is not a windows junction which is basically a
-     * symlink.
-     *
-     * @param directory
-     *            directory path to check
-     * @return true if directory is a windows junction
-     * @throws IOException
-     *             if an I/O error occurs
-     */
-    private static boolean isJunction(Path directory) throws IOException {
-        boolean isWindows = System.getProperty("os.name").toLowerCase()
-                .contains("windows");
-        BasicFileAttributes attrs = Files.readAttributes(directory,
-                BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-        return isWindows && attrs.isDirectory() && attrs.isOther();
-    }
-
-    private static void cleanDirectory(File directory) throws IOException {
-        if (!directory.exists()) {
-            String message = directory + " does not exist";
-            throw new IllegalArgumentException(message);
-        }
-
-        if (!directory.isDirectory()) {
-            String message = directory + " is not a directory";
-            throw new IllegalArgumentException(message);
-        }
-
-        File[] files = directory.listFiles();
-        if (files == null) { // null if security restricted
-            throw new IOException("Failed to list contents of " + directory);
-        }
-
-        IOException exception = null;
-        for (File file : files) {
-            try {
-                forceDelete(file);
-            } catch (IOException ioe) {
-                exception = ioe;
-            }
-        }
-
-        if (exception != null) {
-            throw exception;
-        }
-    }
-
-    private static void forceDelete(File file) throws IOException {
-        if (file.isDirectory()) {
-            deleteDirectory(file);
-        } else {
-            boolean filePresent = file.exists();
-            if (!file.delete()) {
-                if (!filePresent) {
-                    throw new FileNotFoundException(
-                            "File does not exist: " + file);
-                }
-                String message = "Unable to delete file: " + file;
-                throw new IOException(message);
-            }
-        }
+        FileIOUtils.delete(directory);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
@@ -20,10 +20,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.server.communication.TransferUtil;
 
 /**
@@ -134,7 +134,7 @@ public abstract class AbstractFileUploadHandler<R extends AbstractFileUploadHand
             return;
         }
         try {
-            Files.delete(file.toPath());
+            FileIOUtils.delete(file);
         } catch (IOException e) {
             LoggerFactory.getLogger(AbstractFileUploadHandler.class)
                     .warn("Could not delete the file of a rejected or failed "

--- a/flow-server/src/test/java/com/vaadin/flow/internal/DevBundleUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/DevBundleUtilsTest.java
@@ -73,4 +73,30 @@ class DevBundleUtilsTest {
         assertEquals(packagesHash,
                 StringUtil.getHash(Files.readString(packages.toPath())));
     }
+
+    @Test
+    void compressBundle_existingBundleIsReplaced() throws IOException {
+        File projectBase = temporaryFolder.toFile();
+        File devFolder = new File(projectBase, "target/dev-bundle");
+        assertTrue(devFolder.mkdirs());
+        File packages = new File(devFolder, "package.json");
+        Files.writeString(packages.toPath(), "{ \"packages\": [\"first\"] }");
+
+        DevBundleUtils.compressBundle(projectBase, devFolder);
+
+        assertTrue(
+                new File(projectBase, "src/main/bundles/dev.bundle").exists(),
+                "Compressed bundle should have been created");
+
+        // Compressing again has to replace the existing bundle instead of
+        // leaving the previous content in place
+        Files.writeString(packages.toPath(), "{ \"packages\": [\"second\"] }");
+        DevBundleUtils.compressBundle(projectBase, devFolder);
+
+        FileIOUtils.delete(devFolder);
+        DevBundleUtils.unpackBundle(projectBase, devFolder);
+
+        assertEquals("{ \"packages\": [\"second\"] }",
+                Files.readString(packages.toPath()));
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
@@ -16,7 +16,9 @@
 package com.vaadin.flow.internal;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +33,7 @@ import com.vaadin.open.OSUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -132,5 +135,90 @@ class FileIOUtilsTest {
         try (var entries = Files.list(dir.toPath())) {
             assertEquals(1, entries.count());
         }
+    }
+
+    @Test
+    void delete_removesDirectoryContentsRecursively(@TempDir File dir)
+            throws Exception {
+        File nested = new File(dir, "a/b");
+        assertTrue(nested.mkdirs());
+        assertTrue(new File(nested, "file.txt").createNewFile());
+
+        FileIOUtils.delete(new File(dir, "a"));
+
+        assertFalse(new File(dir, "a").exists());
+    }
+
+    @Test
+    void delete_nonExistingFileIsNoOp(@TempDir File dir) throws Exception {
+        FileIOUtils.delete(new File(dir, "missing.txt"));
+    }
+
+    @Test
+    void delete_symlinkedContentsAreLeftUntouched(@TempDir File dir)
+            throws Exception {
+        assumeFalse(FrontendUtils.isWindows());
+
+        File external = new File(dir, "external");
+        assertTrue(external.mkdirs());
+        File externalFile = new File(external, "keep.txt");
+        assertTrue(externalFile.createNewFile());
+
+        File toDelete = new File(dir, "toDelete");
+        assertTrue(toDelete.mkdirs());
+        Files.createSymbolicLink(new File(toDelete, "link").toPath(),
+                external.toPath());
+
+        FileIOUtils.delete(toDelete);
+
+        assertFalse(toDelete.exists());
+        assertTrue(externalFile.exists(),
+                "Contents of the symlinked directory should be kept");
+    }
+
+    @Test
+    void delete_failureExplainsHowToUnblockDeletion(@TempDir File dir)
+            throws Exception {
+        File file = new File(dir, "locked.txt");
+
+        // Simulate a file that cannot be removed, which on Windows typically
+        // means that another process is keeping it open
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.deleteIfExists(file.toPath())).thenThrow(
+                    new AccessDeniedException(file.getAbsolutePath()));
+            // Registering the stub above invoked the real method, so the file
+            // has to be created after it
+            assertTrue(file.createNewFile());
+
+            IOException exception = assertThrows(IOException.class,
+                    () -> FileIOUtils.delete(file));
+
+            assertTrue(exception.getMessage()
+                    .startsWith("Failed to delete " + file.toPath()));
+            assertTrue(
+                    exception.getMessage().contains(
+                            FrontendUtils.isWindows() ? "taskkill" : "lsof"),
+                    "The message should tell how to find and stop the process "
+                            + "holding the file: " + exception.getMessage());
+        }
+    }
+
+    @Test
+    void deleteQuietly_reportsFailureWithoutThrowing(@TempDir File dir)
+            throws Exception {
+        File file = new File(dir, "locked.txt");
+
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.deleteIfExists(file.toPath())).thenThrow(
+                    new AccessDeniedException(file.getAbsolutePath()));
+            assertTrue(file.createNewFile());
+
+            assertFalse(FileIOUtils.deleteQuietly(file));
+        }
+
+        assertTrue(FileIOUtils.deleteQuietly(file));
+        assertFalse(file.exists());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
@@ -269,6 +269,44 @@ class FileIOUtilsTest {
     }
 
     @Test
+    void delete_junctionInsideDirectoryIsRemovedAsLink(@TempDir File dir)
+            throws Exception {
+        assumeFalse(FrontendUtils.isWindows());
+
+        File external = new File(dir, "external");
+        assertTrue(external.mkdirs());
+        File externalFile = new File(external, "keep.txt");
+        assertTrue(externalFile.createNewFile());
+
+        File directory = new File(dir, "bundle");
+        assertTrue(directory.mkdirs());
+        Path junction = new File(directory, "junction").toPath();
+        Files.createSymbolicLink(junction, external.toPath());
+
+        // A junction encountered while walking the tree is reported as a
+        // directory that is also "other", see
+        // delete_junctionIsRemovedAsLink. Traversing into it would delete the
+        // linked contents instead of the link.
+        BasicFileAttributes junctionAttributes = Mockito
+                .mock(BasicFileAttributes.class);
+        Mockito.when(junctionAttributes.isDirectory()).thenReturn(true);
+        Mockito.when(junctionAttributes.isOther()).thenReturn(true);
+
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.readAttributes(junction,
+                    BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS))
+                    .thenReturn(junctionAttributes);
+
+            FileIOUtils.delete(directory);
+        }
+
+        assertFalse(directory.exists());
+        assertTrue(externalFile.exists(),
+                "Contents behind a junction should be kept");
+    }
+
+    @Test
     void delete_failureInsideDirectoryNamesTheBlockingFile(@TempDir File dir)
             throws Exception {
         File directory = new File(dir, "bundle");
@@ -304,23 +342,89 @@ class FileIOUtilsTest {
         // Simulate a file that cannot be removed, which on Windows typically
         // means that another process is keeping it open
         try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
-                Mockito.CALLS_REAL_METHODS)) {
+                Mockito.CALLS_REAL_METHODS);
+                MockedStatic<FrontendUtils> platform = Mockito.mockStatic(
+                        FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
             files.when(() -> Files.deleteIfExists(file.toPath())).thenThrow(
                     new AccessDeniedException(file.getAbsolutePath()));
             // Registering the stub above invoked the real method, so the file
             // has to be created after it
             assertTrue(file.createNewFile());
 
+            platform.when(FrontendUtils::isWindows).thenReturn(true);
+            IOException windows = assertThrows(IOException.class,
+                    () -> FileIOUtils.delete(file));
+
+            assertTrue(windows.getMessage()
+                    .startsWith("Failed to delete " + file.toPath()));
+            assertTrue(windows.getMessage().contains("taskkill"),
+                    "The message should tell how to stop the process holding "
+                            + "the file: " + windows.getMessage());
+            assertTrue(windows.getMessage().contains(file.getAbsolutePath()),
+                    "The path placeholder should be replaced with the actual "
+                            + "path: " + windows.getMessage());
+
+            platform.when(FrontendUtils::isWindows).thenReturn(false);
+            IOException other = assertThrows(IOException.class,
+                    () -> FileIOUtils.delete(file));
+
+            assertTrue(other.getMessage().contains("lsof"),
+                    "The message should tell how to find the process using the "
+                            + "file: " + other.getMessage());
+        }
+    }
+
+    @Test
+    void delete_unreadableEntryReportsFailure(@TempDir File dir)
+            throws Exception {
+        File directory = new File(dir, "bundle");
+        assertTrue(directory.mkdirs());
+        File unreadable = new File(directory, "unreadable.txt");
+        assertTrue(unreadable.createNewFile());
+        AccessDeniedException cause = new AccessDeniedException(
+                unreadable.getAbsolutePath());
+
+        // An entry whose attributes cannot be read has to be reported the same
+        // way as one that cannot be deleted
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.readAttributes(unreadable.toPath(),
+                    BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS))
+                    .thenThrow(cause);
+
+            IOException exception = assertThrows(IOException.class,
+                    () -> FileIOUtils.delete(directory));
+
+            assertTrue(
+                    exception.getMessage().startsWith(
+                            "Failed to delete " + unreadable.toPath()),
+                    exception.getMessage());
+            assertEquals(cause, exception.getCause());
+        }
+    }
+
+    @Test
+    void delete_unreadableTargetReportsFailure(@TempDir File dir)
+            throws Exception {
+        File file = new File(dir, "unreadable.txt");
+        assertTrue(file.createNewFile());
+        AccessDeniedException cause = new AccessDeniedException(
+                file.getAbsolutePath());
+
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.readAttributes(file.toPath(),
+                    BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS))
+                    .thenThrow(cause);
+
             IOException exception = assertThrows(IOException.class,
                     () -> FileIOUtils.delete(file));
 
-            assertTrue(exception.getMessage()
-                    .startsWith("Failed to delete " + file.toPath()));
             assertTrue(
-                    exception.getMessage().contains(
-                            FrontendUtils.isWindows() ? "taskkill" : "lsof"),
-                    "The message should tell how to find and stop the process "
-                            + "holding the file: " + exception.getMessage());
+                    exception.getMessage()
+                            .startsWith("Failed to delete " + file.toPath()),
+                    exception.getMessage());
+            assertEquals(cause, exception.getCause());
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
@@ -361,6 +361,19 @@ class FileIOUtilsTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
+    void deleteFileQuietly_delegatesToDeleteQuietly(@TempDir File dir)
+            throws Exception {
+        File file = new File(dir, "file.txt");
+        assertTrue(file.createNewFile());
+
+        assertTrue(FileIOUtils.deleteFileQuietly(file));
+
+        assertFalse(file.exists());
+        assertFalse(FileIOUtils.deleteFileQuietly(null));
+    }
+
+    @Test
     void deleteQuietly_missingFileSucceedsAndNullFails(@TempDir File dir) {
         assertTrue(FileIOUtils.deleteQuietly(new File(dir, "missing.txt")));
         assertTrue(FileIOUtils

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
@@ -21,8 +21,10 @@ import java.net.URL;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -150,8 +152,36 @@ class FileIOUtilsTest {
     }
 
     @Test
+    void delete_removesPlainFileAndEmptyDirectory(@TempDir File dir)
+            throws Exception {
+        File file = new File(dir, "file.txt");
+        assertTrue(file.createNewFile());
+        File empty = new File(dir, "empty");
+        assertTrue(empty.mkdirs());
+
+        FileIOUtils.delete(file);
+        FileIOUtils.delete(empty);
+
+        assertFalse(file.exists());
+        assertFalse(empty.exists());
+    }
+
+    @Test
+    void delete_pathOverloadRemovesDirectoryContentsRecursively(
+            @TempDir File dir) throws Exception {
+        File nested = new File(dir, "a/b");
+        assertTrue(nested.mkdirs());
+        assertTrue(new File(nested, "file.txt").createNewFile());
+
+        FileIOUtils.delete(new File(dir, "a").toPath());
+
+        assertFalse(new File(dir, "a").exists());
+    }
+
+    @Test
     void delete_nonExistingFileIsNoOp(@TempDir File dir) throws Exception {
         FileIOUtils.delete(new File(dir, "missing.txt"));
+        FileIOUtils.delete(new File(dir, "missing/nested.txt"));
     }
 
     @Test
@@ -174,6 +204,96 @@ class FileIOUtilsTest {
         assertFalse(toDelete.exists());
         assertTrue(externalFile.exists(),
                 "Contents of the symlinked directory should be kept");
+    }
+
+    @Test
+    void delete_symlinkAsTargetIsRemovedAsLink(@TempDir File dir)
+            throws Exception {
+        assumeFalse(FrontendUtils.isWindows());
+
+        File external = new File(dir, "external");
+        assertTrue(external.mkdirs());
+        File externalFile = new File(external, "keep.txt");
+        assertTrue(externalFile.createNewFile());
+
+        Path link = new File(dir, "link").toPath();
+        Files.createSymbolicLink(link, external.toPath());
+
+        FileIOUtils.delete(link);
+
+        assertFalse(Files.exists(link, LinkOption.NOFOLLOW_LINKS));
+        assertTrue(externalFile.exists(),
+                "Contents of the symlinked directory should be kept");
+    }
+
+    @Test
+    void delete_junctionIsRemovedAsLink(@TempDir File dir) throws Exception {
+        assumeFalse(FrontendUtils.isWindows());
+
+        File external = new File(dir, "external");
+        assertTrue(external.mkdirs());
+        File externalFile = new File(external, "keep.txt");
+        assertTrue(externalFile.createNewFile());
+
+        Path junction = new File(dir, "junction").toPath();
+        Files.createSymbolicLink(junction, external.toPath());
+
+        // Junctions can only be created on Windows, where they are reported as
+        // a directory that is also "other". Deleting one has to remove the link
+        // itself instead of traversing into the linked contents.
+        BasicFileAttributes junctionAttributes = Mockito
+                .mock(BasicFileAttributes.class);
+        Mockito.when(junctionAttributes.isDirectory()).thenReturn(true);
+        Mockito.when(junctionAttributes.isOther()).thenReturn(true);
+
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.readAttributes(junction,
+                    BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS))
+                    .thenReturn(junctionAttributes);
+
+            FileIOUtils.delete(junction);
+
+            // The simulated attributes are what makes this meaningful: the
+            // junction is reported as a directory, so only the "other" check
+            // can be the reason its contents were not traversed
+            files.verify(() -> Files.readAttributes(junction,
+                    BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS));
+            files.verify(() -> Files.walkFileTree(Mockito.eq(junction),
+                    Mockito.any()), Mockito.never());
+        }
+
+        assertFalse(Files.exists(junction, LinkOption.NOFOLLOW_LINKS));
+        assertTrue(externalFile.exists(),
+                "Contents behind a junction should be kept");
+    }
+
+    @Test
+    void delete_failureInsideDirectoryNamesTheBlockingFile(@TempDir File dir)
+            throws Exception {
+        File directory = new File(dir, "bundle");
+        assertTrue(directory.mkdirs());
+        File locked = new File(directory, "locked.txt");
+        AccessDeniedException cause = new AccessDeniedException(
+                locked.getAbsolutePath());
+
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.deleteIfExists(locked.toPath()))
+                    .thenThrow(cause);
+            assertTrue(locked.createNewFile());
+
+            IOException exception = assertThrows(IOException.class,
+                    () -> FileIOUtils.delete(directory));
+
+            // The message has to point at the file that blocks the deletion,
+            // not at the directory the deletion was started from
+            assertTrue(
+                    exception.getMessage()
+                            .startsWith("Failed to delete " + locked.toPath()),
+                    exception.getMessage());
+            assertEquals(cause, exception.getCause());
+        }
     }
 
     @Test
@@ -220,5 +340,33 @@ class FileIOUtilsTest {
 
         assertTrue(FileIOUtils.deleteQuietly(file));
         assertFalse(file.exists());
+    }
+
+    @Test
+    void deleteQuietly_removesDirectoryContentsRecursively(@TempDir File dir)
+            throws Exception {
+        File nested = new File(dir, "a/b");
+        assertTrue(nested.mkdirs());
+        assertTrue(new File(nested, "file.txt").createNewFile());
+
+        assertTrue(FileIOUtils.deleteQuietly(new File(dir, "a")));
+        assertFalse(new File(dir, "a").exists());
+
+        File other = new File(dir, "c");
+        assertTrue(other.mkdirs());
+        assertTrue(new File(other, "file.txt").createNewFile());
+
+        assertTrue(FileIOUtils.deleteQuietly(other.toPath()));
+        assertFalse(other.exists());
+    }
+
+    @Test
+    void deleteQuietly_missingFileSucceedsAndNullFails(@TempDir File dir) {
+        assertTrue(FileIOUtils.deleteQuietly(new File(dir, "missing.txt")));
+        assertTrue(FileIOUtils
+                .deleteQuietly(new File(dir, "missing.txt").toPath()));
+
+        assertFalse(FileIOUtils.deleteQuietly((File) null));
+        assertFalse(FileIOUtils.deleteQuietly((Path) null));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FrontendUtilsDeleteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FrontendUtilsDeleteTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the directory deletion helpers of {@link FrontendUtils}. The
+ * remaining {@code node_modules} specific cases live in the
+ * {@code flow-build-tools} tests, as they need an npm install to set up.
+ */
+class FrontendUtilsDeleteTest {
+
+    @Test
+    void deleteDirectory_removesContentsRecursively(@TempDir File dir)
+            throws Exception {
+        File directory = new File(dir, "node_modules");
+        File nested = new File(directory, "a/b");
+        assertTrue(nested.mkdirs());
+        assertTrue(new File(nested, "file.txt").createNewFile());
+
+        FrontendUtils.deleteDirectory(directory);
+
+        assertFalse(directory.exists());
+    }
+
+    @Test
+    void deleteDirectory_onlyRemovesDirectories(@TempDir File dir)
+            throws Exception {
+        File file = new File(dir, "file.txt");
+        assertTrue(file.createNewFile());
+
+        FrontendUtils.deleteDirectory(file);
+        FrontendUtils.deleteDirectory(new File(dir, "missing"));
+
+        assertTrue(file.exists(), "A plain file should not be removed");
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -545,11 +545,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
      * Remove the running port from the vaadinContext and temporary file.
      */
     private void removeRunningDevServerPort() {
-        try {
-            FileIOUtils.delete(devServerPortFile);
-        } catch (IOException e) {
-            // ignore
-        }
+        FileIOUtils.deleteQuietly(devServerPortFile);
     }
 
     @Override


### PR DESCRIPTION
Unify file and folder deletions
and add a clear message that gives
hint on what to do when a file
deletion fails.

Symlinks and junctions are now
handled for all deletions.

deleteIfExists should use deleteSingle
method to get the helper exception.

Closes #7373