### PR TITLE
fix: collect frontend dependencies of dev tools message handlers

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeStartupListener.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeStartupListener.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.base.devserver.DevToolsMessageHandler;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Tag;
@@ -70,8 +71,9 @@ import com.vaadin.flow.theme.Theme;
         JavaScript.Container.class, Theme.class, NoTheme.class,
         HasErrorParameter.class, PWA.class, AppShellConfigurator.class,
         Template.class, LoadDependenciesOnStartup.class,
-        TypeScriptBootstrapModifier.class, Component.class, Layout.class,
-        StyleSheet.class, StyleSheet.Container.class })
+        TypeScriptBootstrapModifier.class, DevToolsMessageHandler.class,
+        Component.class, Layout.class, StyleSheet.class,
+        StyleSheet.Container.class })
 @WebListener
 public class DevModeStartupListener
         implements VaadinServletContextStartupInitializer, Serializable,

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeClassFinderTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeClassFinderTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.base.devserver.DevToolsMessageHandler;
 import com.vaadin.base.devserver.startup.DevModeInitializer.DevModeClassFinder;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.WebComponentExporter;
@@ -73,7 +74,8 @@ class DevModeClassFinderTest {
                 HasErrorParameter.class, PWA.class, AppShellConfigurator.class,
                 Template.class, LoadDependenciesOnStartup.class,
                 Component.class, TypeScriptBootstrapModifier.class,
-                Layout.class, StyleSheet.class, StyleSheet.Container.class);
+                DevToolsMessageHandler.class, Layout.class, StyleSheet.class,
+                StyleSheet.Container.class);
 
         for (Class<?> clz : classes) {
             assertTrue(knownClasses.contains(clz),


### PR DESCRIPTION
FrontendDependencies resolves DevToolsMessageHandler subtypes to add them as internal entry points, but the class was missing from the `@HandlesTypes` of DevModeStartupListener. DevModeClassFinder only knows the classes listed there and throws for anything else, and that exception was swallowed by the surrounding catch block intended for a missing dev tools classpath entry. As a result, frontend dependencies declared by dev tools plugins were silently skipped in development mode when the byte-code scanner is enabled.
