### PR TITLE
test: Check test sources with OnlyNullMarked like main sources

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -241,7 +241,7 @@
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:AnnotatedPackages=com.vaadin.flow.signals</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>


### PR DESCRIPTION
The testCompile execution listed com.vaadin.flow.signals as an annotated package while the compile execution relied on OnlyNullMarked. Test classes share package names with the main sources, so @NullMarked in the main package-info already covers them and the package list adds nothing: both settings produce identical NullAway diagnostics across the whole test tree.
