### PR TITLE
chore: Clarify Signal.effect javadocs

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/Signal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/Signal.java
@@ -128,18 +128,24 @@ public interface Signal<T extends @Nullable Object> extends Serializable {
 
     /**
      * Creates a signal effect that is owned by a given component. The effect is
-     * enabled when the component is attached and automatically disabled when it
-     * is detached.
+     * enabled every time the component is attached and automatically disabled
+     * when it is detached.
      * <p>
      * Example of usage:
      *
      * <pre>
-     * Registration effect = Signal.effect(myComponent, () -> {
+     * Signal.effect(myComponent, () -> {
      *     Notification.show("Component is attached and signal value is "
      *             + someSignal.get());
      * });
-     * effect.remove(); // to remove the effect when no longer needed
      * </pre>
+     * 
+     * <p>
+     * It is recommended to create an effect once in a component constructor and
+     * rely on the automatic enabling and disabling of the effect as the owner
+     * component is attached and detached. Alternatively, the effect can be
+     * created in an attach handler while using the returned registration to
+     * close the effect in a corresponding detach handler.
      *
      * @param owner
      *            the owner component for which the effect is applied, must not
@@ -157,10 +163,10 @@ public interface Signal<T extends @Nullable Object> extends Serializable {
 
     /**
      * Creates a context-aware component-scoped signal effect. The effect is
-     * enabled when the component is attached and automatically disabled when it
-     * is detached. The action receives an {@link EffectContext} providing
-     * information about why the effect is running (initial render, effect
-     * owner's request, or background change).
+     * enabled every time the component is attached and automatically disabled
+     * when it is detached. The action receives an {@link EffectContext}
+     * providing information about why the effect is running (initial render,
+     * effect owner's request, or background change).
      * <p>
      * Example of usage:
      *
@@ -172,6 +178,13 @@ public interface Signal<T extends @Nullable Object> extends Serializable {
      *     }
      * });
      * </pre>
+     * 
+     * <p>
+     * It is recommended to create an effect once in a component constructor and
+     * rely on the automatic enabling and disabling of the effect as the owner
+     * component is attached and detached. Alternatively, the effect can be
+     * created in an attach handler while using the returned registration to
+     * close the effect in a corresponding detach handler.
      *
      * @param owner
      *            the owner component for which the effect is applied, must not


### PR DESCRIPTION
* Clarify that the effect is enabled again every time the owner component is attached
* Remove the use of a registration from the code example since that's the not recommended way of using
* Add a paragraph recommending to set up effects in component constructors while also mentioning that explicit removal is needed in a detach handler if the effect is created in an attach handler
