### PR TITLE
fix: use a relative tsconfig root for the TypeScript checker

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -686,7 +686,12 @@ export const vaadinConfig: UserConfigFn = (env) => {
           // exposes the compiler API to Node, so the checker falls back to
           // running tsc as a separate process and resolves the config
           // strictly against this root without searching parent folders.
-          root: __dirname
+          // The root is relative because the checker passes it to tsc as
+          // "-p <root>" in a command line that is split on spaces, which
+          // would break for a project directory containing a space. Vite is
+          // always spawned with the project root as its working directory,
+          // which is this directory, so "." resolves to the same tsconfig.
+          root: '.'
         }
       }),
       productionMode && visualizer({ brotliSize: true, filename: bundleSizeFile })


### PR DESCRIPTION
vite-plugin-checker builds the tsc command line as a string and splits it on spaces, so the absolute "-p <root>" argument breaks type checking when the project directory contains a space. Vite is always started with the project root as its working directory, both for the production build and for the dev server, so a relative "." resolves to the same tsconfig.json without introducing a splittable argument.
