### PR TITLE
chore: resolve tsconfig.json for the type checker from the project root

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -680,7 +680,14 @@ export const vaadinConfig: UserConfigFn = (env) => {
       },
       //#vitePluginFileSystemRouter#
       checker({
-        typescript: true
+        typescript: {
+          // tsconfig.json is generated next to package.json, not in the
+          // frontend folder Vite uses as its root. TypeScript 7 no longer
+          // exposes the compiler API to Node, so the checker falls back to
+          // running tsc as a separate process and resolves the config
+          // strictly against this root without searching parent folders.
+          root: __dirname
+        }
       }),
       productionMode && visualizer({ brotliSize: true, filename: bundleSizeFile })
     ]


### PR DESCRIPTION
Vite is configured to use the frontend folder as its root, but tsconfig.json is generated next to package.json in the project root. vite-plugin-checker was left to derive the config location from Vite's root, so it looked for a tsconfig.json that is never generated there.

This went unnoticed because the checker resolves the config through the TypeScript compiler API, whose findConfigFile walks up parent folders until it finds a match, ending up at the generated file one level above the frontend folder. Relying on that search is fragile: a project with its own tsconfig.json in the frontend folder silently gets that one instead, and the upward search is not available at all when the checker cannot use the compiler API and runs tsc as a separate process, in which case it resolves the path directly against its root and the dev server fails to start.

Point the checker at the folder the config is generated into so that the file is found directly instead of through a parent folder search.
