### PR TITLE
fix: cancel a deferred id resolution superseded by a later value

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeLabel.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeLabel.java
@@ -104,9 +104,16 @@ public class NativeLabel extends HtmlContainer {
      * If the provided component does not have an id set, one will be
      * automatically generated.
      * <p>
-     * The id is resolved lazily when the label is attached and sent to the
-     * client. This means the component's id can be set after calling this
-     * method. If no id is set by then, one will be generated.
+     * The {@code for} value is available right away, but a generated id is only
+     * assigned to the described component before the next client response after
+     * the label is attached. This means the component's id can be set after
+     * calling this method, in which case that id is referenced instead. For
+     * that reason the value read with {@link #getFor()} should not be cached
+     * within the same request.
+     * <p>
+     * Calling {@link #setFor(String)} or referencing another component cancels
+     * a pending resolution, leaving the previously described component's id
+     * untouched.
      *
      * @param forComponent
      *            the component that this label describes, not <code>null</code>
@@ -117,7 +124,7 @@ public class NativeLabel extends HtmlContainer {
                     "The provided component cannot be null");
         }
         ComponentUtil.resolveOrGenerateIdLater(getElement(), forComponent,
-                "nativelabel-", this::setFor);
+                "nativelabel-", this::getFor, this::setFor);
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeLabelTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeLabelTest.java
@@ -64,6 +64,57 @@ class NativeLabelTest extends ComponentTest {
     }
 
     @Test
+    void setForComponent_explicitIdSetLater_explicitIdWins() {
+        UI ui = new UI();
+        NativeLabel otherComponent = new NativeLabel();
+        NativeLabel l = (NativeLabel) getComponent();
+        ui.add(l, otherComponent);
+        l.setFor(otherComponent);
+
+        l.setFor("another-input");
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("another-input", l.getFor().orElse(null));
+        assertFalse(otherComponent.getId().isPresent());
+    }
+
+    @Test
+    void setForComponent_clearedLater_forIsCleared() {
+        UI ui = new UI();
+        NativeLabel otherComponent = new NativeLabel();
+        NativeLabel l = (NativeLabel) getComponent();
+        ui.add(l, otherComponent);
+        l.setFor(otherComponent);
+
+        l.setFor("");
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertFalse(l.getFor().isPresent());
+        assertFalse(otherComponent.getId().isPresent());
+    }
+
+    @Test
+    void setForComponent_calledTwice_lastComponentWins() {
+        UI ui = new UI();
+        NativeLabel firstTarget = new NativeLabel();
+        NativeLabel secondTarget = new NativeLabel();
+        NativeLabel l = (NativeLabel) getComponent();
+        ui.add(l, firstTarget, secondTarget);
+
+        l.setFor(firstTarget);
+        l.setFor(secondTarget);
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertFalse(firstTarget.getId().isPresent(),
+                "The superseded target should keep its original id");
+        assertEquals(secondTarget.getId().orElse(null),
+                l.getFor().orElse(null));
+    }
+
+    @Test
     void setForComponent_idSetLater() {
         UI ui = new UI();
         NativeLabel otherComponent = new NativeLabel();

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -40,6 +40,8 @@ import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ShadowRoot;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.function.SerializableTriConsumer;
 import com.vaadin.flow.i18n.LocaleChangeEvent;
 import com.vaadin.flow.i18n.LocaleChangeObserver;
@@ -810,15 +812,11 @@ public class ComponentUtil {
     }
 
     /**
-     * Resolves the id of {@code targetComponent} lazily, before the next client
-     * response after {@code sourceElement} is attached. If the target still
-     * does not have an id at that point, one is generated using
-     * {@code generatedIdPrefix} followed by a random UUID and assigned to the
-     * target. The resolved id is then passed to {@code idConsumer}.
-     * <p>
-     * This allows components that need to reference another component by id
-     * (e.g. for {@code for} or {@code aria-labelledby} attributes) to accept a
-     * {@link Component} instead of requiring the caller to assign an id first.
+     * Resolves the id of {@code targetComponent} lazily, as described in
+     * {@link #resolveOrGenerateIdLater(Element, Component, String, SerializableSupplier, SerializableConsumer)},
+     * but without a getter for the current value, so the resolution cannot
+     * detect that it has been superseded, and with a consumer that is not
+     * necessarily serializable.
      *
      * @param sourceElement
      *            the element whose attachment triggers the resolution, not
@@ -830,23 +828,96 @@ public class ComponentUtil {
      * @param idConsumer
      *            receives the resolved id at sync time, not {@code null}
      * @since 25.2
+     * @deprecated use
+     *             {@link #resolveOrGenerateIdLater(Element, Component, String, SerializableSupplier, SerializableConsumer)}
+     *             instead. Without a getter, a value set after this call is
+     *             overwritten when the resolution runs, and the target of a
+     *             superseded resolution is still assigned a generated id. In
+     *             addition, the pending resolution is stored in the state tree,
+     *             or as an attach listener while {@code sourceElement} is
+     *             detached, so a consumer that is not serializable makes the
+     *             session fail to serialize.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     public static void resolveOrGenerateIdLater(Element sourceElement,
             Component targetComponent, String generatedIdPrefix,
             Consumer<String> idConsumer) {
+        sourceElement.getNode().runWhenAttached(
+                ui -> ui.getInternals().getStateTree().beforeClientResponse(
+                        sourceElement.getNode(), context -> idConsumer.accept(
+                                targetComponent.getId().orElseGet(() -> {
+                                    String generated = generatedIdPrefix
+                                            + UUID.randomUUID();
+                                    targetComponent.setId(generated);
+                                    return generated;
+                                }))));
+    }
+
+    /**
+     * References {@code targetComponent} by id, generating an id for it if
+     * needed, so that components can accept a {@link Component} for references
+     * such as {@code for} or {@code aria-labelledby} instead of requiring the
+     * caller to assign an id first.
+     * <p>
+     * The id that the target is going to have is passed to {@code idConsumer}
+     * immediately: either the target's current id, or one generated from
+     * {@code generatedIdPrefix} followed by a random UUID. A generated id is
+     * only assigned to the target before the next client response after
+     * {@code sourceElement} is attached, so the target's own id can still be
+     * set after this call, in which case {@code idConsumer} receives that id
+     * instead.
+     * <p>
+     * The value read by {@code idGetter} tells the pending resolution whether
+     * it is still the one in effect. If the value differs from what was passed
+     * to {@code idConsumer}, because the caller has set an explicit value,
+     * cleared it, or referenced another component in the meantime, the pending
+     * resolution does nothing and the target keeps its original, possibly
+     * absent, id.
+     * <p>
+     * Since the value can still change before the next client response, callers
+     * should not cache the value read through {@code idGetter} within the same
+     * request.
+     *
+     * @param sourceElement
+     *            the element whose attachment triggers the resolution, not
+     *            {@code null}
+     * @param targetComponent
+     *            the component whose id should be resolved, not {@code null}
+     * @param generatedIdPrefix
+     *            prefix used when an id needs to be generated, not {@code null}
+     * @param idGetter
+     *            reads the current value written through {@code idConsumer},
+     *            not {@code null}
+     * @param idConsumer
+     *            receives the id referencing the target, not {@code null}
+     */
+    public static void resolveOrGenerateIdLater(Element sourceElement,
+            Component targetComponent, String generatedIdPrefix,
+            SerializableSupplier<Optional<String>> idGetter,
+            SerializableConsumer<String> idConsumer) {
+        // Written right away so that a value set later, including a cleared
+        // one, is recognized as superseding this resolution
+        String pendingId = targetComponent.getId()
+                .orElseGet(() -> generatedIdPrefix + UUID.randomUUID());
+        idConsumer.accept(pendingId);
+
         sourceElement.getNode()
                 .runWhenAttached(ui -> ui.getInternals().getStateTree()
                         .beforeClientResponse(sourceElement.getNode(),
                                 context -> {
+                                    if (!Optional.of(pendingId)
+                                            .equals(idGetter.get())) {
+                                        return;
+                                    }
                                     String id = targetComponent.getId()
                                             .orElseGet(() -> {
-                                                String generated = generatedIdPrefix
-                                                        + UUID.randomUUID();
                                                 targetComponent
-                                                        .setId(generated);
-                                                return generated;
+                                                        .setId(pendingId);
+                                                return pendingId;
                                             });
-                                    idConsumer.accept(id);
+                                    if (!pendingId.equals(id)) {
+                                        idConsumer.accept(id);
+                                    }
                                 }));
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -108,7 +108,16 @@ public interface HasAriaDescription extends HasElement {
      * the given description component.
      * <p>
      * The description component does not need an ID: if it has none by the time
-     * the value is sent to the client, one is generated automatically.
+     * the value is sent to the client, one is generated automatically. The
+     * attribute value is available right away, but a generated ID is only
+     * assigned to the description component before the next client response
+     * after this component is attached, so the value read with
+     * {@link #getAriaDescribedBy()} should not be cached within the same
+     * request.
+     * <p>
+     * Calling {@link #setAriaDescribedBy(String)}, also with {@code null} to
+     * remove the attribute, or referencing another component cancels a pending
+     * resolution, leaving the previously referenced component's ID untouched.
      * <p>
      * The description component must be in the same DOM scope as this
      * component, otherwise screen readers will fail to announce the description
@@ -129,7 +138,7 @@ public interface HasAriaDescription extends HasElement {
         }
         ComponentUtil.resolveOrGenerateIdLater(getElement(),
                 descriptionComponent, "ariadescribedby-",
-                this::setAriaDescribedBy);
+                this::getAriaDescribedBy, this::setAriaDescribedBy);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
@@ -115,9 +115,16 @@ public interface HasAriaLabel extends HasElement {
      * component. If {@code labelComponent} does not have an id, one is
      * generated automatically.
      * <p>
-     * The id is resolved lazily before the next client response after this
-     * component is attached, so the label component's id can be set after
-     * calling this method. If no id is set by then, one will be generated.
+     * The aria-labelledby value is available right away, but a generated id is
+     * only assigned to the label component before the next client response
+     * after this component is attached, so the label component's id can be set
+     * after calling this method, in which case that id is referenced instead.
+     * For that reason the value read with {@link #getAriaLabelledBy()} should
+     * not be cached within the same request.
+     * <p>
+     * Calling {@link #setAriaLabelledBy(String)}, also with {@code null} to
+     * clear the value, or referencing another component cancels a pending
+     * resolution, leaving the previously referenced component's id untouched.
      * <p>
      * The label component <b>must</b> be in the same DOM scope as this
      * component, otherwise screen readers may fail to announce the label
@@ -137,7 +144,8 @@ public interface HasAriaLabel extends HasElement {
                     "The provided component cannot be null");
         }
         ComponentUtil.resolveOrGenerateIdLater(getElement(), labelComponent,
-                "arialabelledby-", this::setAriaLabelledBy);
+                "arialabelledby-", this::getAriaLabelledBy,
+                this::setAriaLabelledBy);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
@@ -15,8 +15,13 @@
  */
 package com.vaadin.flow.component;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +30,8 @@ import com.vaadin.flow.component.ComponentTest.TestComponent;
 import com.vaadin.flow.component.ComponentTest.TestDiv;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -246,6 +253,129 @@ class ComponentUtilTest {
         assertEquals(List.of(contentWithChild, grandchild),
                 ComponentUtil.streamDescendants(composite).toList(),
                 "streamDescendants must recurse through Composite content");
+    }
+
+    @Test
+    void resolveOrGenerateIdLater_existingId_valueSetImmediately() {
+        UI ui = new UI();
+        TestDiv source = new TestDiv();
+        TestDiv target = new TestDiv();
+        target.setId("the-target");
+        ui.add(source, target);
+
+        Element sourceElement = source.getElement();
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, target, "prefix-",
+                () -> Optional
+                        .ofNullable(sourceElement.getAttribute("data-target")),
+                id -> sourceElement.setAttribute("data-target", id));
+
+        assertEquals("the-target", sourceElement.getAttribute("data-target"),
+                "The value should be available before the resolution runs");
+    }
+
+    @Test
+    void resolveOrGenerateIdLater_explicitValueSetLater_resolutionSuperseded() {
+        UI ui = new UI();
+        TestDiv source = new TestDiv();
+        TestDiv target = new TestDiv();
+        ui.add(source, target);
+
+        Element sourceElement = source.getElement();
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, target, "prefix-",
+                () -> Optional
+                        .ofNullable(sourceElement.getAttribute("data-target")),
+                id -> sourceElement.setAttribute("data-target", id));
+        sourceElement.setAttribute("data-target", "explicit");
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("explicit", sourceElement.getAttribute("data-target"));
+        assertFalse(target.getId().isPresent(),
+                "No id should be generated for a superseded target");
+    }
+
+    @Test
+    void resolveOrGenerateIdLater_calledTwice_firstResolutionSuperseded() {
+        UI ui = new UI();
+        TestDiv source = new TestDiv();
+        TestDiv firstTarget = new TestDiv();
+        TestDiv secondTarget = new TestDiv();
+        ui.add(source, firstTarget, secondTarget);
+
+        Element sourceElement = source.getElement();
+        SerializableSupplier<Optional<String>> valueGetter = () -> Optional
+                .ofNullable(sourceElement.getAttribute("data-target"));
+        SerializableConsumer<String> valueSetter = id -> sourceElement
+                .setAttribute("data-target", id);
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, firstTarget,
+                "prefix-", valueGetter, valueSetter);
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, secondTarget,
+                "prefix-", valueGetter, valueSetter);
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertFalse(firstTarget.getId().isPresent(),
+                "No id should be generated for a superseded target");
+        assertEquals(secondTarget.getId().orElse(null),
+                sourceElement.getAttribute("data-target"));
+    }
+
+    @Test
+    void resolveOrGenerateIdLater_attached_pendingResolutionIsSerializable()
+            throws Exception {
+        UI ui = new UI();
+        TestDiv source = new TestDiv();
+        TestDiv target = new TestDiv();
+        target.setId("the-target");
+        ui.add(source, target);
+
+        Element sourceElement = source.getElement();
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, target, "prefix-",
+                () -> Optional
+                        .ofNullable(sourceElement.getAttribute("data-target")),
+                id -> sourceElement.setAttribute("data-target", id));
+
+        UI uiCopy = serializeAndDeserialize(ui);
+        uiCopy.getInternals().getStateTree()
+                .runExecutionsBeforeClientResponse();
+
+        assertEquals("the-target", uiCopy.getChildren().findFirst()
+                .orElseThrow().getElement().getAttribute("data-target"));
+    }
+
+    @Test
+    void resolveOrGenerateIdLater_detached_pendingResolutionIsSerializable()
+            throws Exception {
+        TestDiv source = new TestDiv();
+        TestDiv target = new TestDiv();
+        target.setId("the-target");
+
+        // not attached yet, so the resolution is kept as an attach listener
+        Element sourceElement = source.getElement();
+        ComponentUtil.resolveOrGenerateIdLater(sourceElement, target, "prefix-",
+                () -> Optional
+                        .ofNullable(sourceElement.getAttribute("data-target")),
+                id -> sourceElement.setAttribute("data-target", id));
+
+        TestDiv sourceCopy = serializeAndDeserialize(source);
+        UI ui = new UI();
+        ui.add(sourceCopy);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("the-target",
+                sourceCopy.getElement().getAttribute("data-target"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T serializeAndDeserialize(T instance) throws Exception {
+        ByteArrayOutputStream bs = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bs)) {
+            out.writeObject(instance);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bs.toByteArray()))) {
+            return (T) in.readObject();
+        }
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
@@ -84,6 +84,55 @@ class HasAriaDescriptionTest {
     }
 
     @Test
+    void setAriaDescribedByComponent_explicitValueSetAfter_explicitValueWins() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent descriptionComponent = new TestComponent();
+        ui.add(component, descriptionComponent);
+
+        component.setAriaDescribedBy(descriptionComponent);
+        component.setAriaDescribedBy("explicit-id");
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        Assertions.assertEquals("explicit-id",
+                component.getAriaDescribedBy().get());
+        Assertions.assertFalse(descriptionComponent.getId().isPresent());
+    }
+
+    @Test
+    void setAriaDescribedByComponent_removedAfter_attributeStaysRemoved() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent descriptionComponent = new TestComponent();
+        ui.add(component, descriptionComponent);
+
+        component.setAriaDescribedBy(descriptionComponent);
+        component.setAriaDescribedBy((String) null);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        Assertions.assertFalse(component.getAriaDescribedBy().isPresent());
+        Assertions.assertFalse(descriptionComponent.getId().isPresent());
+    }
+
+    @Test
+    void setAriaDescribedByComponent_calledTwice_lastComponentWins() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent firstDescription = new TestComponent();
+        TestComponent secondDescription = new TestComponent();
+        ui.add(component, firstDescription, secondDescription);
+
+        component.setAriaDescribedBy(firstDescription);
+        component.setAriaDescribedBy(secondDescription);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        Assertions.assertFalse(firstDescription.getId().isPresent(),
+                "The superseded description should keep its original id");
+        Assertions.assertEquals(secondDescription.getId().orElse(null),
+                component.getAriaDescribedBy().orElse(null));
+    }
+
+    @Test
     void setAriaDescribedByComponent_withIdSetAfter() {
         UI ui = new UI();
         TestComponent component = new TestComponent();

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaLabelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaLabelTest.java
@@ -138,6 +138,54 @@ class HasAriaLabelTest {
     }
 
     @Test
+    void setAriaLabelledByComponent_explicitValueSetLater_explicitValueWins() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent labelComponent = new TestComponent();
+        ui.add(component, labelComponent);
+
+        component.setAriaLabelledBy(labelComponent);
+        component.setAriaLabelledBy("explicit-id");
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("explicit-id", component.getAriaLabelledBy().get());
+        assertFalse(labelComponent.getId().isPresent());
+    }
+
+    @Test
+    void setAriaLabelledByComponent_clearedLater_ariaLabelledByIsCleared() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent labelComponent = new TestComponent();
+        ui.add(component, labelComponent);
+
+        component.setAriaLabelledBy(labelComponent);
+        component.setAriaLabelledBy((String) null);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertFalse(component.getAriaLabelledBy().isPresent());
+        assertFalse(labelComponent.getId().isPresent());
+    }
+
+    @Test
+    void setAriaLabelledByComponent_calledTwice_lastComponentWins() {
+        UI ui = new UI();
+        TestComponent component = new TestComponent();
+        TestComponent firstLabel = new TestComponent();
+        TestComponent secondLabel = new TestComponent();
+        ui.add(component, firstLabel, secondLabel);
+
+        component.setAriaLabelledBy(firstLabel);
+        component.setAriaLabelledBy(secondLabel);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertFalse(firstLabel.getId().isPresent(),
+                "The superseded label should keep its original id");
+        assertEquals(secondLabel.getId().orElse(null),
+                component.getAriaLabelledBy().orElse(null));
+    }
+
+    @Test
     void setAriaLabelledByComponent_idSetLater() {
         UI ui = new UI();
         TestComponent component = new TestComponent();


### PR DESCRIPTION
setAriaLabelledBy(Component) and NativeLabel.setFor(Component) resolve the target's id before the next client response. The pending resolution could not be cancelled, so it overwrote any value set afterwards in the same request, and a target that nothing referenced any more was still assigned a generated id.

The id that the target is going to have is now passed to the caller right away, and the pending resolution assigns a generated id to the target only while that value is still in effect. Setting an explicit value, clearing it, or referencing another component thus cancels the resolution, leaving the superseded target's id untouched. Since the value follows the target's id if that changes before the next client response, it must not be cached within the same request.

resolveOrGenerateIdLater takes a getter for the current value to detect this, and both the getter and the consumer are serializable, so the pending resolution kept in the state tree, or as an attach listener while the source element is detached, no longer makes the session fail to serialize.

Fixes #25119
Fixes #25118
