### PR TITLE
test: wait for the committer before declaring a CombinedUsage deadlock

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/UsageTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/UsageTrackerTest.java
@@ -474,11 +474,13 @@ class UsageTrackerTest extends SignalTestBase {
                 committerRef.set(committer);
                 committer.start();
 
-                // Wait until the committer holds the tree lock and is blocked
-                // trying to enter the monitor. Bounded so the fixed code --
-                // where the committer never stays blocked -- does not hang.
+                // Wait until the committer either holds the tree lock and
+                // is blocked trying to enter the monitor (the inversion) or
+                // has run the commit to completion (no inversion). Bounded so
+                // that neither outcome hangs the test.
                 long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
                 while (committer.getState() != Thread.State.BLOCKED
+                        && committer.getState() != Thread.State.TERMINATED
                         && System.nanoTime() < deadline) {
                     Thread.onSpinWait();
                 }
@@ -513,16 +515,24 @@ class UsageTrackerTest extends SignalTestBase {
 
         registrar.join(10_000);
 
+        // The committer runs to completion on its own once registration no
+        // longer holds the monitor, so wait for it too: only a thread that is
+        // still alive after its own join is actually stuck.
         Thread committer = committerRef.get();
-        if (registrar.isAlive() || (committer != null && committer.isAlive())) {
+        if (committer != null) {
+            committer.join(10_000);
+        }
+
+        boolean registrarStuck = registrar.isAlive();
+        boolean committerStuck = committer != null && committer.isAlive();
+        if (registrarStuck || committerStuck) {
             ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
             long[] deadlocked = tmx.findDeadlockedThreads();
             StringBuilder sb = new StringBuilder(
                     "CombinedUsage lock-order inversion between the SignalTree "
                             + "lock and the CombinedUsage monitor (see #25166): "
-                            + "registrar alive=" + registrar.isAlive()
-                            + ", committer alive="
-                            + (committer != null && committer.isAlive()));
+                            + "registrar alive=" + registrarStuck
+                            + ", committer alive=" + committerStuck);
             if (deadlocked != null) {
                 sb.append(", deadlocked thread IDs=")
                         .append(Arrays.toString(deadlocked));


### PR DESCRIPTION
combinedUsage_registerWhileCommitting_noDeadlock joined only the registrar thread and then treated a still-running committer as a deadlock. The committer usually finishes during the two second spin that waits for it to become BLOCKED, but it can transiently block on the small synchronized section in CombinedUsage.onChange, which ends the spin within microseconds and leaves the commit in flight when aliveness is checked.

Join the committer as well and capture both aliveness flags once, so the failure message reflects the state that triggered it. Ending the spin on TERMINATED too lets the non-deadlocking case finish immediately instead of always waiting out the deadline.
