### PR TITLE
fix: read minimum frontend package age from config in dev mode

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -81,6 +81,7 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
+import static com.vaadin.flow.server.InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS;
 import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
 import static com.vaadin.flow.server.InitParameters.NODE_FOLDER;
 import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
@@ -292,6 +293,9 @@ public class DevModeInitializer implements Serializable {
         boolean npmExcludeWebComponents = config
                 .getBooleanProperty(NPM_EXCLUDE_WEB_COMPONENTS, false);
 
+        int minimumFrontendPackageAgeDays = Integer.parseInt(config
+                .getStringProperty(MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, "1"));
+
         options.enablePackagesUpdate(true)
                 .useByteCodeScanner(useByteCodeScanner)
                 .withFrontendGeneratedFolder(frontendGeneratedFolder)
@@ -314,6 +318,8 @@ public class DevModeInitializer implements Serializable {
                         getFrontendExtraFileExtensions(config))
                 .withReact(reactEnable)
                 .withNpmExcludeWebComponents(npmExcludeWebComponents)
+                .withMinimumFrontendPackageAgeDays(
+                        minimumFrontendPackageAgeDays)
                 .withNodeVersion(config.getStringProperty(NODE_VERSION,
                         DEFAULT_NODE_VERSION))
                 .withNodeFolder(config.getStringProperty(NODE_FOLDER, null))

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -57,6 +58,8 @@ import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
 import com.vaadin.flow.server.frontend.FrontendBuildUtils;
+import com.vaadin.flow.server.frontend.NodeTasks;
+import com.vaadin.flow.server.frontend.Options;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.VaadinInitializerException;
 
@@ -251,6 +254,28 @@ class DevModeInitializerTest extends DevModeInitializerTestBase {
         mainPackageFile.delete();
         process();
         assertDevModeHandlerStarted();
+    }
+
+    @Test
+    void minimumFrontendPackageAgeDays_readFromConfig_passedToOptions()
+            throws Exception {
+        Mockito.when(appConfig.getStringProperty(
+                InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, "1"))
+                .thenReturn("6");
+
+        assertEquals(7,
+                captureNodeTasksOptions().getMinimumFrontendPackageAgeDays());
+    }
+
+    private Options captureNodeTasksOptions() throws Exception {
+        List<Options> captured = new ArrayList<>();
+        try (MockedConstruction<NodeTasks> ignored = Mockito
+                .mockConstruction(NodeTasks.class, (mock, context) -> captured
+                        .add((Options) context.arguments().get(0)))) {
+            process();
+        }
+        assertEquals(1, captured.size());
+        return captured.get(0);
     }
 
     @Test

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
@@ -261,7 +261,7 @@ class DevModeInitializerTest extends DevModeInitializerTestBase {
             throws Exception {
         Mockito.when(appConfig.getStringProperty(
                 InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, "1"))
-                .thenReturn("6");
+                .thenReturn("7");
 
         assertEquals(7,
                 captureNodeTasksOptions().getMinimumFrontendPackageAgeDays());


### PR DESCRIPTION
The dev mode initializer built the frontend Options without reading the npm.minimumFrontendPackageAgeDays property, so the minimum package age check was ignored at runtime and always fell back to the Options default of one day. The Maven build path already wired this through, making dev mode inconsistent with the build.

Read the property in DevModeInitializer and pass it to the Options via withMinimumFrontendPackageAgeDays.
