### PR TITLE
fix: collect frontend dependencies of dev tools message handlers (CP: 24.10)

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeStartupListener.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeStartupListener.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.base.devserver.DevToolsMessageHandler;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Tag;
@@ -62,7 +63,8 @@ import com.vaadin.flow.theme.Theme;
         JavaScript.Container.class, Theme.class, NoTheme.class,
         HasErrorParameter.class, PWA.class, AppShellConfigurator.class,
         Template.class, LoadDependenciesOnStartup.class,
-        TypeScriptBootstrapModifier.class, Component.class, Layout.class })
+        TypeScriptBootstrapModifier.class, DevToolsMessageHandler.class,
+        Component.class, Layout.class })
 @WebListener
 public class DevModeStartupListener
         implements VaadinServletContextStartupInitializer, Serializable,

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeClassFinderTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeClassFinderTest.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import jakarta.servlet.annotation.HandlesTypes;
 
+import com.vaadin.base.devserver.DevToolsMessageHandler;
 import com.vaadin.base.devserver.startup.DevModeInitializer.DevModeClassFinder;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.WebComponentExporter;
@@ -64,7 +65,7 @@ public class DevModeClassFinderTest {
                 HasErrorParameter.class, PWA.class, AppShellConfigurator.class,
                 Template.class, LoadDependenciesOnStartup.class,
                 Component.class, TypeScriptBootstrapModifier.class,
-                Layout.class);
+                DevToolsMessageHandler.class, Layout.class);
 
         for (Class<?> clz : classes) {
             assertTrue("should be a known class " + clz.getName(),


### PR DESCRIPTION
FrontendDependencies resolves DevToolsMessageHandler subtypes to add them as internal entry points, but the class was missing from the `@HandlesTypes` of DevModeStartupListener. DevModeClassFinder only knows the classes listed there and throws for anything else, and that exception was swallowed by the surrounding catch block intended for a missing dev tools classpath entry. As a result, frontend dependencies declared by dev tools plugins were silently skipped in development mode when the byte-code scanner is enabled.
