### PR TITLE
fix: ignore declared versions for packages that come with Lit

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -25,6 +25,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.server.Constants;
@@ -37,6 +40,21 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
  * @since 24.4
  */
 public class ExclusionFilter implements Serializable {
+
+    /**
+     * Packages that are part of a package Flow manages the version of, mapped
+     * to the package that owns them.
+     * <p>
+     * The owning package is released together with the packages it is built
+     * from and only works with the versions it was released with, so a version
+     * declared for one of them elsewhere cannot be honoured. Pinning them
+     * separately resolves the owning package against packages it was never
+     * combined with, which leaves the application with two implementations of
+     * the same API.
+     */
+    private static final Map<String, String> OWNED_PACKAGES = Map.of(
+            "lit-element", "lit", "lit-html", "lit", "@lit/reactive-element",
+            "lit");
 
     private final ClassFinder finder;
 
@@ -76,7 +94,8 @@ public class ExclusionFilter implements Serializable {
 
     /**
      * Exclude dependencies from the given map based on the
-     * vaadin-*versions.json files.
+     * vaadin-*versions.json files, and dependencies that are part of a package
+     * Flow manages the version of.
      *
      * @param dependencies
      *            the dependencies to filter
@@ -89,8 +108,27 @@ public class ExclusionFilter implements Serializable {
         var exclusions = getExclusions();
         return dependencies.entrySet().stream()
                 .filter(entry -> !exclusions.contains(entry.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey,
-                        Map.Entry::getValue));
+                .filter(this::isVersionUsable).collect(Collectors
+                        .toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private boolean isVersionUsable(Map.Entry<String, String> dependency) {
+        String owner = OWNED_PACKAGES.get(dependency.getKey());
+        if (owner == null) {
+            return true;
+        }
+        getLogger().warn(
+                """
+                        Ignoring the version '{}' declared for '{}', which is part of '{}' and comes with it.
+                        Declaring a version for it resolves '{}' against packages it was not released with.
+                        Remove the @NpmPackage annotation for '{}' from the add-on or application declaring it.""",
+                dependency.getValue(), dependency.getKey(), owner, owner,
+                dependency.getKey());
+        return false;
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ExclusionFilter.class);
     }
 
     private List<String> getExclusions() throws IOException {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -108,14 +108,16 @@ public class ExclusionFilter implements Serializable {
         var exclusions = getExclusions();
         return dependencies.entrySet().stream()
                 .filter(entry -> !exclusions.contains(entry.getKey()))
-                .filter(this::isVersionUsable).collect(Collectors
-                        .toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .filter(entry -> !comesWithOwningPackage(entry))
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        Map.Entry::getValue));
     }
 
-    private boolean isVersionUsable(Map.Entry<String, String> dependency) {
+    private boolean comesWithOwningPackage(
+            Map.Entry<String, String> dependency) {
         String owner = OWNED_PACKAGES.get(dependency.getKey());
         if (owner == null) {
-            return true;
+            return false;
         }
         getLogger().warn(
                 """
@@ -124,7 +126,7 @@ public class ExclusionFilter implements Serializable {
                         Remove the @NpmPackage annotation for '{}' from the add-on or application declaring it.""",
                 dependency.getValue(), dependency.getKey(), owner, owner,
                 dependency.getKey());
-        return false;
+        return true;
     }
 
     private static Logger getLogger() {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/ExclusionFilterTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/ExclusionFilterTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
+public class ExclusionFilterTest {
+
+    private ExclusionFilter filter;
+
+    @BeforeEach
+    public void init() {
+        // Without versions files the only exclusions left are the packages
+        // that come with a package Flow manages the version of.
+        filter = new ExclusionFilter(Mockito.mock(ClassFinder.class), true);
+    }
+
+    @Test
+    public void packagesOwnedByLit_excluded() throws IOException {
+        Map<String, String> dependencies = filter.exclude(Map.of("lit-element",
+                "^3.2.2", "lit-html", "2.4.0", "@lit/reactive-element", "1.6.3",
+                "@polymer/paper-button", "^3.0.1"));
+
+        Assert.assertEquals(Map.of("@polymer/paper-button", "^3.0.1"),
+                dependencies);
+    }
+
+    @Test
+    public void litItself_notExcluded() throws IOException {
+        Map<String, String> dependencies = filter
+                .exclude(Map.of("lit", "3.3.3"));
+
+        Assert.assertEquals(Map.of("lit", "3.3.3"), dependencies);
+    }
+}

--- a/flow-tests/test-frontend/pom.xml
+++ b/flow-tests/test-frontend/pom.xml
@@ -52,6 +52,7 @@
         <module>vite-embedded-webcomponent-resync-longpolling</module>
         <module>test-npm</module>
         <module>test-npm/pom-production.xml</module>
+        <module>test-npm-legacy-lit-addon</module>
         <module>test-pnpm</module>
         <module>test-pnpm/pom-production.xml</module>
       </modules>

--- a/flow-tests/test-frontend/test-npm-legacy-lit-addon/pom.xml
+++ b/flow-tests/test-frontend/test-npm-legacy-lit-addon/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.vaadin</groupId>
+    <artifactId>test-frontend</artifactId>
+    <version>25.3-SNAPSHOT</version>
+  </parent>
+  <artifactId>flow-test-npm-legacy-lit-addon</artifactId>
+
+  <packaging>war</packaging>
+  <name>Flow tests for add-ons pinning legacy Lit packages</name>
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <!-- npm hoists one lit-element to the root and nests the other, which is
+         what makes a conflicting pin observable. pnpm's hoisted linker
+         collapses the two copies and hides the conflict. -->
+    <vaadin.pnpm.enable>false</vaadin.pnpm.enable>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-dev-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>jetty:run</defaultGoal>
+    <plugins>
+      <!-- The add-on pins conflicting versions on purpose, so the resolved
+           node_modules must not be reused between runs. -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${project.basedir}</directory>
+              <includes>
+                <include>package.json</include>
+                <include>package-lock.json</include>
+                <include>types.d.ts</include>
+                <include>tsconfig.json</include>
+                <include>node_modules/**</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+        <executions>
+          <execution>
+            <id>auto-clean</id>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-frontend</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/main/frontend/legacy-lit-addon.js
+++ b/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/main/frontend/legacy-lit-addon.js
@@ -1,0 +1,33 @@
+import { LitElement, html } from 'lit';
+
+/**
+ * Mimics an add-on that is built on Lit, and renders through a reactive
+ * property so that the property initializers Lit installs are exercised.
+ */
+class LegacyLitAddonElement extends LitElement {
+  static get properties() {
+    return {
+      page: { type: Number }
+    };
+  }
+
+  constructor() {
+    super();
+    this.page = 1;
+  }
+
+  render() {
+    return html`
+      <button id="previousPage" @click="${() => this._movePage(-1)}">Previous</button>
+      <span id="currentPage">${this.page}</span>
+      <button id="nextPage" @click="${() => this._movePage(1)}">Next</button>
+    `;
+  }
+
+  _movePage(delta) {
+    this.page = Math.max(1, this.page + delta);
+    this.dispatchEvent(new CustomEvent('page-change', { detail: { page: this.page } }));
+  }
+}
+
+customElements.define('legacy-lit-addon', LegacyLitAddonElement);

--- a/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/main/java/com/vaadin/flow/legacylitaddon/LegacyLitAddon.java
+++ b/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/main/java/com/vaadin/flow/legacylitaddon/LegacyLitAddon.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.legacylitaddon;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+
+/**
+ * An add-on component that pins the Lit packages Flow also depends on, to the
+ * versions that were current when the add-on was written. Lit itself is not
+ * pinned, so {@code lit} resolves to the version Flow manages while
+ * {@code lit-element} and {@code lit-html} resolve to the pinned ones, which
+ * the two cannot be combined with.
+ */
+@Tag("legacy-lit-addon")
+@NpmPackage(value = "lit-element", version = "^3.2.2")
+@NpmPackage(value = "lit-html", version = "2.4.0")
+@JsModule("./legacy-lit-addon.js")
+public class LegacyLitAddon extends Component {
+}

--- a/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/main/java/com/vaadin/flow/legacylitaddon/LegacyLitAddonView.java
+++ b/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/main/java/com/vaadin/flow/legacylitaddon/LegacyLitAddonView.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.legacylitaddon;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("legacy-lit-addon")
+public class LegacyLitAddonView extends Div {
+
+    public LegacyLitAddonView() {
+        setId("legacyLitAddonView");
+        LegacyLitAddon addon = new LegacyLitAddon();
+        addon.setId("legacyLitAddon");
+        add(addon);
+    }
+}

--- a/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/test/java/com/vaadin/flow/legacylitaddon/LegacyLitAddonIT.java
+++ b/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/test/java/com/vaadin/flow/legacylitaddon/LegacyLitAddonIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.legacylitaddon;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * An add-on that pins {@code lit-element} and {@code lit-html} to versions that
+ * the Lit version Flow manages cannot be combined with must not leave two Lit
+ * implementations in the resolved frontend dependencies. When it does, classes
+ * built with the decorators of one implementation extend the base class of the
+ * other, and fail to initialize their properties.
+ */
+public class LegacyLitAddonIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/legacy-lit-addon";
+    }
+
+    @Before
+    public void init() {
+        open();
+        waitUntil(ExpectedConditions
+                .presenceOfElementLocated(By.id("legacyLitAddonView")));
+    }
+
+    @Test
+    public void addonRenders_noClientSideErrors() {
+        TestBenchElement addon = $("legacy-lit-addon").first();
+        TestBenchElement nextPage = addon.$(TestBenchElement.class)
+                .id("nextPage");
+
+        Assert.assertEquals("1",
+                addon.$(TestBenchElement.class).id("currentPage").getText());
+        nextPage.click();
+        Assert.assertEquals("2",
+                addon.$(TestBenchElement.class).id("currentPage").getText());
+
+        checkLogsForErrors();
+    }
+
+    @Test
+    public void singleLitVersionLoaded() {
+        // Lit records the warnings it has issued in dev mode, which is where
+        // it reports having been loaded more than once.
+        List<?> warnings = (List<?>) executeScript(
+                "return globalThis.litIssuedWarnings"
+                        + " ? Array.from(globalThis.litIssuedWarnings) : []");
+        Assert.assertFalse("Lit was loaded more than once",
+                warnings.stream().map(String::valueOf)
+                        .anyMatch(warning -> warning
+                                .contains("Multiple versions of Lit loaded")));
+    }
+}

--- a/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/test/java/com/vaadin/flow/legacylitaddon/LegacyLitAddonIT.java
+++ b/flow-tests/test-frontend/test-npm-legacy-lit-addon/src/test/java/com/vaadin/flow/legacylitaddon/LegacyLitAddonIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.legacylitaddon;
 
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,18 +58,5 @@ public class LegacyLitAddonIT extends ChromeBrowserTest {
                 addon.$(TestBenchElement.class).id("currentPage").getText());
 
         checkLogsForErrors();
-    }
-
-    @Test
-    public void singleLitVersionLoaded() {
-        // Lit records the warnings it has issued in dev mode, which is where
-        // it reports having been loaded more than once.
-        List<?> warnings = (List<?>) executeScript(
-                "return globalThis.litIssuedWarnings"
-                        + " ? Array.from(globalThis.litIssuedWarnings) : []");
-        Assert.assertFalse("Lit was loaded more than once",
-                warnings.stream().map(String::valueOf)
-                        .anyMatch(warning -> warning
-                                .contains("Multiple versions of Lit loaded")));
     }
 }


### PR DESCRIPTION
lit is released together with lit-element, lit-html and reactive-element, and only works with the versions it was released with. A version declared for one of them through @NpmPackage was still added to package.json, from where it also reached the generated versions and the overrides that pin them for the whole dependency tree. That resolved lit against packages it was never combined with, so the LitElement it re-exports and the decorators it re-exports came from two different reactive-element versions, and every class built with those decorators failed to initialize its properties, leaving the page blank.

Drop these packages from the scanned dependencies, and log what was ignored and how to stop declaring it, so the version that comes with lit is the one that is used.

The integration test runs on npm, which hoists one lit-element and nests the other. pnpm's hoisted linker collapses the two copies and resolves everything against a single reactive-element, hiding the conflict, so the flow-tests default of pnpm is turned off for it.

Fixes #23944
