### PR TITLE
fix: do not reinstall packages when pnpm reformats its workspace file

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/PnpmWorkspaceFile.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/PnpmWorkspaceFile.java
@@ -89,11 +89,10 @@ class PnpmWorkspaceFile {
     }
 
     /**
-     * Persists the file when its serialized content changed. When the whole
-     * document is empty the file is deleted, because an empty
-     * {@code pnpm-workspace.yaml} carries no configuration; user-authored
-     * override keys and other sections keep the document non-empty and thus
-     * keep the file alive.
+     * Persists the file when its content changed. When the whole document is
+     * empty the file is deleted, because an empty {@code pnpm-workspace.yaml}
+     * carries no configuration; user-authored override keys and other sections
+     * keep the document non-empty and thus keep the file alive.
      *
      * @return {@code true} if the file was written or deleted
      */
@@ -105,14 +104,16 @@ class PnpmWorkspaceFile {
             }
             return false;
         }
-        String yaml = YAML.writeValueAsString(document);
-        String current = file.isFile()
-                ? Files.readString(file.toPath(), StandardCharsets.UTF_8)
-                : null;
-        if (yaml.equals(current)) {
+        // The parsed content is compared instead of the serialized text, as a
+        // file holding the same configuration in a different layout, for
+        // example one pnpm has rewritten while installing, is not a change.
+        // Reporting it as one marks package.json as modified, which runs a
+        // package install on every dev-mode start.
+        if (document.equals(load())) {
             return false;
         }
-        Files.writeString(file.toPath(), yaml, StandardCharsets.UTF_8);
+        Files.writeString(file.toPath(), YAML.writeValueAsString(document),
+                StandardCharsets.UTF_8);
         return true;
     }
 }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -442,6 +442,34 @@ class NodeUpdatePackagesNpmVersionLockingTest extends NodeUpdateTestUtil {
     }
 
     @Test
+    void pnpmIsInUse_workspaceFileReformattedByPnpm_notReportedAsChange()
+            throws IOException {
+        TaskUpdatePackages packageUpdater = createPackageUpdater(true);
+        ObjectNode packageJson = packageUpdater.getPackageJson();
+        ((ObjectNode) packageJson.get(DEPENDENCIES)).put(TEST_DEPENDENCY,
+                PLATFORM_PINNED_DEPENDENCY_VERSION);
+        packageUpdater.generateVersionsJson(packageJson);
+        packageUpdater.lockVersionForNpm(packageJson);
+
+        File workspaceFile = new File(baseDir,
+                PnpmWorkspaceFile.WORKSPACE_FILE);
+        assertTrue(workspaceFile.exists(),
+                "Precondition: the run wrote the workspace file");
+
+        // pnpm rewrites the file while installing, adding its own block with
+        // scalars unquoted where Flow quotes them. The configuration Flow
+        // manages is unchanged, so the next run must not report a change: that
+        // would mark package.json as modified and run a package install.
+        Files.writeString(workspaceFile.toPath(), Files
+                .readString(workspaceFile.toPath(), StandardCharsets.UTF_8)
+                + "allowBuilds:\n  esbuild: set this to true or false\n",
+                StandardCharsets.UTF_8);
+
+        assertFalse(packageUpdater.lockVersionForNpm(packageJson),
+                "Reformatting by pnpm must not be reported as a dependency change");
+    }
+
+    @Test
     void pnpmIsInUse_legacyPnpmOverridesInPackageJson_migratedToWorkspace()
             throws IOException {
         TaskUpdatePackages packageUpdater = createPackageUpdater(true);

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/PnpmWorkspaceFileTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/PnpmWorkspaceFileTest.java
@@ -133,4 +133,24 @@ class PnpmWorkspaceFileTest {
         assertFalse(again.save(),
                 "Rewriting identical content should report no change");
     }
+
+    @Test
+    void save_isIdempotent_whenOnlyLayoutDiffers() throws Exception {
+        // The configuration Flow writes, in the layout pnpm leaves behind after
+        // an install: its own allowBuilds block, and scalars unquoted where
+        // Flow quotes them.
+        Files.writeString(workspaceFile().toPath(), """
+                allowBuilds:
+                  esbuild: set this to true or false
+                overrides:
+                  dep: 1.0.0
+                """, StandardCharsets.UTF_8);
+
+        PnpmWorkspaceFile workspace = new PnpmWorkspaceFile(projectRoot);
+        workspace.setOverrides(Map.of("dep", "1.0.0"));
+
+        assertFalse(workspace.save(),
+                "A file holding the same content in a different layout is not a "
+                        + "change; reporting one triggers a needless package install");
+    }
 }


### PR DESCRIPTION
PnpmWorkspaceFile.save() compared the serialized text of pnpm-workspace.yaml against the file on disk. pnpm rewrites that file while installing, in its own formatting, so the next dev-mode start re-serialized identical content, saw different text and reported a change. That marks package.json as modified and runs a full package install on the first reload of a fresh project, while the user waits.

Compare the parsed content instead, so the same configuration in a different layout is not a change.

Fixes #25083
