### PR TITLE
fix: log unsafe URL fallback at warn level

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -272,19 +272,18 @@ public class UrlUtil {
     public static boolean isSafeUrl(String url) {
         VaadinService service = VaadinService.getCurrent();
         Set<String> safeSchemes;
+
         if (service == null) {
-            if (getLogger().isDebugEnabled()) {
-                getLogger()
-                        .debug("No VaadinService available on current thread; "
-                                + "falling back to default safe URL schemes. "
-                                + "Any custom {} configuration will not apply "
-                                + "here.", InitParameters.URL_SAFE_SCHEMES);
-            }
+            getLogger().warn("No VaadinService available on current thread; "
+                    + "falling back to default safe URL schemes. "
+                    + "Any custom {} configuration will not apply " + "here.",
+                    InitParameters.URL_SAFE_SCHEMES);
             safeSchemes = Constants.DEFAULT_URL_SAFE_SCHEMES;
         } else {
             safeSchemes = service.getDeploymentConfiguration()
                     .getUrlSafeSchemes();
         }
+
         return isSafeUrl(url, safeSchemes);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -307,4 +307,15 @@ class UrlUtilTest {
             assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)"));
         }
     }
+
+    @Test
+    void isSafeUrl_noVaadinService_fallsBackToDefaultSchemes() {
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(null);
+
+            assertTrue(UrlUtil.isSafeUrl("https://vaadin.com"));
+            assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)"));
+        }
+    }
 }


### PR DESCRIPTION
## Description

No new dependencies are required.

When `UrlUtil.isSafeUrl(String)` is called without a `VaadinService` available on the current thread, the URL safety check falls back to the default safe URL schemes. This fallback was previously logged at DEBUG level.

This change raises the log level from DEBUG to WARN so that application developers have a better chance of noticing when the configured URL safety schemes cannot be applied.

A test has been added to verify that the fallback behavior still uses the default safe URL schemes when no `VaadinService` is available.

Fixes #25086

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.