### PR TITLE
fix: decode percent-encoded paths when looking up translation files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/i18n/I18NUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/I18NUtil.java
@@ -18,7 +18,11 @@ package com.vaadin.flow.i18n;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -30,6 +34,8 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.internal.UrlUtil;
 
 import static com.vaadin.flow.i18n.DefaultI18NProvider.BUNDLE_FILENAME;
 import static com.vaadin.flow.i18n.DefaultI18NProvider.BUNDLE_FOLDER;
@@ -139,15 +145,14 @@ public final class I18NUtil {
     protected static List<File> getTranslationFiles(URL resource) {
         List<File> files = new ArrayList<>();
 
-        File bundleFolder = new File(resource.getFile());
+        String protocol = resource.getProtocol();
 
-        if ("jar".equals(resource.getProtocol()) ||
+        if ("jar".equals(protocol) ||
         // wsjar check is for OpenLiberty
-                "wsjar".equals(resource.getProtocol())) {
-            String file = resource.getFile().substring("file:".length(),
-                    resource.getFile().indexOf('!'));
-            try {
-                Enumeration<JarEntry> entries = new JarFile(file).entries();
+                "wsjar".equals(protocol)) {
+            File jar = getJarFile(resource);
+            try (JarFile jarFile = new JarFile(jar)) {
+                Enumeration<JarEntry> entries = jarFile.entries();
                 entries.asIterator().forEachRemaining(entry -> {
                     String fileName = entry.getName();
                     if (fileName.contains(BUNDLE_FOLDER)
@@ -157,15 +162,71 @@ public final class I18NUtil {
                 });
             } catch (IOException ioe) {
                 getLogger().debug(
-                        "failed to read jar file '" + file + "' contents", ioe);
+                        "failed to read jar file '" + jar + "' contents", ioe);
             }
-        } else if ("vfs".equals(resource.getProtocol())) {
+        } else if ("vfs".equals(protocol)) {
             files.addAll(listJBossVfsDirectory(resource));
-        } else if (bundleFolder.exists() && bundleFolder.isDirectory()) {
-            Arrays.stream(bundleFolder.listFiles()).filter(File::isFile)
-                    .forEach(files::add);
+        } else {
+            File bundleFolder = toFile(resource);
+            if (bundleFolder.isDirectory()) {
+                Arrays.stream(bundleFolder.listFiles()).filter(File::isFile)
+                        .forEach(files::add);
+            } else {
+                getLogger().debug(
+                        "Translation folder '{}', resolved from resource '{}', is not an existing directory",
+                        bundleFolder, resource);
+            }
         }
         return files;
+    }
+
+    /**
+     * Converts a resource URL into a file.
+     * <p>
+     * A class loader returns percent-encoded URLs, so a path containing for
+     * example a space arrives as {@code %20}. Going through {@link URL#toURI()}
+     * decodes it back into a path that exists on disk.
+     *
+     * @param resource
+     *            the resource URL to convert
+     * @return the file the URL points to
+     */
+    private static File toFile(URL resource) {
+        try {
+            return new File(resource.toURI());
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            // Not an absolute file: URI, keep the previous behaviour
+            getLogger().debug("Cannot convert resource '{}' into a file path",
+                    resource, e);
+            return new File(UrlUtil.decodeURIComponent(resource.getFile()));
+        }
+    }
+
+    /**
+     * Resolves the jar file that a {@code jar:} or {@code wsjar:} resource
+     * lives in.
+     * <p>
+     * The jar location is the part of the URL before the {@code !} separator,
+     * and it is percent-encoded just like any other URL.
+     *
+     * @param resource
+     *            the resource URL to resolve the jar for
+     * @return the jar file containing the resource
+     */
+    private static File getJarFile(URL resource) {
+        String file = resource.getFile();
+        int separatorIndex = file.indexOf('!');
+        String jarUrl = separatorIndex == -1 ? file
+                : file.substring(0, separatorIndex);
+        try {
+            return Paths.get(URI.create(jarUrl)).toFile();
+        } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+            // Not a plain file: URL, for example a jar nested inside a war
+            getLogger().debug(
+                    "Cannot resolve a file path for the jar of resource '{}'",
+                    resource, e);
+            return new File(UrlUtil.decodeURIComponent(jarUrl));
+        }
     }
 
     // Borrowed from DevModeInitializer

--- a/flow-server/src/test/java/com/vaadin/flow/i18n/I18NUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/i18n/I18NUtilTest.java
@@ -96,6 +96,48 @@ class I18NUtilTest {
                 "Missing Finnish bundle");
     }
 
+    // A class loader percent-encodes the URL it returns, so a space in any
+    // parent folder arrives as %20 and must be decoded before use.
+    @Test
+    void resourceFolderPathContainsSpace_returnsExpectedLocales()
+            throws IOException {
+        File spacedResources = Files
+                .createDirectory(temporaryFolder.resolve("folder with space"))
+                .toFile();
+        Mockito.when(mockLoader.getResource(DefaultI18NProvider.BUNDLE_FOLDER))
+                .thenReturn(spacedResources.toURI().toURL());
+
+        Files.writeString(
+                new File(spacedResources,
+                        DefaultI18NProvider.BUNDLE_FILENAME + ".properties")
+                        .toPath(),
+                "title=Default lang", StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE);
+        Files.writeString(
+                new File(spacedResources,
+                        DefaultI18NProvider.BUNDLE_FILENAME + "_de.properties")
+                        .toPath(),
+                "title=deutsch", StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE);
+        Files.writeString(
+                new File(spacedResources,
+                        DefaultI18NProvider.BUNDLE_FILENAME
+                                + "_fi_FI.properties")
+                        .toPath(),
+                "title=Suomi", StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE);
+
+        List<Locale> defaultTranslationLocales = I18NUtil
+                .getDefaultTranslationLocales(mockLoader);
+
+        assertEquals(2, defaultTranslationLocales.size(),
+                "Translation files should be found even though the path contains a space");
+        assertTrue(defaultTranslationLocales.contains(new Locale("de")),
+                "Missing German bundle");
+        assertTrue(defaultTranslationLocales.contains(new Locale("fi", "FI")),
+                "Missing Finnish bundle");
+    }
+
     @Test
     void noTranslationFiles_returnsEmptyList() throws IOException {
         Mockito.when(mockLoader.getResource(DefaultI18NProvider.BUNDLE_FOLDER))
@@ -169,6 +211,31 @@ class I18NUtilTest {
                 .getDefaultTranslationLocales(urlClassLoader);
         assertEquals(2, defaultTranslationLocales.size(),
                 "Translation files with locale inside JAR should be resolved");
+
+        assertTrue(defaultTranslationLocales.contains(new Locale("fi", "FI")),
+                "Finnish locale translation should have been found");
+        assertTrue(defaultTranslationLocales.contains(new Locale("ja", "JP")),
+                "Japan locale translation should have been found");
+    }
+
+    // The jar path is cut out of the percent-encoded URL, so a space in any
+    // parent folder must be decoded before the jar can be opened.
+    @Test
+    void jarPathContainsSpace_translationFilesInJar_findsLanguages()
+            throws IOException {
+        Path spacedFolder = Files
+                .createDirectory(temporaryFolder.resolve("folder with space"));
+        Path path = generateZipArchive(spacedFolder);
+
+        ClassLoader urlClassLoader = new URLClassLoader(
+                new URL[] { path.toUri().toURL() });
+
+        assertTrue(I18NUtil.containsDefaultTranslation(urlClassLoader),
+                "Default file should return true");
+        List<Locale> defaultTranslationLocales = I18NUtil
+                .getDefaultTranslationLocales(urlClassLoader);
+        assertEquals(2, defaultTranslationLocales.size(),
+                "Translation files inside a JAR should be resolved even though the path contains a space");
 
         assertTrue(defaultTranslationLocales.contains(new Locale("fi", "FI")),
                 "Finnish locale translation should have been found");


### PR DESCRIPTION
Translations were silently ignored when any folder in the path to the application contained a space. A class loader returns percent-encoded URLs, so a space arrives as %20, and building a File straight from URL.getFile() produced a path that does not exist on disk. The folder lookup then found nothing, the default I18N provider was created with an empty list of locales, and the session never switched away from the default language. Nothing was logged.

Resolve the folder through URL.toURI() and the jar location through Paths.get(URI.create(...)), so both are decoded before use. Where the URL is not an absolute file: URI, fall back to UrlUtil.decodeURIComponent, which unlike URLDecoder does not turn '+' into a space.

Also close the JarFile that was left open while reading its entries, and log at debug level when the translation folder does not resolve to an existing directory, so this kind of failure is visible next time.

Fixes #25156
