### PR TITLE
chore: deprecate NoTheme annotation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/theme/NoTheme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/NoTheme.java
@@ -47,5 +47,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
+@Deprecated(since = "25.1")
 public @interface NoTheme {
 }


### PR DESCRIPTION
Theme has been deprecated in Vaadin 25, but `@NoTheme` wasn't.
This change deprecates the annotation.
