### PR TITLE
chore: declare the Vite build plugins as ES modules

### DIFF
--- a/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/package.json
+++ b/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/package.json
@@ -8,6 +8,7 @@
   },
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",
+  "type": "module",
   "files": [
     "react-function-location-plugin.js"
   ]

--- a/flow-build-tools/src/main/resources/plugins/rollup-plugin-postcss-lit-custom/package.json
+++ b/flow-build-tools/src/main/resources/plugins/rollup-plugin-postcss-lit-custom/package.json
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/vaadin/flow/issues"
   },
+  "type": "module",
   "files": [
     "rollup-plugin-postcss-lit.js"
   ]

--- a/flow-build-tools/src/main/resources/plugins/rollup-plugin-vaadin-i18n/package.json
+++ b/flow-build-tools/src/main/resources/plugins/rollup-plugin-vaadin-i18n/package.json
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/vaadin/flow/issues"
   },
+  "type": "module",
   "files": [
     "rollup-plugin-vaadin-i18n.js"
   ],

--- a/flow-build-tools/src/main/resources/plugins/theme-loader/package.json
+++ b/flow-build-tools/src/main/resources/plugins/theme-loader/package.json
@@ -13,6 +13,7 @@
   "bugs": {
     "url": "https://github.com/vaadin/flow/issues"
   },
+  "type": "module",
   "files": [
     "theme-loader.js",
     "theme-loader-utils.js"

--- a/flow-build-tools/src/main/resources/plugins/theme-loader/theme-loader.js
+++ b/flow-build-tools/src/main/resources/plugins/theme-loader/theme-loader.js
@@ -1,6 +1,6 @@
 import { getOptions } from 'loader-utils';
 import { dirname, basename, resolve } from 'path';
-import { rewriteCssUrls } from './theme-loader-utils';
+import { rewriteCssUrls } from './theme-loader-utils.js';
 
 /**
  * This custom loader handles rewriting urls for the application theme css files.

--- a/flow-build-tools/src/main/resources/plugins/vite-plugin-local-web-components/package.json
+++ b/flow-build-tools/src/main/resources/plugins/vite-plugin-local-web-components/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/vaadin/flow/issues"
   },
+  "type": "module",
   "files": [
     "index.ts"
   ],

--- a/flow-build-tools/src/main/resources/plugins/vite-plugin-service-worker/package.json
+++ b/flow-build-tools/src/main/resources/plugins/vite-plugin-service-worker/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/vaadin/flow/issues"
   },
+  "type": "module",
   "files": [
     "index.ts"
   ],


### PR DESCRIPTION
The plugins under target/plugins are written with ESM syntax but their package.json files did not declare "type": "module", so Node treats them as CommonJS. Vite 8 warns about this for every plugin that ends up in the config graph.

theme-loader.js resolved its sibling import without a file extension, which only works under CommonJS resolution, so it gets the extension.

Part of #25242
