### PR TITLE
chore: enable auto-merge on main branch

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -417,7 +417,7 @@ jobs:
             saved-workspace
   auto-merge:
     needs: api-diff-labeling
-    if: github.event_name == 'pull_request' && github.base_ref != 'main'
+    if: github.event_name == 'pull_request'
     timeout-minutes: 5
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
summaries for the updated auto merging rule
- PR is in a `open` status
- not draft
- has `+0.0.1` label
- author has **write** access to flow repo
- CP: not main, author is `vaadin-bot`, title contains `CP:XXX` , and enable the auto-merge
- Chore/Test: title starts with `chore:` or `test:` , just auto review  (maybe leave a message to remind the author about merging or separate review)