### PR TITLE
fix: do not send a literal "Content-Type: null" header from Xhr

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/gwt/elemental/js/util/Xhr.java
+++ b/flow-client/src/main/java/com/vaadin/client/gwt/elemental/js/util/Xhr.java
@@ -167,7 +167,8 @@ public class Xhr {
      * @param requestData
      *            the data to be passed to XMLHttpRequest.send
      * @param contentType
-     *            a value for the Content-Type HTTP header
+     *            a value for the Content-Type HTTP header, or {@code null}
+     *            to send the request without a Content-Type header
      * @param callback
      *            the callback to notify
      * @return a reference to the sent XmlHttpRequest
@@ -190,7 +191,8 @@ public class Xhr {
      * @param requestData
      *            the data to be passed to XMLHttpRequest.send
      * @param contentType
-     *            a value for the Content-Type HTTP header
+     *            a value for the Content-Type HTTP header, or {@code null}
+     *            to send the request without a Content-Type header
      * @param callback
      *            the callback to notify
      * @return a reference to the sent XmlHttpRequest
@@ -221,7 +223,12 @@ public class Xhr {
         try {
             xhr.setOnReadyStateChange(new Handler(callback));
             xhr.open(method, url);
-            xhr.setRequestHeader("Content-type", contentType);
+            if (contentType != null) {
+                // Setting a null value would send the literal header
+                // "Content-Type: null" (the browser stringifies it), which
+                // strict server-side parsers reject as malformed.
+                xhr.setRequestHeader("Content-type", contentType);
+            }
             xhr.setWithCredentials(true);
             xhr.send(requestData);
         } catch (JavaScriptException e) {


### PR DESCRIPTION
### Description

`Xhr.request` sets the `Content-Type` request header unconditionally. When the `contentType` parameter is `null` — as it is for every heartbeat request sent by `Heartbeat.send()` (`Xhr.post(uri, null, null, callback)`) — the Java `null` crosses JSNI as a JS `null`, the browser stringifies it per the XHR spec, and the request goes on the wire with the malformed header `Content-Type: null`.

This fix skips `setRequestHeader` when `contentType == null`: a body-less request without a `Content-Type` header is valid, and it is exactly what the server side expects for heartbeats. The two `post(...)` javadocs now document `null` as "send no Content-Type header".

### Why

Strict server-side Content-Type parsers reject the malformed header. Concrete failure mode (details in #25104): in an application that also uses Spring for GraphQL's WebMVC transport, the GraphQL route predicate parses the Content-Type of every POST during handler mapping and answers 415 for the unparseable value — every heartbeat fails, `DefaultConnectionStateHandler` treats the status as a recoverable connection error, and users get a permanent "connection lost / reconnecting" overlay on a healthy connection.

Fixes #25104

### Type of change

- [x] Bugfix
- [ ] Feature
