### PR TITLE
fix: keep JS parameters serializable via custom serialization

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -154,6 +154,18 @@ public class UIInternals implements Serializable {
             Collections.addAll(this.parameters, parameters);
         }
 
+        /*
+         * Restores an invocation whose parameters were already validated when
+         * it was first created. Skips the dry run because deserialization may
+         * reach this point before the state nodes behind any element parameters
+         * are fully restored.
+         */
+        private JavaScriptInvocation(String expression,
+                List<Object> parameters) {
+            this.expression = expression;
+            this.parameters.addAll(parameters);
+        }
+
         /**
          * Gets the JavaScript expression to invoke.
          *
@@ -170,6 +182,34 @@ public class UIInternals implements Serializable {
          */
         public List<Object> getParameters() {
             return Collections.unmodifiableList(parameters);
+        }
+
+        /**
+         * Replaces this instance with a form whose parameters Java
+         * serialization can write. An invocation can wait in the session across
+         * requests when its target element is not yet attached or not visible,
+         * and parameters are only ever encoded for the client, so a parameter
+         * that is not itself serializable can be stored as the JSON it encodes
+         * to.
+         */
+        private Object writeReplace() {
+            return new SerializedForm(expression, parameters);
+        }
+
+        private static final class SerializedForm implements Serializable {
+
+            private final String expression;
+            private final List<Object> parameters;
+
+            private SerializedForm(String expression, List<Object> parameters) {
+                this.expression = expression;
+                this.parameters = parameters.stream()
+                        .map(JacksonCodec::serializableParameter).toList();
+            }
+
+            private Object readResolve() {
+                return new JavaScriptInvocation(expression, parameters);
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1892,6 +1892,13 @@ public class Element extends Node<Element> {
      * function, {@code null}, or {@code undefined} (the latter being the
      * implicit value when there is no {@code return}). Returning any other
      * value, including a promise, is logged as an error on the client.
+     * <p>
+     * The parameters are retained for the lifetime of the registration so the
+     * initializer can be re-run on re-attach, which means they are held in the
+     * HTTP session between requests. A parameter that is not
+     * {@link java.io.Serializable} is stored as the JSON it encodes to, so the
+     * browser still receives the same value but mutations made to it after the
+     * session is serialized are not picked up.
      *
      * @param expression
      *            the JavaScript expression to invoke, not <code>null</code>

--- a/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.dom;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -45,6 +46,13 @@ import com.vaadin.flow.internal.JacksonCodec;
  * {@link Element} (attached elements arrive as DOM nodes, detached ones as
  * {@code null}) and nested {@link JsFunction} instances. Capture types are
  * validated when the value is created.
+ * <p>
+ * A {@code JsFunction} can outlive the request that created it, for example
+ * when it is passed to {@link Element#addJsInitializer(String, Object...)
+ * addJsInitializer}, and is then written to the HTTP session. Captures that are
+ * not {@link Serializable} are stored as the JSON they encode to, so the
+ * browser still receives the same value; such a capture is snapshotted when the
+ * session is serialized and later mutations to it are not picked up.
  * <p>
  * Inside the body, {@code this} is whatever the caller of the materialised
  * function chooses (i.e. it follows normal JavaScript call semantics &ndash;
@@ -96,6 +104,42 @@ public final class JsFunction implements Serializable {
         return new JsFunction(body,
                 Collections.unmodifiableList(Arrays.asList(copy)),
                 Collections.emptyList());
+    }
+
+    /**
+     * Replaces this instance with a form whose captures Java serialization can
+     * write. Captures are only ever encoded for the client, so a capture that
+     * is not itself serializable can be stored as the JSON it encodes to
+     * without changing what the browser receives.
+     */
+    private Object writeReplace() {
+        return new SerializedForm(body, captures, argumentNames);
+    }
+
+    private static final class SerializedForm implements Serializable {
+
+        private final String body;
+        private final List<@Nullable Object> captures;
+        private final List<String> argumentNames;
+
+        private SerializedForm(String body, List<@Nullable Object> captures,
+                List<String> argumentNames) {
+            this.body = body;
+            this.argumentNames = argumentNames;
+
+            List<@Nullable Object> serializable = new ArrayList<>(
+                    captures.size());
+            for (@Nullable
+            Object capture : captures) {
+                serializable.add(JacksonCodec.serializableParameter(capture));
+            }
+            this.captures = serializable;
+        }
+
+        private Object readResolve() {
+            return new JsFunction(body, Collections.unmodifiableList(captures),
+                    argumentNames);
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -92,6 +92,37 @@ public class JacksonCodec {
         }
     }
 
+    /**
+     * Converts a JavaScript parameter into a form that Java serialization can
+     * write to the HTTP session, without changing what the client eventually
+     * receives.
+     * <p>
+     * Values that are already {@link Serializable} are returned as-is, which
+     * keeps their encoding deferred to the moment the UIDL message is built.
+     * That matters for {@link com.vaadin.flow.dom.Element} and
+     * {@link ReturnChannelRegistration}, whose encoding depends on state that
+     * may still change: an element attached only after the session is restored
+     * must encode as a DOM reference, not as the {@code null} it would have
+     * produced earlier.
+     * <p>
+     * Anything else is encoded to JSON now and stored as the resulting
+     * {@link JsonNode}. Since {@link #encodeWithoutTypeInfo(Object)} passes a
+     * {@code JsonNode} through untouched, the client receives exactly the same
+     * message it would have received without the round trip. The value is
+     * therefore snapshotted: mutations made after the session is serialized are
+     * not visible to the browser.
+     *
+     * @param parameter
+     *            the parameter to convert, may be {@code null}
+     * @return an equivalent value that Java serialization can write
+     */
+    public static Object serializableParameter(Object parameter) {
+        if (parameter == null || parameter instanceof Serializable) {
+            return parameter;
+        }
+        return encodeWithTypeInfo(parameter);
+    }
+
     private static JsonNode encodeReturnChannel(
             ReturnChannelRegistration value) {
         ObjectMapper mapper = JacksonUtils.getMapper();

--- a/flow-server/src/test/java/com/vaadin/flow/component/JavaScriptInvocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/JavaScriptInvocationTest.java
@@ -21,6 +21,7 @@ import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.internal.JacksonCodec;
 import com.vaadin.flow.internal.JacksonUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,5 +43,27 @@ class JavaScriptInvocationTest {
         assertEquals("string", deserialized.getParameters().get(0));
         assertEquals("jsonString",
                 ((JsonNode) deserialized.getParameters().get(1)).asString());
+    }
+
+    @Test
+    void testSerializable_parameterNotSerializable_sameClientEncoding() {
+        // A bean Jackson can encode but Java serialization cannot write. It is
+        // stored as the JSON it encodes to, so the browser sees no difference.
+        JavaScriptInvocation invocation = new UIInternals.JavaScriptInvocation(
+                "expression", new NotSerializableBean());
+        JsonNode expected = JacksonCodec
+                .encodeWithTypeInfo(invocation.getParameters().get(0));
+
+        JavaScriptInvocation deserialized = SerializationUtils
+                .deserialize(SerializationUtils.serialize(invocation));
+
+        assertEquals(expected, JacksonCodec
+                .encodeWithTypeInfo(deserialized.getParameters().get(0)));
+    }
+
+    public static class NotSerializableBean {
+        public String getName() {
+            return "name";
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/JsFunctionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/JsFunctionTest.java
@@ -15,8 +15,18 @@
  */
 package com.vaadin.flow.dom;
 
-import org.junit.jupiter.api.Test;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+
+import com.vaadin.flow.internal.JacksonCodec;
+import com.vaadin.flow.internal.JacksonUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsFunctionTest {
@@ -25,5 +35,54 @@ class JsFunctionTest {
     void withArguments_alreadySet_throws() {
         JsFunction fn = JsFunction.of("return a;").withArguments("a");
         assertThrows(IllegalStateException.class, () -> fn.withArguments("b"));
+    }
+
+    @Test
+    void javaSerializationRoundTrip_preservesFunction() throws Exception {
+        JsFunction fn = JsFunction
+                .of("return $0($1)", JsFunction.of("return $0", "inner"),
+                        JacksonUtils.createObjectNode().put("a", 1))
+                .withArguments("event");
+
+        JsFunction restored = serializeAndDeserialize(fn);
+
+        assertEquals(fn.getBody(), restored.getBody());
+        assertEquals(fn.getArgumentNames(), restored.getArgumentNames());
+        assertEquals(2, restored.getCaptures().size());
+        assertEquals("inner", ((JsFunction) restored.getCaptures().get(0))
+                .getCaptures().get(0));
+    }
+
+    @Test
+    void javaSerializationRoundTrip_captureNotSerializable_sameClientEncoding()
+            throws Exception {
+        // A bean Jackson can encode but Java serialization cannot write. It is
+        // stored as the JSON it encodes to, so the browser sees no difference.
+        JsFunction fn = JsFunction.of("return $0", new NotSerializableBean());
+        JsonNode expected = JacksonCodec
+                .encodeWithTypeInfo(fn.getCaptures().get(0));
+
+        JsFunction restored = serializeAndDeserialize(fn);
+
+        assertEquals(expected,
+                JacksonCodec.encodeWithTypeInfo(restored.getCaptures().get(0)));
+    }
+
+    private static JsFunction serializeAndDeserialize(JsFunction fn)
+            throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(fn);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (JsFunction) in.readObject();
+        }
+    }
+
+    public static class NotSerializableBean {
+        public String getName() {
+            return "name";
+        }
     }
 }


### PR DESCRIPTION
JsFunction and JavaScriptInvocation both declare Serializable but hold their values in a List<Object>, so nothing stopped a value that Java serialization cannot write from ending up in the HTTP session. Neither is reliably transient: addJsInitializer retains a JsFunction for the lifetime of the registration so the initializer can be re-run on every re-attach, and an invocation waits in the session when its target element is not yet attached or is invisible. A bad value surfaced as a NotSerializableException during session passivation.

Two unrelated kinds of serialization are involved. Jackson encodes the values for the browser and works for any bean; Java serialization writes them to the session and works only for Serializable. Requiring Serializable would have narrowed what executeJs accepts, undoing the bean support added in #22378 and rejecting JsonNode-typed variables, since JsonNode does not itself declare Serializable.

Instead both types now write a serialization proxy that converts each value through JacksonCodec.serializableParameter: values that are already Serializable pass through untouched, and anything else is stored as the JSON it encodes to. encodeWithoutTypeInfo passes a JsonNode through unchanged, so the client receives an identical message.

Only non-serializable values are converted, which is what keeps Element and ReturnChannelRegistration encoding deferred to the moment the UIDL message is built — an element attached only after the session is restored must still encode as a DOM reference rather than the null it would have produced earlier. Restoring an invocation skips the constructor's dry-run encode, since deserialization can reach it before the state nodes behind element parameters are fully restored.
