### PR TITLE
feat: add HasAriaDescription interface

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -20,31 +20,39 @@ import java.util.Optional;
 import com.vaadin.flow.dom.ElementConstants;
 
 /**
- * A generic interface for components that support setting the accessible
- * description. The description is announced by screen readers when the
- * component receives focus.
+ * A generic interface for components that have an accessible description.
  * <p>
- * The description can be provided either as plain text with
- * {@link #setAriaDescription(String)}, or with
- * {@link #setAriaDescribedBy(String)} by referencing another element whose
- * content serves as the description. If both are set, the element reference
- * takes precedence.
+ * The accessible description provides supplementary information about the
+ * component to assistive technologies, such as screen readers.
+ * <p>
+ * It can be set as plain text with the {@code aria-description} attribute, or
+ * by referencing existing elements on the page with the
+ * {@code aria-describedby} attribute. Prefer the latter when the description is
+ * already visible to all users.
  *
  * @author Vaadin Ltd
  * @since 25.3
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description">
+ *      MDN: aria-description</a>
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby">
+ *      MDN: aria-describedby</a>
  */
 public interface HasAriaDescription extends HasElement {
 
     /**
-     * Set the aria-description of the component to the given text.
+     * Sets the {@code aria-description} attribute of the component to the given
+     * text.
      * <p>
-     * If both aria-description and aria-describedby are present,
-     * aria-describedby takes precedence.
-     * <p>
-     * See: https://www.w3.org/TR/wai-aria/#aria-description
+     * If both {@code aria-description} and {@code aria-describedby} are
+     * present, {@code aria-describedby} takes precedence.
      *
      * @param ariaDescription
-     *            the aria-description text to set or {@code null} to clear
+     *            the description text, or {@code null} to remove the attribute
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description">
+     *      MDN: aria-description</a>
      */
     default void setAriaDescription(String ariaDescription) {
         if (ariaDescription != null) {
@@ -58,7 +66,7 @@ public interface HasAriaDescription extends HasElement {
     }
 
     /**
-     * Gets the aria-description of the component.
+     * Gets the {@code aria-description} attribute of the component.
      *
      * @return an optional aria-description, or an empty optional if none has
      *         been set
@@ -69,18 +77,20 @@ public interface HasAriaDescription extends HasElement {
     }
 
     /**
-     * Sets the aria-describedby of the component.
+     * Sets the {@code aria-describedby} attribute of the component to one or
+     * more element IDs, separated by spaces.
      * <p>
-     * The value must be a valid id attribute of another element that describes
-     * the component. The description element must be in the same DOM scope of
-     * the component, otherwise screen readers will fail to announce the
-     * description content properly.
-     * <p>
-     * See: https://www.w3.org/TR/wai-aria/#aria-describedby
+     * Each ID must match the {@code id} attribute of another element that
+     * describes the component. The description elements must be in the same DOM
+     * scope as the component, otherwise screen readers will fail to announce
+     * the description content properly.
      *
      * @param ariaDescribedBy
-     *            the string with the id of the element that will be used as
-     *            description or {@code null} to clear
+     *            a space-separated list of element IDs, or {@code null} to
+     *            remove the attribute
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby">
+     *      MDN: aria-describedby</a>
      */
     default void setAriaDescribedBy(String ariaDescribedBy) {
         if (ariaDescribedBy != null) {
@@ -94,20 +104,23 @@ public interface HasAriaDescription extends HasElement {
     }
 
     /**
-     * Sets the aria-describedby of the component to reference the given
-     * description component.
+     * Sets the {@code aria-describedby} attribute of the component to reference
+     * the given description component.
      * <p>
-     * The description component does not need an id: if it has none by the time
+     * The description component does not need an ID: if it has none by the time
      * the value is sent to the client, one is generated automatically.
      * <p>
      * The description component must be in the same DOM scope as this
      * component, otherwise screen readers will fail to announce the description
      * content properly.
-     * <p>
-     * See: https://www.w3.org/TR/wai-aria/#aria-describedby
      *
      * @param descriptionComponent
      *            the component to use as the description, not {@code null}
+     * @throws IllegalArgumentException
+     *             if {@code descriptionComponent} is {@code null}; use
+     *             {@link #setAriaDescribedBy(String)} with {@code null} to
+     *             remove the attribute instead
+     * @see #setAriaDescribedBy(String)
      */
     default void setAriaDescribedBy(Component descriptionComponent) {
         if (descriptionComponent == null) {
@@ -120,7 +133,7 @@ public interface HasAriaDescription extends HasElement {
     }
 
     /**
-     * Gets the aria-describedby of the component.
+     * Gets the {@code aria-describedby} attribute of the component.
      *
      * @return an optional aria-describedby, or an empty optional if none has
      *         been set

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -32,8 +32,8 @@ import com.vaadin.flow.dom.ElementConstants;
  * the description text is visible on screen, aria-describedby <b>should</b> be
  * used and aria-description <b>should not</b> be used.
  * <p>
- * <b>Don't include both</b>. If both are present on the same element,
- * aria-describedby will take precedence over aria-description.
+ * If both attributes are present on the same element, aria-describedby takes
+ * precedence over aria-description.
  * <p>
  * See: https://www.w3.org/TR/wai-aria/#aria-description
  * <p>
@@ -47,9 +47,8 @@ public interface HasAriaDescription extends HasElement {
     /**
      * Set the aria-description of the component to the given text.
      * <p>
-     * This method should not be used if {@link #setAriaDescribedBy(String)} is
-     * also used. If both attributes are present, aria-describedby will take
-     * precedence over aria-description.
+     * If both aria-description and aria-describedby are present,
+     * aria-describedby takes precedence.
      *
      * @param ariaDescription
      *            the aria-description text to set or {@code null} to clear

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.dom.ElementConstants;
  * See: https://www.w3.org/TR/wai-aria/#aria-describedby
  *
  * @author Vaadin Ltd
+ * @since 25.3
  */
 public interface HasAriaDescription extends HasElement {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -28,9 +28,7 @@ import com.vaadin.flow.dom.ElementConstants;
  * to some other element.
  * <p>
  * The purpose of these attributes is to provide the user with additional
- * descriptive text that complements the accessible name of the component. If
- * the description text is visible on screen, aria-describedby should be used
- * and aria-description should not be used.
+ * descriptive text that complements the accessible name of the component.
  *
  * @author Vaadin Ltd
  * @since 25.3

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -18,17 +18,10 @@ package com.vaadin.flow.component;
 import com.vaadin.flow.dom.ElementConstants;
 
 /**
- * A generic interface for components and other user interface objects that may
- * have an aria-description and an aria-describedby DOM attributes to set the
- * accessible description of the component.
- * <p>
- * The default implementation sets the aria-description and aria-describedby of
- * the component to the given {@link #getElement()}. Override all methods in
- * this interface if the aria-description and aria-describedby should be added
- * to some other element.
- * <p>
- * The purpose of these attributes is to provide the user with additional
- * descriptive text that complements the accessible name of the component.
+ * A generic interface for components that support setting the accessible
+ * description with the aria-description and aria-describedby DOM attributes.
+ * The description complements the accessible name of the component with
+ * additional descriptive text.
  *
  * @author Vaadin Ltd
  * @since 25.3

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import com.vaadin.flow.dom.ElementConstants;
+
+/**
+ * A generic interface for components and other user interface objects that may
+ * have an aria-description and an aria-describedby DOM attributes to set the
+ * accessible description of the component.
+ * <p>
+ * The default implementation sets the aria-description and aria-describedby of
+ * the component to the given {@link #getElement()}. Override all methods in
+ * this interface if the aria-description and aria-describedby should be added
+ * to some other element.
+ * <p>
+ * The purpose of these attributes is to provide the user with additional
+ * descriptive text that complements the accessible name of the component. If
+ * the description text is visible on screen, aria-describedby <b>should</b> be
+ * used and aria-description <b>should not</b> be used.
+ * <p>
+ * <b>Don't include both</b>. If both are present on the same element,
+ * aria-describedby will take precedence over aria-description.
+ * <p>
+ * See: https://www.w3.org/TR/wai-aria/#aria-description
+ * <p>
+ * See: https://www.w3.org/TR/wai-aria/#aria-describedby
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasAriaDescription extends HasElement {
+
+    /**
+     * Set the aria-description of the component to the given text.
+     * <p>
+     * This method should not be used if {@link #setAriaDescribedBy(String)} is
+     * also used. If both attributes are present, aria-describedby will take
+     * precedence over aria-description.
+     *
+     * @param ariaDescription
+     *            the aria-description text to set or {@code null} to clear
+     */
+    default void setAriaDescription(String ariaDescription) {
+        if (ariaDescription != null) {
+            getElement().setAttribute(
+                    ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME,
+                    ariaDescription);
+        } else {
+            getElement().removeAttribute(
+                    ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME);
+        }
+    }
+
+    /**
+     * Gets the aria-description of the component.
+     *
+     * @return the aria-description of the component or {@code null} if no
+     *         aria-description has been set
+     */
+    default String getAriaDescription() {
+        return getElement()
+                .getAttribute(ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME);
+    }
+
+    /**
+     * Set the aria-describedby of the component. The value must be a valid id
+     * attribute of another element that describes the component. The
+     * description element <b>must</b> be in the same DOM scope of the
+     * component, otherwise screen readers may fail to announce the description
+     * content properly.
+     *
+     * @param ariaDescribedBy
+     *            the string with the id of the element that will be used as
+     *            description or {@code null} to clear
+     */
+    default void setAriaDescribedBy(String ariaDescribedBy) {
+        if (ariaDescribedBy != null) {
+            getElement().setAttribute(
+                    ElementConstants.ARIA_DESCRIBEDBY_ATTRIBUTE_NAME,
+                    ariaDescribedBy);
+        } else {
+            getElement().removeAttribute(
+                    ElementConstants.ARIA_DESCRIBEDBY_ATTRIBUTE_NAME);
+        }
+    }
+
+    /**
+     * Set the aria-describedby of the component to reference the given
+     * description component. If {@code descriptionComponent} does not have an
+     * id, one is generated automatically.
+     * <p>
+     * The id is resolved lazily before the next client response after this
+     * component is attached, so the description component's id can be set after
+     * calling this method. If no id is set by then, one will be generated.
+     * <p>
+     * The description component <b>must</b> be in the same DOM scope as this
+     * component, otherwise screen readers may fail to announce the description
+     * content properly.
+     *
+     * @param descriptionComponent
+     *            the component to use as the description, not {@code null}
+     */
+    default void setAriaDescribedBy(Component descriptionComponent) {
+        if (descriptionComponent == null) {
+            throw new IllegalArgumentException(
+                    "The provided component cannot be null");
+        }
+        ComponentUtil.resolveOrGenerateIdLater(getElement(),
+                descriptionComponent, "ariadescribedby-",
+                this::setAriaDescribedBy);
+    }
+
+    /**
+     * Gets the aria-describedby of the component.
+     *
+     * @return the aria-describedby of the component or {@code null} if no
+     *         aria-describedby has been set
+     */
+    default String getAriaDescribedBy() {
+        return getElement()
+                .getAttribute(ElementConstants.ARIA_DESCRIBEDBY_ATTRIBUTE_NAME);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -62,8 +62,7 @@ public interface HasAriaDescription extends HasElement {
     /**
      * Gets the aria-description of the component.
      *
-     * @return the aria-description of the component or {@code null} if no
-     *         aria-description has been set
+     * @return the aria-description or {@code null} if none has been set
      */
     default String getAriaDescription() {
         return getElement()
@@ -71,11 +70,12 @@ public interface HasAriaDescription extends HasElement {
     }
 
     /**
-     * Set the aria-describedby of the component. The value must be a valid id
-     * attribute of another element that describes the component. The
-     * description element must be in the same DOM scope of the component,
-     * otherwise screen readers may fail to announce the description content
-     * properly.
+     * Sets the aria-describedby of the component.
+     * <p>
+     * The value must be a valid id attribute of another element that describes
+     * the component. The description element must be in the same DOM scope of
+     * the component, otherwise screen readers will fail to announce the
+     * description content properly.
      * <p>
      * See: https://www.w3.org/TR/wai-aria/#aria-describedby
      *
@@ -104,7 +104,7 @@ public interface HasAriaDescription extends HasElement {
      * calling this method. If no id is set by then, one will be generated.
      * <p>
      * The description component must be in the same DOM scope as this
-     * component, otherwise screen readers may fail to announce the description
+     * component, otherwise screen readers will fail to announce the description
      * content properly.
      * <p>
      * See: https://www.w3.org/TR/wai-aria/#aria-describedby
@@ -125,8 +125,7 @@ public interface HasAriaDescription extends HasElement {
     /**
      * Gets the aria-describedby of the component.
      *
-     * @return the aria-describedby of the component or {@code null} if no
-     *         aria-describedby has been set
+     * @return the aria-describedby or {@code null} if none has been set
      */
     default String getAriaDescribedBy() {
         return getElement()

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -93,13 +93,11 @@ public interface HasAriaDescription extends HasElement {
     }
 
     /**
-     * Set the aria-describedby of the component to reference the given
-     * description component. If {@code descriptionComponent} does not have an
-     * id, one is generated automatically.
+     * Sets the aria-describedby of the component to reference the given
+     * description component.
      * <p>
-     * The id is resolved lazily before the next client response after this
-     * component is attached, so the description component's id can be set after
-     * calling this method. If no id is set by then, one will be generated.
+     * The description component does not need an id: if it has none by the time
+     * the value is sent to the client, one is generated automatically.
      * <p>
      * The description component must be in the same DOM scope as this
      * component, otherwise screen readers will fail to announce the description

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component;
 
+import java.util.Optional;
+
 import com.vaadin.flow.dom.ElementConstants;
 
 /**
@@ -53,11 +55,12 @@ public interface HasAriaDescription extends HasElement {
     /**
      * Gets the aria-description of the component.
      *
-     * @return the aria-description or {@code null} if none has been set
+     * @return an optional aria-description, or an empty optional if none has
+     *         been set
      */
-    default String getAriaDescription() {
-        return getElement()
-                .getAttribute(ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME);
+    default Optional<String> getAriaDescription() {
+        return Optional.ofNullable(getElement().getAttribute(
+                ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME));
     }
 
     /**
@@ -114,10 +117,11 @@ public interface HasAriaDescription extends HasElement {
     /**
      * Gets the aria-describedby of the component.
      *
-     * @return the aria-describedby or {@code null} if none has been set
+     * @return an optional aria-describedby, or an empty optional if none has
+     *         been set
      */
-    default String getAriaDescribedBy() {
-        return getElement()
-                .getAttribute(ElementConstants.ARIA_DESCRIBEDBY_ATTRIBUTE_NAME);
+    default Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(getElement().getAttribute(
+                ElementConstants.ARIA_DESCRIBEDBY_ATTRIBUTE_NAME));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -29,11 +29,8 @@ import com.vaadin.flow.dom.ElementConstants;
  * <p>
  * The purpose of these attributes is to provide the user with additional
  * descriptive text that complements the accessible name of the component. If
- * the description text is visible on screen, aria-describedby <b>should</b> be
- * used and aria-description <b>should not</b> be used.
- * <p>
- * If both attributes are present on the same element, aria-describedby takes
- * precedence over aria-description.
+ * the description text is visible on screen, aria-describedby should be used
+ * and aria-description should not be used.
  *
  * @author Vaadin Ltd
  * @since 25.3
@@ -76,9 +73,9 @@ public interface HasAriaDescription extends HasElement {
     /**
      * Set the aria-describedby of the component. The value must be a valid id
      * attribute of another element that describes the component. The
-     * description element <b>must</b> be in the same DOM scope of the
-     * component, otherwise screen readers may fail to announce the description
-     * content properly.
+     * description element must be in the same DOM scope of the component,
+     * otherwise screen readers may fail to announce the description content
+     * properly.
      * <p>
      * See: https://www.w3.org/TR/wai-aria/#aria-describedby
      *
@@ -106,7 +103,7 @@ public interface HasAriaDescription extends HasElement {
      * component is attached, so the description component's id can be set after
      * calling this method. If no id is set by then, one will be generated.
      * <p>
-     * The description component <b>must</b> be in the same DOM scope as this
+     * The description component must be in the same DOM scope as this
      * component, otherwise screen readers may fail to announce the description
      * content properly.
      * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -21,9 +21,13 @@ import com.vaadin.flow.dom.ElementConstants;
 
 /**
  * A generic interface for components that support setting the accessible
- * description with the aria-description and aria-describedby DOM attributes.
- * The description complements the accessible name of the component with
- * additional descriptive text.
+ * description. The description is announced by screen readers when the
+ * component receives focus.
+ * <p>
+ * The description can be provided either as plain text with
+ * {@link #setAriaDescription(String)}, or by referencing another element that
+ * contains it with {@link #setAriaDescribedBy(String)}. If both are set, the
+ * element reference takes precedence.
  *
  * @author Vaadin Ltd
  * @since 25.3

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -34,10 +34,6 @@ import com.vaadin.flow.dom.ElementConstants;
  * <p>
  * If both attributes are present on the same element, aria-describedby takes
  * precedence over aria-description.
- * <p>
- * See: https://www.w3.org/TR/wai-aria/#aria-description
- * <p>
- * See: https://www.w3.org/TR/wai-aria/#aria-describedby
  *
  * @author Vaadin Ltd
  * @since 25.3
@@ -49,6 +45,8 @@ public interface HasAriaDescription extends HasElement {
      * <p>
      * If both aria-description and aria-describedby are present,
      * aria-describedby takes precedence.
+     * <p>
+     * See: https://www.w3.org/TR/wai-aria/#aria-description
      *
      * @param ariaDescription
      *            the aria-description text to set or {@code null} to clear
@@ -81,6 +79,8 @@ public interface HasAriaDescription extends HasElement {
      * description element <b>must</b> be in the same DOM scope of the
      * component, otherwise screen readers may fail to announce the description
      * content properly.
+     * <p>
+     * See: https://www.w3.org/TR/wai-aria/#aria-describedby
      *
      * @param ariaDescribedBy
      *            the string with the id of the element that will be used as
@@ -109,6 +109,8 @@ public interface HasAriaDescription extends HasElement {
      * The description component <b>must</b> be in the same DOM scope as this
      * component, otherwise screen readers may fail to announce the description
      * content properly.
+     * <p>
+     * See: https://www.w3.org/TR/wai-aria/#aria-describedby
      *
      * @param descriptionComponent
      *            the component to use as the description, not {@code null}

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -25,9 +25,10 @@ import com.vaadin.flow.dom.ElementConstants;
  * component receives focus.
  * <p>
  * The description can be provided either as plain text with
- * {@link #setAriaDescription(String)}, or by referencing another element that
- * contains it with {@link #setAriaDescribedBy(String)}. If both are set, the
- * element reference takes precedence.
+ * {@link #setAriaDescription(String)}, or with
+ * {@link #setAriaDescribedBy(String)} by referencing another element whose
+ * content serves as the description. If both are set, the element reference
+ * takes precedence.
  *
  * @author Vaadin Ltd
  * @since 25.3

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
@@ -446,10 +446,18 @@ public class ElementConstants {
     public static final String ARIA_LABEL_ATTRIBUTE_NAME = "aria-label";
     /**
      * The aria-labelledby attribute.
-     * 
+     *
      * @since 24.1
      */
     public static final String ARIA_LABELLEDBY_ATTRIBUTE_NAME = "aria-labelledby";
+    /**
+     * The aria-describedby attribute.
+     */
+    public static final String ARIA_DESCRIBEDBY_ATTRIBUTE_NAME = "aria-describedby";
+    /**
+     * The aria-description attribute.
+     */
+    public static final String ARIA_DESCRIPTION_ATTRIBUTE_NAME = "aria-description";
 
     private ElementConstants() {
         // Constants only

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
@@ -452,10 +452,14 @@ public class ElementConstants {
     public static final String ARIA_LABELLEDBY_ATTRIBUTE_NAME = "aria-labelledby";
     /**
      * The aria-describedby attribute.
+     *
+     * @since 25.3
      */
     public static final String ARIA_DESCRIBEDBY_ATTRIBUTE_NAME = "aria-describedby";
     /**
      * The aria-description attribute.
+     *
+     * @since 25.3
      */
     public static final String ARIA_DESCRIPTION_ATTRIBUTE_NAME = "aria-description";
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HasAriaDescriptionTest {
+
+    @Tag(Tag.MAIN) // main is used, because div is not a valid target by default
+    private static class TestComponent extends Component
+            implements HasAriaDescription {
+
+    }
+
+    @Test
+    void withoutAriaDescription_getAriaDescriptionReturnsNull() {
+        TestComponent component = new TestComponent();
+
+        assertNull(component.getAriaDescription());
+    }
+
+    @Test
+    void setAriaDescription() {
+        TestComponent component = new TestComponent();
+        component.setAriaDescription("test AriaDescription");
+
+        assertEquals("test AriaDescription", component.getAriaDescription());
+    }
+
+    @Test
+    void withAriaDescription_setAriaDescriptionToNullClearsAriaDescription() {
+        TestComponent component = new TestComponent();
+        component.setAriaDescription("test AriaDescription");
+
+        component.setAriaDescription(null);
+        assertNull(component.getAriaDescription());
+    }
+
+    @Test
+    void withoutAriaDescribedBy_getAriaDescribedByReturnsNull() {
+        TestComponent component = new TestComponent();
+
+        assertNull(component.getAriaDescribedBy());
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        TestComponent component = new TestComponent();
+        component.setAriaDescribedBy("test AriaDescribedBy");
+
+        assertEquals("test AriaDescribedBy", component.getAriaDescribedBy());
+    }
+
+    @Test
+    void withAriaDescribedBy_setAriaDescribedByToNullClearsAriaDescribedBy() {
+        TestComponent component = new TestComponent();
+        component.setAriaDescribedBy("test AriaDescribedBy");
+
+        component.setAriaDescribedBy((String) null);
+        assertNull(component.getAriaDescribedBy());
+    }
+
+    @Test
+    void setAriaDescribedByComponent_withExistingId() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent descriptionComponent = new TestComponent();
+        descriptionComponent.setId("the-description");
+        ui.add(component, descriptionComponent);
+
+        component.setAriaDescribedBy(descriptionComponent);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("the-description", component.getAriaDescribedBy());
+    }
+
+    @Test
+    void setAriaDescribedByComponent_withoutId_generatesId() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent descriptionComponent = new TestComponent();
+        assertFalse(descriptionComponent.getId().isPresent());
+        ui.add(component, descriptionComponent);
+
+        component.setAriaDescribedBy(descriptionComponent);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertTrue(descriptionComponent.getId().isPresent());
+        assertTrue(descriptionComponent.getId().get()
+                .startsWith("ariadescribedby-"));
+        assertEquals(descriptionComponent.getId().get(),
+                component.getAriaDescribedBy());
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
@@ -15,12 +15,8 @@
  */
 package com.vaadin.flow.component;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HasAriaDescriptionTest {
 
@@ -31,10 +27,10 @@ class HasAriaDescriptionTest {
     }
 
     @Test
-    void withoutAriaDescription_getAriaDescriptionReturnsNull() {
+    void withoutAriaDescription_getAriaDescriptionReturnsEmptyOptional() {
         TestComponent component = new TestComponent();
 
-        assertNull(component.getAriaDescription());
+        Assertions.assertFalse(component.getAriaDescription().isPresent());
     }
 
     @Test
@@ -42,7 +38,8 @@ class HasAriaDescriptionTest {
         TestComponent component = new TestComponent();
         component.setAriaDescription("test AriaDescription");
 
-        assertEquals("test AriaDescription", component.getAriaDescription());
+        Assertions.assertEquals("test AriaDescription",
+                component.getAriaDescription().get());
     }
 
     @Test
@@ -51,14 +48,14 @@ class HasAriaDescriptionTest {
         component.setAriaDescription("test AriaDescription");
 
         component.setAriaDescription(null);
-        assertNull(component.getAriaDescription());
+        Assertions.assertFalse(component.getAriaDescription().isPresent());
     }
 
     @Test
-    void withoutAriaDescribedBy_getAriaDescribedByReturnsNull() {
+    void withoutAriaDescribedBy_getAriaDescribedByReturnsEmptyOptional() {
         TestComponent component = new TestComponent();
 
-        assertNull(component.getAriaDescribedBy());
+        Assertions.assertFalse(component.getAriaDescribedBy().isPresent());
     }
 
     @Test
@@ -66,7 +63,8 @@ class HasAriaDescriptionTest {
         TestComponent component = new TestComponent();
         component.setAriaDescribedBy("test AriaDescribedBy");
 
-        assertEquals("test AriaDescribedBy", component.getAriaDescribedBy());
+        Assertions.assertEquals("test AriaDescribedBy",
+                component.getAriaDescribedBy().get());
     }
 
     @Test
@@ -75,7 +73,7 @@ class HasAriaDescriptionTest {
         component.setAriaDescribedBy("test AriaDescribedBy");
 
         component.setAriaDescribedBy((String) null);
-        assertNull(component.getAriaDescribedBy());
+        Assertions.assertFalse(component.getAriaDescribedBy().isPresent());
     }
 
     @Test
@@ -89,7 +87,8 @@ class HasAriaDescriptionTest {
         component.setAriaDescribedBy(descriptionComponent);
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        assertEquals("the-description", component.getAriaDescribedBy());
+        Assertions.assertEquals("the-description",
+                component.getAriaDescribedBy().get());
     }
 
     @Test
@@ -97,16 +96,31 @@ class HasAriaDescriptionTest {
         UI ui = new UI();
         TestComponent component = new TestComponent();
         TestComponent descriptionComponent = new TestComponent();
-        assertFalse(descriptionComponent.getId().isPresent());
+        Assertions.assertFalse(descriptionComponent.getId().isPresent());
         ui.add(component, descriptionComponent);
 
         component.setAriaDescribedBy(descriptionComponent);
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        assertTrue(descriptionComponent.getId().isPresent());
-        assertTrue(descriptionComponent.getId().get()
+        Assertions.assertTrue(descriptionComponent.getId().isPresent());
+        Assertions.assertTrue(descriptionComponent.getId().get()
                 .startsWith("ariadescribedby-"));
-        assertEquals(descriptionComponent.getId().get(),
-                component.getAriaDescribedBy());
+        Assertions.assertEquals(descriptionComponent.getId().get(),
+                component.getAriaDescribedBy().get());
+    }
+
+    @Test
+    void setAriaDescribedByComponent_idSetLater() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent descriptionComponent = new TestComponent();
+        ui.add(component, descriptionComponent);
+
+        component.setAriaDescribedBy(descriptionComponent);
+        descriptionComponent.setId("manually-set-id");
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        Assertions.assertEquals("manually-set-id",
+                component.getAriaDescribedBy().get());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
@@ -27,100 +27,74 @@ class HasAriaDescriptionTest {
     }
 
     @Test
-    void withoutAriaDescription_getAriaDescriptionReturnsEmptyOptional() {
-        TestComponent component = new TestComponent();
-
-        Assertions.assertFalse(component.getAriaDescription().isPresent());
-    }
-
-    @Test
     void setAriaDescription() {
         TestComponent component = new TestComponent();
-        component.setAriaDescription("test AriaDescription");
+        Assertions.assertFalse(component.getAriaDescription().isPresent());
 
-        Assertions.assertEquals("test AriaDescription",
+        component.setAriaDescription("description text");
+        Assertions.assertEquals("description text",
                 component.getAriaDescription().get());
-    }
-
-    @Test
-    void withAriaDescription_setAriaDescriptionToNullClearsAriaDescription() {
-        TestComponent component = new TestComponent();
-        component.setAriaDescription("test AriaDescription");
 
         component.setAriaDescription(null);
         Assertions.assertFalse(component.getAriaDescription().isPresent());
     }
 
     @Test
-    void withoutAriaDescribedBy_getAriaDescribedByReturnsEmptyOptional() {
-        TestComponent component = new TestComponent();
-
-        Assertions.assertFalse(component.getAriaDescribedBy().isPresent());
-    }
-
-    @Test
     void setAriaDescribedBy() {
         TestComponent component = new TestComponent();
-        component.setAriaDescribedBy("test AriaDescribedBy");
+        Assertions.assertFalse(component.getAriaDescribedBy().isPresent());
 
-        Assertions.assertEquals("test AriaDescribedBy",
+        component.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
                 component.getAriaDescribedBy().get());
-    }
-
-    @Test
-    void withAriaDescribedBy_setAriaDescribedByToNullClearsAriaDescribedBy() {
-        TestComponent component = new TestComponent();
-        component.setAriaDescribedBy("test AriaDescribedBy");
 
         component.setAriaDescribedBy((String) null);
         Assertions.assertFalse(component.getAriaDescribedBy().isPresent());
     }
 
     @Test
-    void setAriaDescribedByComponent_withExistingId() {
+    void setAriaDescribedByComponent_withoutId() {
         UI ui = new UI();
         TestComponent component = new TestComponent();
         TestComponent descriptionComponent = new TestComponent();
-        descriptionComponent.setId("the-description");
         ui.add(component, descriptionComponent);
 
         component.setAriaDescribedBy(descriptionComponent);
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        Assertions.assertEquals("the-description",
+        String generatedId = descriptionComponent.getId().get();
+        Assertions.assertTrue(generatedId.startsWith("ariadescribedby-"));
+        Assertions.assertEquals(generatedId,
                 component.getAriaDescribedBy().get());
     }
 
     @Test
-    void setAriaDescribedByComponent_withoutId_generatesId() {
+    void setAriaDescribedByComponent_withIdSetBefore() {
         UI ui = new UI();
         TestComponent component = new TestComponent();
         TestComponent descriptionComponent = new TestComponent();
-        Assertions.assertFalse(descriptionComponent.getId().isPresent());
         ui.add(component, descriptionComponent);
 
+        descriptionComponent.setId("description-id");
         component.setAriaDescribedBy(descriptionComponent);
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        Assertions.assertTrue(descriptionComponent.getId().isPresent());
-        Assertions.assertTrue(descriptionComponent.getId().get()
-                .startsWith("ariadescribedby-"));
-        Assertions.assertEquals(descriptionComponent.getId().get(),
+        Assertions.assertEquals("description-id",
                 component.getAriaDescribedBy().get());
     }
 
     @Test
-    void setAriaDescribedByComponent_idSetLater() {
+    void setAriaDescribedByComponent_withIdSetAfter() {
         UI ui = new UI();
         TestComponent component = new TestComponent();
         TestComponent descriptionComponent = new TestComponent();
         ui.add(component, descriptionComponent);
 
         component.setAriaDescribedBy(descriptionComponent);
-        descriptionComponent.setId("manually-set-id");
+        descriptionComponent.setId("description-id");
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        Assertions.assertEquals("manually-set-id",
+        Assertions.assertEquals("description-id",
                 component.getAriaDescribedBy().get());
     }
 }


### PR DESCRIPTION
## Description

Adds a `HasAriaDescription` mixin interface for setting the accessible description of a component, following the `HasAriaLabel` pattern:

- `setAriaDescription(String)` / `getAriaDescription()` for the `aria-description` attribute
- `setAriaDescribedBy(String)` / `getAriaDescribedBy()` for the `aria-describedby` attribute
- `setAriaDescribedBy(Component)` for referencing a description component directly, generating an id for it lazily when needed (same mechanism as `setAriaLabelledBy(Component)`)

Also adds the `aria-description` and `aria-describedby` attribute name constants to `ElementConstants`.

Part of https://github.com/vaadin/web-components/issues/11975

## Type of change

- [x] Feature