### PR TITLE
fix: make resolveOrGenerateIdLater accept a serializable consumer

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ShadowRoot;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableTriConsumer;
 import com.vaadin.flow.i18n.LocaleChangeEvent;
 import com.vaadin.flow.i18n.LocaleChangeObserver;
@@ -810,6 +811,37 @@ public class ComponentUtil {
     }
 
     /**
+     * Resolves the id of {@code targetComponent} lazily, as described in
+     * {@link #resolveOrGenerateIdLater(Element, Component, String, SerializableConsumer)},
+     * but accepts a consumer that is not necessarily serializable.
+     *
+     * @param sourceElement
+     *            the element whose attachment triggers the resolution, not
+     *            {@code null}
+     * @param targetComponent
+     *            the component whose id should be resolved, not {@code null}
+     * @param generatedIdPrefix
+     *            prefix used when an id needs to be generated, not {@code null}
+     * @param idConsumer
+     *            receives the resolved id at sync time, not {@code null}
+     * @since 25.2
+     * @deprecated use
+     *             {@link #resolveOrGenerateIdLater(Element, Component, String, SerializableConsumer)}
+     *             instead. The pending resolution is stored in the state tree,
+     *             or as an attach listener while {@code sourceElement} is
+     *             detached, so a consumer that is not serializable makes the
+     *             session fail to serialize.
+     */
+    @Deprecated(since = "25.3", forRemoval = true)
+    public static void resolveOrGenerateIdLater(Element sourceElement,
+            Component targetComponent, String generatedIdPrefix,
+            Consumer<String> idConsumer) {
+        resolveOrGenerateIdLater(sourceElement, targetComponent,
+                generatedIdPrefix,
+                (SerializableConsumer<String>) idConsumer::accept);
+    }
+
+    /**
      * Resolves the id of {@code targetComponent} lazily, before the next client
      * response after {@code sourceElement} is attached. If the target still
      * does not have an id at that point, one is generated using
@@ -829,11 +861,10 @@ public class ComponentUtil {
      *            prefix used when an id needs to be generated, not {@code null}
      * @param idConsumer
      *            receives the resolved id at sync time, not {@code null}
-     * @since 25.2
      */
     public static void resolveOrGenerateIdLater(Element sourceElement,
             Component targetComponent, String generatedIdPrefix,
-            Consumer<String> idConsumer) {
+            SerializableConsumer<String> idConsumer) {
         sourceElement.getNode()
                 .runWhenAttached(ui -> ui.getInternals().getStateTree()
                         .beforeClientResponse(sourceElement.getNode(),

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
@@ -15,6 +15,10 @@
  */
 package com.vaadin.flow.component;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -246,6 +250,60 @@ class ComponentUtilTest {
         assertEquals(List.of(contentWithChild, grandchild),
                 ComponentUtil.streamDescendants(composite).toList(),
                 "streamDescendants must recurse through Composite content");
+    }
+
+    @Test
+    void resolveOrGenerateIdLater_attached_pendingResolutionIsSerializable()
+            throws Exception {
+        UI ui = new UI();
+        TestDiv source = new TestDiv();
+        TestDiv target = new TestDiv();
+        target.setId("the-target");
+        ui.add(source, target);
+
+        Element sourceElement = source.getElement();
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, target, "prefix-",
+                id -> sourceElement.setAttribute("data-target", id));
+
+        UI uiCopy = serializeAndDeserialize(ui);
+        uiCopy.getInternals().getStateTree()
+                .runExecutionsBeforeClientResponse();
+
+        assertEquals("the-target", uiCopy.getChildren().findFirst()
+                .orElseThrow().getElement().getAttribute("data-target"));
+    }
+
+    @Test
+    void resolveOrGenerateIdLater_detached_pendingResolutionIsSerializable()
+            throws Exception {
+        TestDiv source = new TestDiv();
+        TestDiv target = new TestDiv();
+        target.setId("the-target");
+
+        // not attached yet, so the resolution is kept as an attach listener
+        Element sourceElement = source.getElement();
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, target, "prefix-",
+                id -> sourceElement.setAttribute("data-target", id));
+
+        TestDiv sourceCopy = serializeAndDeserialize(source);
+        UI ui = new UI();
+        ui.add(sourceCopy);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("the-target",
+                sourceCopy.getElement().getAttribute("data-target"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T serializeAndDeserialize(T instance) throws Exception {
+        ByteArrayOutputStream bs = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bs)) {
+            out.writeObject(instance);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bs.toByteArray()))) {
+            return (T) in.readObject();
+        }
     }
 
 }


### PR DESCRIPTION
The pending id resolution is stored in the state tree, or as an attach listener while the source element is detached, so a plain Consumer made the session fail to serialize. This affected `setAriaLabelledBy(Component)` and `NativeLabel.setFor(Component)`.

Adds an overload taking a `SerializableConsumer` and deprecates the `Consumer` one, so existing code keeps compiling and running as before.

Fixes #25118
