### PR TITLE
chore: run validation and formatter for PRs against any base branch

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -3,8 +3,11 @@ name: Formatter
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    # spotless available in 25.x
-    branches: [main]
+    # Deliberately unfiltered by base branch so that PRs stacked on another
+    # feature branch are checked too, not only those targeting main. Spotless
+    # is only configured in 25.x, which is all this copy of the workflow can
+    # ever run against: PRs against an older maintenance branch use that
+    # branch's own copy of this file.
   merge_group:
 
 # Cancel previous runs if a new one is triggered

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,7 +5,9 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
+    # Deliberately unfiltered by base branch so that PRs stacked on another
+    # feature branch are validated too, not only those targeting main.
+    # PRs against a maintenance branch run that branch's own copy of this file.
   merge_group:
 permissions:
   contents: read


### PR DESCRIPTION
Both workflows filtered pull_request events to base branch main, so PRs stacked on another feature branch got no GitHub Actions run at all. The filter dates back to when these were pull_request_target workflows, where limiting the base branch was a security control; that rationale went away when they moved to plain pull_request.

Dropping the filter only widens this copy of the workflows, since a PR runs the workflow file from its own merge ref: PRs against a maintenance branch keep using that branch's copy. That also keeps spotless available for every base the formatter can now see, as this copy only ever runs against 25.x.
