### PR TITLE
docs: correct NativeLabel.setFor(String) javadoc null contract

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeLabel.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeLabel.java
@@ -123,10 +123,13 @@ public class NativeLabel extends HtmlContainer {
     /**
      * Sets the id of the component that this label describes. The id should be
      * defined in case the described component is not an ancestor of the label.
+     * <p>
+     * Passing an empty string clears the <code>for</code> attribute, so that
+     * {@link #getFor()} returns an empty optional.
      *
      * @param forId
-     *            the id of the described component, or <code>null</code> if
-     *            there is no value
+     *            the id of the described component, or an empty string to clear
+     *            the <code>for</code> attribute, not <code>null</code>
      */
     public void setFor(String forId) {
         set(forDescriptor, forId);


### PR DESCRIPTION
Corrects the `NativeLabel.setFor(String)` javadoc, which promised `null` support but throws. The real, framework-wide contract is that optional string attributes throw on `null` and are cleared by passing an empty string.

Fixes #25121

Generated with [Claude Code](https://claude.ai/code)