### PR TITLE
chore: deprecate remaining user agent and platform detection methods

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -33,7 +33,6 @@ import com.vaadin.flow.component.screenorientation.ScreenOrientationType;
 import com.vaadin.flow.component.wakelock.WakeLockAvailability;
 import com.vaadin.flow.component.webshare.WebShareSupport;
 import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.server.VaadinSession;
 
 /**
  * Provides extended information about the web browser, such as screen
@@ -395,12 +394,33 @@ public class ExtendedClientDetails implements Serializable {
     }
 
     /**
+     * Gets the raw platform string reported by the browser through
+     * {@code window.navigator.platform}, for example {@code "iPhone"},
+     * {@code "MacIntel"} or {@code "Linux x86_64"}.
+     * <p>
+     * The underlying browser API is deprecated and the values it reports are
+     * neither standardized nor reliable: browsers freeze, spoof or omit them,
+     * and the same platform string is reported for different devices (iPadOS
+     * reports {@code "MacIntel"}, the same value as a desktop Mac). Prefer
+     * feature detection over branching on this value.
+     *
+     * @return the platform reported by the browser, or {@code null} if the
+     *         browser did not report one
+     */
+    public String getNavigatorPlatform() {
+        return navigatorPlatform;
+    }
+
+    /**
      * Check if the browser is run on IPad.
      *
      * @return true if run on IPad false if the user is not using IPad or if no
      *         information from the browser is present
      * @since 2.2
+     * @deprecated use feature detection instead of platform detection, or
+     *             inspect {@link #getNavigatorPlatform()} directly
      */
+    @Deprecated(since = "25.3")
     public boolean isIPad() {
         return navigatorPlatform != null && (navigatorPlatform
                 .startsWith("iPad")
@@ -413,11 +433,14 @@ public class ExtendedClientDetails implements Serializable {
      * @return {@code true} if run on IOS , {@code false} if the user is not
      *         using IOS or if no information from the browser is present
      * @since 2.2
+     * @deprecated use feature detection instead of platform detection, or
+     *             inspect {@link #getNavigatorPlatform()} directly
      */
+    @Deprecated(since = "25.3")
     public boolean isIOS() {
-        return isIPad() || VaadinSession.getCurrent().getBrowser().isIPhone()
-                || (navigatorPlatform != null
-                        && navigatorPlatform.startsWith("iPod"));
+        return isIPad() || (navigatorPlatform != null
+                && (navigatorPlatform.startsWith("iPhone")
+                        || navigatorPlatform.startsWith("iPod")));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -356,13 +356,15 @@ public class WebBrowser implements Serializable {
      *
      * @return true if run on IPhone false if the user is not using IPhone or if
      *         no information on the browser is present
+     * @deprecated use a parsing library like ua-parser/uap-java to parse the
+     *             user agent from {@link #getUserAgent()}
      */
+    @Deprecated(since = "25.3")
     public boolean isIPhone() {
-        return userAgent != null
-                && (userAgent.contains("macintosh")
-                        || userAgent.contains("mac osx")
-                        || userAgent.contains("mac os x"))
-                && userAgent.contains("iphone");
+        if (getBrowserDetails() == null) {
+            return false;
+        }
+        return browserDetails.isIPhone();
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -15,24 +15,14 @@
  */
 package com.vaadin.flow.component.page;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import com.vaadin.flow.internal.CurrentInstance;
-import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.WebBrowser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExtendedClientDetailsTest {
-
-    @AfterEach
-    void tearDown() {
-        CurrentInstance.clearAll();
-    }
 
     @Test
     void initializeWithClientValues_gettersReturnExpectedValues() {
@@ -86,62 +76,31 @@ class ExtendedClientDetailsTest {
     }
 
     @Test
-    void differentNavigatorPlatformDetails_Ipod_isIOSReturnsExpectedValue() {
-        ExtendedClientDetails details = new ExtendBuilder()
-                .setNavigatorPlatform("iPod ..").buildDetails();
+    void differentNavigatorPlatformDetails_isIOSReturnsExpectedValue() {
+        ExtendBuilder detailsBuilder = new ExtendBuilder();
 
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        CurrentInstance.setCurrent(session);
-        WebBrowser browser = Mockito.mock(WebBrowser.class);
-        Mockito.when(session.getBrowser()).thenReturn(browser);
-        Mockito.when(browser.isIPhone()).thenReturn(false);
+        assertFalse(detailsBuilder.buildDetails().isIOS(), "Linux is not iOS");
 
-        assertTrue(details.isIOS());
+        detailsBuilder.setNavigatorPlatform("iPhone");
+        assertTrue(detailsBuilder.buildDetails().isIOS(), "'iPhone' is iOS");
 
-        CurrentInstance.clearAll();
+        detailsBuilder.setNavigatorPlatform("iPod touch");
+        assertTrue(detailsBuilder.buildDetails().isIOS(),
+                "'iPod touch' is iOS");
+
+        detailsBuilder.setNavigatorPlatform("iPad");
+        assertTrue(detailsBuilder.buildDetails().isIOS(), "an iPad is iOS");
     }
 
     @Test
-    void isIOS_isIPad_returnsTrue() {
-        ExtendedClientDetails details = Mockito
-                .mock(ExtendedClientDetails.class);
-        Mockito.doCallRealMethod().when(details).isIOS();
-        Mockito.when(details.isIPad()).thenReturn(true);
+    void getNavigatorPlatform_returnsValueReportedByBrowser() {
+        ExtendBuilder detailsBuilder = new ExtendBuilder();
 
-        assertTrue(details.isIOS());
-    }
+        assertEquals("Linux i686",
+                detailsBuilder.buildDetails().getNavigatorPlatform());
 
-    @Test
-    void isIOS_notIPadIsIPhone_returnsTrue() {
-        ExtendedClientDetails details = Mockito
-                .mock(ExtendedClientDetails.class);
-        Mockito.doCallRealMethod().when(details).isIOS();
-
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        VaadinSession.setCurrent(session);
-
-        WebBrowser browser = Mockito.mock(WebBrowser.class);
-        Mockito.when(session.getBrowser()).thenReturn(browser);
-
-        Mockito.when(browser.isIPhone()).thenReturn(true);
-
-        assertTrue(details.isIOS());
-    }
-
-    @Test
-    void isIOS_notIPad_notIsIPhone_returnsFalse() {
-        ExtendedClientDetails details = Mockito
-                .mock(ExtendedClientDetails.class);
-        Mockito.doCallRealMethod().when(details).isIOS();
-
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        VaadinSession.setCurrent(session);
-
-        WebBrowser browser = Mockito.mock(WebBrowser.class);
-        Mockito.when(session.getBrowser()).thenReturn(browser);
-        Mockito.when(browser.isIPhone()).thenReturn(false);
-
-        assertFalse(details.isIOS());
+        detailsBuilder.setNavigatorPlatform(null);
+        assertNull(detailsBuilder.buildDetails().getNavigatorPlatform());
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/WebBrowserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/WebBrowserTest.java
@@ -93,6 +93,16 @@ class WebBrowserTest {
     }
 
     @Test
+    void isSafariOnIPhone_userDetails_returnsTrue() {
+        VaadinRequest request = initRequest(
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Mobile/15E148 Safari/604.1");
+
+        browser = new WebBrowser(request);
+        assertTrue(browser.isIPhone());
+        assertTrue(browser.isSafari());
+    }
+
+    @Test
     void isFirefoxOnAndroid_userDetails_returnsTrue() {
         VaadinRequest request = initRequest(
                 "Mozilla/5.0 (Android; Tablet; rv:33.0) Gecko/33.0 Firefox/33.0");


### PR DESCRIPTION
Completes the deprecation started in #22283. WebBrowser.isIPhone() was the only user-agent-derived method left undeprecated, and ExtendedClientDetails isIPad()/isIOS() were the last platform-sniffing methods, both built on window.navigator.platform, an API browsers themselves have deprecated.

isIPhone() also stopped detecting iPhones: it matched lowercase literals against the raw User-Agent header, which WebBrowser never normalizes, so a real "Mozilla/5.0 (iPhone; CPU iPhone OS ... like Mac OS X)" never matched. Delegating back to BrowserDetails, which lowercases the string it parses, restores detection and keeps the method consistent with its siblings.

ExtendedClientDetails gains getNavigatorPlatform() so applications that still need the value can read it directly rather than through derived predicates. isIOS() now resolves the iPhone case from navigator.platform instead of the user agent, so no server code reaches for the user agent parser and the method no longer requires a current VaadinSession.

Related to #21830