### PR TITLE
chore: update default Node.js version to v24.19.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24.9.0'
+          node-version: '24.19.0'
 
       - name: Install TestBench license
         if: env.TB_LICENSE != ''

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{env._HEAD_SHA}}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24.9.0'
+          node-version: '24.19.0'
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -196,7 +196,7 @@ jobs:
           ref: ${{env._HEAD_SHA}}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24.9.0'
+          node-version: '24.19.0'
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: '11.0.8'
@@ -431,7 +431,7 @@ jobs:
           token: ${{ secrets.VAADIN_BOT_TOKEN }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24.9.0'
+          node-version: '24.19.0'
       - name: Auto-merge PR
         env:
           GITHUB_TOKEN: ${{ secrets.VAADIN_BOT_TOKEN }}

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -73,13 +73,13 @@ public class FrontendTools {
      * 
      * @since 4.0
      */
-    public static final String DEFAULT_NODE_VERSION = "v24.17.0";
+    public static final String DEFAULT_NODE_VERSION = "v24.19.0";
     /**
      * This is the version shipped with the default Node version.
      * 
      * @since 9.0
      */
-    public static final String DEFAULT_NPM_VERSION = "11.13.0";
+    public static final String DEFAULT_NPM_VERSION = "11.17.0";
 
     public static final String DEFAULT_PNPM_VERSION = "11.19.0";
 


### PR DESCRIPTION
v24.18.1 is a security release fixing CVE-2026-56846, CVE-2026-56848 and CVE-2026-58043 (High) plus four medium severity issues. v24.19.0 additionally updates the bundled root certificates to NSS 3.123.1.

The bundled npm version and the Node.js version used in CI are updated to match.
