### PR TITLE
refactor: remove aria-description API from HasAriaDescription

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaDescription.java
@@ -23,58 +23,17 @@ import com.vaadin.flow.dom.ElementConstants;
  * A generic interface for components that have an accessible description.
  * <p>
  * The accessible description provides supplementary information about the
- * component to assistive technologies, such as screen readers.
- * <p>
- * It can be set as plain text with the {@code aria-description} attribute, or
- * by referencing existing elements on the page with the
- * {@code aria-describedby} attribute. Prefer the latter when the description is
- * already visible to all users.
+ * component to assistive technologies, such as screen readers. It is set by
+ * referencing existing elements on the page with the {@code aria-describedby}
+ * attribute.
  *
  * @author Vaadin Ltd
  * @since 25.3
- * @see <a href=
- *      "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description">
- *      MDN: aria-description</a>
  * @see <a href=
  *      "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby">
  *      MDN: aria-describedby</a>
  */
 public interface HasAriaDescription extends HasElement {
-
-    /**
-     * Sets the {@code aria-description} attribute of the component to the given
-     * text.
-     * <p>
-     * If both {@code aria-description} and {@code aria-describedby} are
-     * present, {@code aria-describedby} takes precedence.
-     *
-     * @param ariaDescription
-     *            the description text, or {@code null} to remove the attribute
-     * @see <a href=
-     *      "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description">
-     *      MDN: aria-description</a>
-     */
-    default void setAriaDescription(String ariaDescription) {
-        if (ariaDescription != null) {
-            getElement().setAttribute(
-                    ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME,
-                    ariaDescription);
-        } else {
-            getElement().removeAttribute(
-                    ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME);
-        }
-    }
-
-    /**
-     * Gets the {@code aria-description} attribute of the component.
-     *
-     * @return an optional aria-description, or an empty optional if none has
-     *         been set
-     */
-    default Optional<String> getAriaDescription() {
-        return Optional.ofNullable(getElement().getAttribute(
-                ElementConstants.ARIA_DESCRIPTION_ATTRIBUTE_NAME));
-    }
 
     /**
      * Sets the {@code aria-describedby} attribute of the component to one or

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementConstants.java
@@ -456,12 +456,6 @@ public class ElementConstants {
      * @since 25.3
      */
     public static final String ARIA_DESCRIBEDBY_ATTRIBUTE_NAME = "aria-describedby";
-    /**
-     * The aria-description attribute.
-     *
-     * @since 25.3
-     */
-    public static final String ARIA_DESCRIPTION_ATTRIBUTE_NAME = "aria-description";
 
     private ElementConstants() {
         // Constants only

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaDescriptionTest.java
@@ -27,19 +27,6 @@ class HasAriaDescriptionTest {
     }
 
     @Test
-    void setAriaDescription() {
-        TestComponent component = new TestComponent();
-        Assertions.assertFalse(component.getAriaDescription().isPresent());
-
-        component.setAriaDescription("description text");
-        Assertions.assertEquals("description text",
-                component.getAriaDescription().get());
-
-        component.setAriaDescription(null);
-        Assertions.assertFalse(component.getAriaDescription().isPresent());
-    }
-
-    @Test
     void setAriaDescribedBy() {
         TestComponent component = new TestComponent();
         Assertions.assertFalse(component.getAriaDescribedBy().isPresent());


### PR DESCRIPTION
## Description

Removes `setAriaDescription(String)` and `getAriaDescription()` from the `HasAriaDescription` interface (added in #25117, unreleased) because assistive technology support for the `aria-description` attribute is still not ideal. The API can be reconsidered later once support improves.

Part of https://github.com/vaadin/web-components/issues/11975