### PR TITLE
chore: import vite.generated with its file extension in vite.config.ts

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
@@ -48,9 +48,15 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
     private final Options options;
 
     private final Set<String> webComponentTags;
-    private static final String[] reactPluginTemplatesUsedInStarters = new String[] {
+    /**
+     * Configurations that Flow or a starter has generated in the past and that
+     * the user has not touched since. They carry no customizations, so they can
+     * be replaced with the current default to pick up fixes made to it.
+     */
+    private static final String[] outdatedUnmodifiedTemplates = new String[] {
             getSimplifiedTemplate("vite.config-react.ts"),
-            getSimplifiedTemplate("vite.config-react-swc.ts") };
+            getSimplifiedTemplate("vite.config-react-swc.ts"),
+            getSimplifiedTemplate("vite.config-v25.2.ts") };
 
     static final String FILE_SYSTEM_ROUTER_DEPENDENCY = "@vaadin/hilla-file-router/vite-plugin.js";
 
@@ -96,7 +102,7 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
                 return;
             }
             log().info(
-                    "Replacing vite.config.ts with the default version as the React plugin is now automatically included");
+                    "Replacing the unmodified vite.config.ts with the current default version");
         }
 
         try (InputStream resource = this.getClass().getClassLoader()
@@ -110,7 +116,7 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
     private boolean replaceWithDefault(File configFile) throws IOException {
         String text = simplifyTemplate(
                 Files.readString(configFile.toPath(), StandardCharsets.UTF_8));
-        for (String template : reactPluginTemplatesUsedInStarters) {
+        for (String template : outdatedUnmodifiedTemplates) {
             if (text.equals(template)) {
                 return true;
             }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateViteTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateViteTest.java
@@ -93,6 +93,24 @@ class TaskUpdateViteTest {
     }
 
     @Test
+    void unmodifiedOutdatedConfigFile_replacedWithCurrentDefault()
+            throws IOException {
+        File configFile = new File(temporaryFolder, FrontendUtils.VITE_CONFIG);
+        String previousDefault = IOUtils.toString(
+                TaskUpdateVite.class.getResource("vite.config-v25.2.ts"),
+                StandardCharsets.UTF_8);
+        FileUtils.write(configFile, previousDefault, StandardCharsets.UTF_8);
+
+        new TaskUpdateVite(options, null).execute();
+
+        String template = IOUtils.toString(configFile.toURI(),
+                StandardCharsets.UTF_8);
+
+        assertTrue(template.contains("from './vite.generated.ts'"),
+                "Unmodified config from a previous version should have been replaced with the current default");
+    }
+
+    @Test
     void generatedConfigFileExists_alwaysOverwritten() throws IOException {
         File generatedConfigFile = new File(temporaryFolder,
                 FrontendUtils.VITE_GENERATED_CONFIG);

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vite.config-v25.2.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vite.config-v25.2.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated.ts';
+import { overrideVaadinConfig } from './vite.generated';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-server/src/main/resources/vite.config.ts
+++ b/flow-server/src/main/resources/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-tests/test-application-theme/test-reusable-as-parent-vite/vite.config.ts
+++ b/flow-tests/test-application-theme/test-reusable-as-parent-vite/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-tests/test-dev-mode/vite.config.ts
+++ b/flow-tests/test-dev-mode/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   plugins: [

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/vite.config.ts
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/vite.config.ts
@@ -1,5 +1,5 @@
 import { PluginOption, UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 function addCssToIndex(): PluginOption {
   return {

--- a/flow-tests/test-frontend/vite-basics/vite.config.ts
+++ b/flow-tests/test-frontend/vite-basics/vite.config.ts
@@ -2,7 +2,7 @@ import {
   PluginOption,
   UserConfigFn
 } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 /**
  * Dumps effective contents of config.optimizeDeps for tests

--- a/flow-tests/test-frontend/vite-context-path/vite.config.ts
+++ b/flow-tests/test-frontend/vite-context-path/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 /**
  * Dumps effective contents of config.optimizeDeps for tests

--- a/flow-tests/test-frontend/vite-embedded/vite.config.ts
+++ b/flow-tests/test-frontend/vite-embedded/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-tests/test-frontend/vite-production/vite.config.ts
+++ b/flow-tests/test-frontend/vite-production/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/vite.config.ts
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-tests/test-frontend/vite-pwa-disabled-offline/vite.config.ts
+++ b/flow-tests/test-frontend/vite-pwa-disabled-offline/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-tests/test-frontend/vite-pwa-production/vite.config.ts
+++ b/flow-tests/test-frontend/vite-pwa-production/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters

--- a/flow-tests/test-frontend/vite-pwa/vite.config.ts
+++ b/flow-tests/test-frontend/vite-pwa/vite.config.ts
@@ -1,5 +1,5 @@
 import { UserConfigFn } from 'vite';
-import { overrideVaadinConfig } from './vite.generated';
+import { overrideVaadinConfig } from './vite.generated.ts';
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters


### PR DESCRIPTION
Vite's native config loader hands the config to Node, which does not resolve extensionless imports, so the import needs to name the .ts file.

Projects whose vite.config.ts is still byte-identical to a default generated by an earlier version get it regenerated, so the fix also reaches existing projects that never customized the file.

Part of #25242
