### PR TITLE
chore: update default Node.js version to v22.23.2

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '24.19.0'
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '24.19.0'
       - uses: pnpm/action-setup@v3
         with:
           version: '8.6.11'
@@ -295,7 +295,7 @@ jobs:
           token: ${{ secrets.VAADIN_BOT_TOKEN }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '24.9.0'
+          node-version: '24.19.0'
       - name: Auto-merge PR
         env:
           GITHUB_TOKEN: ${{ secrets.VAADIN_BOT_TOKEN }}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -60,13 +60,13 @@ public class FrontendTools {
      *
      * @since 4.0
      */
-    public static final String DEFAULT_NODE_VERSION = "v22.23.1";
+    public static final String DEFAULT_NODE_VERSION = "v22.23.2";
     /**
      * This is the version shipped with the default Node version.
      *
      * @since 9.0
      */
-    public static final String DEFAULT_NPM_VERSION = "10.9.7";
+    public static final String DEFAULT_NPM_VERSION = "10.9.8";
 
     public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 


### PR DESCRIPTION
v22.23.2 is a security release fixing CVE-2026-56846, CVE-2026-56848 and CVE-2026-58043 (High) plus four medium severity issues.

The bundled npm version is updated to match. All CI jobs now use Node 24, which is above the supported minimum (Node 20) and gets security updates for longer than the Node 22 line.
