### PR TITLE
revert: chore(deps): bump org.jspecify:jspecify from 1.0.0 to 1.0.1 (#25081)

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -22,6 +22,7 @@
     <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
     </dependency>
 
     <!-- DefaultApplicationConfigurationFactory is declared as an OSGi

--- a/pom.xml
+++ b/pom.xml
@@ -225,12 +225,6 @@
         <version>3.1.1</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.jspecify</groupId>
-        <artifactId>jspecify</artifactId>
-        <version>1.0.1</version>
-      </dependency>
-
       <!-- Test dependencies -->
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This reverts commit c2671a753ede8b6f82e0328be0d0fc634753c900.

JSpecify bump causes lots of convergence issues all around. Let's wait for updates in external projects like `reactor`.