### PR TITLE
chore: update default pnpm version to 8.15.9

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -170,7 +170,7 @@ jobs:
           node-version: '22.14.0'
       - uses: pnpm/action-setup@v3
         with:
-          version: '8.6.11'
+          version: '8.15.9'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 'latest'

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -68,7 +68,7 @@ public class FrontendTools {
      */
     public static final String DEFAULT_NPM_VERSION = "10.9.7";
 
-    public static final String DEFAULT_PNPM_VERSION = "8.6.11";
+    public static final String DEFAULT_PNPM_VERSION = "8.15.9";
 
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";


### PR DESCRIPTION
8.15.9 is the last release in the pnpm 8 line. Updates the pnpm version used in CI to match.
