### PR TITLE
fix: restore iPhone detection in WebBrowser

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -358,11 +358,10 @@ public class WebBrowser implements Serializable {
      *         no information on the browser is present
      */
     public boolean isIPhone() {
-        return userAgent != null
-                && (userAgent.contains("macintosh")
-                        || userAgent.contains("mac osx")
-                        || userAgent.contains("mac os x"))
-                && userAgent.contains("iphone");
+        if (getBrowserDetails() == null) {
+            return false;
+        }
+        return browserDetails.isIPhone();
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/WebBrowserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/WebBrowserTest.java
@@ -93,6 +93,16 @@ class WebBrowserTest {
     }
 
     @Test
+    void isSafariOnIPhone_userDetails_returnsTrue() {
+        VaadinRequest request = initRequest(
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Mobile/15E148 Safari/604.1");
+
+        browser = new WebBrowser(request);
+        assertTrue(browser.isIPhone());
+        assertTrue(browser.isSafari());
+    }
+
+    @Test
     void isFirefoxOnAndroid_userDetails_returnsTrue() {
         VaadinRequest request = initRequest(
                 "Mozilla/5.0 (Android; Tablet; rv:33.0) Gecko/33.0 Firefox/33.0");


### PR DESCRIPTION
isIPhone() matched lowercase literals against the raw User-Agent header, which WebBrowser never normalizes, so a real iPhone sending "Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) ..." never matched and the method always returned false. ExtendedClientDetails.isIOS() delegates here for the iPhone case, so it reported false on iPhones as well.

Delegating back to BrowserDetails, which lowercases the string it parses, restores detection and makes the method consistent with the other user-agent based checks in this class.
