### PR TITLE
chore: remove legacy jsinterop BOM import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
     <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jsinterop.version>1.0.2</jsinterop.version>
     <sonar.java.source>21</sonar.java.source>
     <sonar.issuesReport.console.enable>true</sonar.issuesReport.console.enable>
     <sonar.issuesReport.html.enable>true</sonar.issuesReport.html.enable>
@@ -174,14 +173,6 @@
         <groupId>jakarta.platform</groupId>
         <artifactId>jakarta.jakartaee-bom</artifactId>
         <version>${jakarta.ee.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.google.jsinterop</groupId>
-        <artifactId>jsinterop</artifactId>
-        <version>${jsinterop.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The root pom imported com.google.jsinterop:jsinterop:1.0.2, which was superseded once flow-client started importing the GWT BOM; that BOM pins jsinterop-annotations to 2.0.0 and, being declared in the module itself, already won over the parent. Maven 4 flags the two imports as conflicting.

Fixes #25133
