### PR TITLE
fix: keep replaced children until the new ones are in place

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -1105,8 +1105,21 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             /*
              * When a full clear event is fired, all nodes must be removed,
              * including the nodes the server doesn't know about.
+             *
+             * The state tree is already fully updated at this point, so a
+             * non-empty children list means the server is replacing the
+             * contents rather than only emptying them. In that case the old
+             * nodes are kept until the replacements have been inserted: a
+             * container that is momentarily empty loses the scroll position of
+             * the surrounding scrollable element, since the browser clamps the
+             * offset to the collapsed scroll range.
              */
-            removeAllChildren(htmlNode);
+            if (context.node.getList(NodeFeatures.ELEMENT_CHILDREN)
+                    .length() == 0) {
+                removeAllChildren(htmlNode);
+            } else {
+                removeAllChildrenAfterReplacement(context);
+            }
         } else {
             JsArray<?> remove = event.getRemove();
             for (int i = 0; i < remove.length(); i++) {
@@ -1138,6 +1151,56 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         DomElement wrap = DomApi.wrap(htmlNode);
         while (wrap.getFirstChild() != null) {
             wrap.removeChild(wrap.getFirstChild());
+        }
+    }
+
+    /**
+     * Removes the children the node has right now, but only once the whole
+     * change set has been applied so that the nodes replacing them are already
+     * in place.
+     *
+     * @param context
+     *            the binding context of the node whose children are replaced
+     */
+    private void removeAllChildrenAfterReplacement(BindingContext context) {
+        // getChildNodes returns the live DOM child list, so the nodes to remove
+        // are collected before anything is inserted
+        JsArray<Node> liveChildren = DomApi.wrap(context.htmlNode)
+                .getChildNodes();
+        JsArray<Node> replacedChildren = JsCollections.array();
+        for (int i = 0; i < liveChildren.length(); i++) {
+            replacedChildren.push(liveChildren.get(i));
+        }
+
+        Reactive.addPostFlushListener(
+                () -> removeReplacedChildren(context, replacedChildren));
+    }
+
+    private void removeReplacedChildren(BindingContext context,
+            JsArray<Node> replacedChildren) {
+        Node htmlNode = context.htmlNode;
+
+        NodeList nodeChildren = context.node
+                .getList(NodeFeatures.ELEMENT_CHILDREN);
+        JsSet<Node> keptChildren = JsCollections.set();
+        for (int i = 0; i < nodeChildren.length(); i++) {
+            Node domNode = ((StateNode) nodeChildren.get(i)).getDomNode();
+            if (domNode != null) {
+                keptChildren.add(domNode);
+            }
+        }
+
+        for (int i = 0; i < replacedChildren.length(); i++) {
+            Node child = replacedChildren.get(i);
+            /*
+             * A node that the server re-added to this same parent is part of
+             * the new contents, and a node that the server moved to another
+             * parent now belongs to that parent. Neither may be removed here.
+             */
+            if (!keptChildren.has(child)
+                    && DomApi.wrap(child).getParentNode() == htmlNode) {
+                DomApi.wrap(htmlNode).removeChild(child);
+            }
         }
     }
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -1113,6 +1113,12 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
              * container that is momentarily empty loses the scroll position of
              * the surrounding scrollable element, since the browser clamps the
              * offset to the collapsed scroll range.
+             *
+             * The container then holds the old and the new contents at the same
+             * time, so a layout while both are attached measures roughly twice
+             * the final height. That is the trade for keeping the scroll range
+             * alive, and it is the harmless direction: the offset is clamped
+             * when the range shrinks, never when it grows.
              */
             if (context.node.getList(NodeFeatures.ELEMENT_CHILDREN)
                     .length() == 0) {
@@ -1180,15 +1186,8 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             JsArray<Node> replacedChildren) {
         Node htmlNode = context.htmlNode;
 
-        NodeList nodeChildren = context.node
-                .getList(NodeFeatures.ELEMENT_CHILDREN);
-        JsSet<Node> keptChildren = JsCollections.set();
-        for (int i = 0; i < nodeChildren.length(); i++) {
-            Node domNode = ((StateNode) nodeChildren.get(i)).getDomNode();
-            if (domNode != null) {
-                keptChildren.add(domNode);
-            }
-        }
+        JsSet<Node> keptChildren = getMappedDomNodes(
+                context.node.getList(NodeFeatures.ELEMENT_CHILDREN));
 
         for (int i = 0; i < replacedChildren.length(); i++) {
             Node child = replacedChildren.get(i);
@@ -1249,18 +1248,36 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
     private static Node getFirstNodeMappedAsStateNode(
             NodeList mappedNodeChildren, Node htmlNode) {
+        JsSet<Node> mappedDomNodes = getMappedDomNodes(mappedNodeChildren);
 
         JsArray<Node> clientList = DomApi.wrap(htmlNode).getChildNodes();
         for (int i = 0; i < clientList.length(); i++) {
             Node clientNode = clientList.get(i);
-            for (int j = 0; j < mappedNodeChildren.length(); j++) {
-                StateNode stateNode = (StateNode) mappedNodeChildren.get(j);
-                if (clientNode.equals(stateNode.getDomNode())) {
-                    return clientNode;
-                }
+            if (mappedDomNodes.has(clientNode)) {
+                return clientNode;
             }
         }
         return null;
+    }
+
+    /**
+     * Collects the DOM nodes of the given state nodes into a set, so that the
+     * nodes currently in the DOM can be matched against them without scanning
+     * the state node list for each of them.
+     *
+     * @param stateNodes
+     *            the state nodes to collect the DOM nodes of
+     * @return the DOM nodes of the state nodes that have one
+     */
+    private static JsSet<Node> getMappedDomNodes(NodeList stateNodes) {
+        JsSet<Node> domNodes = JsCollections.set();
+        for (int i = 0; i < stateNodes.length(); i++) {
+            Node domNode = ((StateNode) stateNodes.get(i)).getDomNode();
+            if (domNode != null) {
+                domNodes.add(domNode);
+            }
+        }
+        return domNodes;
     }
 
     private StateNode getPreviousSibling(int index, BindingContext context) {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -511,6 +511,80 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         assertNull(childElement.getParentElement());
     }
 
+    public void testClearAndAddChildren_replacementAddedBeforeOldChildRemoved() {
+        Binder.bind(node, element);
+
+        children.add(0, createChildNode("old"));
+        Reactive.flush();
+
+        Element oldElement = element.getFirstElementChild();
+
+        children.clear();
+        children.add(0, createChildNode("new"));
+
+        /*
+         * A flush listener registered after the splice events has run by the
+         * time the children handlers are done but before the old children are
+         * removed, which is where the container must not have been emptied: an
+         * empty container loses the scroll position of the scrollable element
+         * around it.
+         */
+        int[] childCountWhileReplacing = new int[1];
+        Reactive.addFlushListener(
+                () -> childCountWhileReplacing[0] = element
+                        .getChildElementCount());
+
+        Reactive.flush();
+
+        assertEquals(2, childCountWhileReplacing[0]);
+
+        assertEquals(1, element.getChildElementCount());
+        assertEquals("new", element.getFirstElementChild().getId());
+        assertNull(oldElement.getParentElement());
+    }
+
+    public void testClearChildrenWithoutReplacement_allNodesRemoved() {
+        Binder.bind(node, element);
+
+        children.add(0, createChildNode("child"));
+        Reactive.flush();
+
+        // a node the server does not know about
+        element.appendChild(Browser.getDocument().createAnchorElement());
+
+        children.clear();
+        Reactive.flush();
+
+        assertEquals(0, element.getChildElementCount());
+    }
+
+    public void testClearChildren_reAddedAndMovedChildrenKept() {
+        Binder.bind(node, element);
+
+        StateNode container = createChildNode(null, "div");
+        StateNode childNode = createChildNode("child");
+        children.add(0, container);
+        children.add(1, childNode);
+        Reactive.flush();
+
+        HTMLCollection initialChildren = element.getChildren();
+        Element containerElement = (Element) initialChildren.at(0);
+        Element childElement = (Element) initialChildren.at(1);
+
+        // the server empties the node, adds the container back and moves the
+        // child into the container
+        children.clear();
+        children.add(0, container);
+        container.getList(NodeFeatures.ELEMENT_CHILDREN).add(0, childNode);
+
+        Reactive.flush();
+
+        assertEquals(1, element.getChildElementCount());
+        assertSame(containerElement, element.getFirstElementChild());
+        assertEquals(1, containerElement.getChildElementCount());
+        assertSame(childElement, containerElement.getFirstElementChild());
+    }
+
     public void testRemoveChildPosition() {
         Binder.bind(node, element);
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ClearAndReplaceChildrenView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ClearAndReplaceChildrenView.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.ClearAndReplaceChildrenView", layout = ViewTestLayout.class)
+public class ClearAndReplaceChildrenView extends AbstractDivView {
+
+    private final Div content = new Div();
+
+    public ClearAndReplaceChildrenView() {
+        Div scroller = new Div(content);
+        scroller.setId("scroller");
+        scroller.getStyle().set("height", "200px").set("overflow", "auto");
+
+        fillContent();
+
+        add(createButton("Replace content", "replace", event -> fillContent()),
+                scroller);
+    }
+
+    private void fillContent() {
+        content.removeAll();
+
+        Div rows = new Div();
+        for (int i = 1; i <= 100; i++) {
+            Div row = new Div("Row " + i);
+            row.getStyle().set("height", "30px");
+            rows.add(row);
+        }
+        content.add(rows);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ClearAndReplaceChildrenIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ClearAndReplaceChildrenIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ClearAndReplaceChildrenIT extends ChromeBrowserTest {
+
+    /**
+     * A container that is momentarily empty makes the browser clamp the scroll
+     * offset of the scrollable element around it to the collapsed scroll range,
+     * and the offset is not restored when the contents come back. Whether the
+     * offset visibly breaks depends on how eagerly the browser clamps, so this
+     * asserts the invariant that the fix provides rather than the symptom: the
+     * DOM mutations replacing the contents never leave the container empty.
+     */
+    @Test
+    public void replaceContent_containerIsNeverEmpty() {
+        open();
+        waitForElementPresent(By.id("scroller"));
+
+        getCommandExecutor().executeScript(
+                """
+                        const content = document.getElementById('scroller').firstElementChild;
+                        content.firstElementChild.dataset.replaced = 'true';
+                        let childCount = content.childElementCount;
+                        window.minChildCount = childCount;
+                        window.maxChildCount = childCount;
+                        new MutationObserver((records) => {
+                          for (const record of records) {
+                            childCount -= record.removedNodes.length;
+                            childCount += record.addedNodes.length;
+                            window.minChildCount = Math.min(window.minChildCount, childCount);
+                            window.maxChildCount = Math.max(window.maxChildCount, childCount);
+                          }
+                        }).observe(content, { childList: true });
+                        """);
+
+        findElement(By.id("replace")).click();
+
+        waitUntil(driver -> getCommandExecutor().executeScript(
+                """
+                        const content = document.getElementById('scroller').firstElementChild;
+                        return content.childElementCount === 1
+                            && !content.firstElementChild.dataset.replaced;
+                        """));
+
+        Long minChildCount = (Long) getCommandExecutor()
+                .executeScript("return window.minChildCount;");
+        Long maxChildCount = (Long) getCommandExecutor()
+                .executeScript("return window.maxChildCount;");
+
+        // the replacement and the old contents overlap, which also proves the
+        // observer saw both mutations rather than the counts being untouched
+        Assert.assertEquals(
+                "The replacement should be added before the old contents are removed",
+                2L, maxChildCount.longValue());
+        Assert.assertEquals(
+                "The container should never be emptied while its contents are replaced",
+                1L, minChildCount.longValue());
+    }
+}


### PR DESCRIPTION
When the server clears a container and refills it in the same round trip, the client applied the two changes as separate steps: the clear emptied the container, and only then were the replacements inserted. While the container is empty the scrollable range around it collapses, and a layout in that window makes the browser reduce the scroll offset and keep the reduced value once the contents are back. Firefox runs into this with content that gets its size asynchronously, such as a FormLayout, so a surrounding Scroller jumps back towards the top after a rebuild.

The children of a cleared node are now removed once the whole change set has been applied, so the replacements are attached while the old nodes are still there and the container is never empty. Nodes that the server moved to another parent and nodes that it added back to the same parent are left alone. A clear with no replacements still empties the container right away.

Fixes #24053
