### PR TITLE
refactor: add ComponentUtil child-by-type helpers and use them in Table

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.NullMarked;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
@@ -81,7 +82,7 @@ public class Table extends HtmlComponent
      * @return the table's {@code <caption>}, or an empty optional.
      */
     private Optional<TableCaption> findCaption() {
-        return findChild(TableCaption.class);
+        return ComponentUtil.getFirstChildOfType(this, TableCaption.class);
     }
 
     /**
@@ -140,7 +141,7 @@ public class Table extends HtmlComponent
      * @return the table's {@code <thead>}, or an empty optional.
      */
     public Optional<TableHead> findHead() {
-        return findChild(TableHead.class);
+        return ComponentUtil.getFirstChildOfType(this, TableHead.class);
     }
 
     /**
@@ -177,7 +178,7 @@ public class Table extends HtmlComponent
      * @return the table's {@code <tfoot>}, or an empty optional.
      */
     public Optional<TableFoot> findFoot() {
-        return findChild(TableFoot.class);
+        return ComponentUtil.getFirstChildOfType(this, TableFoot.class);
     }
 
     /**
@@ -206,8 +207,7 @@ public class Table extends HtmlComponent
      * @return the table's bodies.
      */
     public List<TableBody> getBodies() {
-        return getChildren().filter(TableBody.class::isInstance)
-                .map(TableBody.class::cast).toList();
+        return ComponentUtil.getChildrenOfType(this, TableBody.class).toList();
     }
 
     /**
@@ -217,7 +217,8 @@ public class Table extends HtmlComponent
      * @return the table's first body.
      */
     public TableBody getBody() {
-        return findChild(TableBody.class).orElseGet(this::addBody);
+        return ComponentUtil.getFirstChildOfType(this, TableBody.class)
+                .orElseGet(this::addBody);
     }
 
     /**
@@ -250,11 +251,6 @@ public class Table extends HtmlComponent
      */
     public void removeBody(TableBody body) {
         removeChild(body);
-    }
-
-    private <T extends Component> Optional<T> findChild(Class<T> type) {
-        return getChildren().filter(type::isInstance).map(type::cast)
-                .findFirst();
     }
 
     private void removeChild(Component child) {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -75,7 +75,7 @@ public class Table extends HtmlComponent implements ClickNotifier<Table> {
      *
      * @return the table's {@code <caption>}, or an empty optional.
      */
-    public Optional<TableCaption> findCaption() {
+    private Optional<TableCaption> findCaption() {
         return findChild(TableCaption.class);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -18,8 +18,11 @@ package com.vaadin.flow.component.html;
 import java.util.List;
 import java.util.Optional;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.dom.Element;
@@ -41,8 +44,10 @@ import com.vaadin.flow.dom.Element;
  *      &lt;table&gt; — The Table element</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.TABLE)
-public class Table extends HtmlComponent implements ClickNotifier<Table> {
+public class Table extends HtmlComponent
+        implements ClickNotifier<Table>, HasAriaLabel {
 
     /**
      * Ranks of the children of a <code>&lt;table&gt;</code>, in the order the

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.dom.Element;
+
+/**
+ * Component representing a <code>&lt;table&gt;</code> element.
+ * <p>
+ * Unlike the deprecated {@link NativeTable}, this component does not extend
+ * {@link com.vaadin.flow.component.HtmlContainer}, so it has no generic
+ * {@code add(Component)}. A <code>&lt;table&gt;</code> may only contain a
+ * {@code <caption>}, {@code <thead>}, {@code <tbody>} and {@code <tfoot>}, and
+ * those are reached through the accessors below, which also keep them in the
+ * order the WHATWG HTML specification requires.
+ *
+ * @see <a href="https://html.spec.whatwg.org/multipage/tables.html">WHATWG
+ *      HTML: Tabular data</a>
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table">MDN:
+ *      &lt;table&gt; — The Table element</a>
+ * @since 25.3
+ */
+@Tag(Tag.TABLE)
+public class Table extends HtmlComponent implements ClickNotifier<Table> {
+
+    /**
+     * Ranks of the children of a <code>&lt;table&gt;</code>, in the order the
+     * HTML specification requires them to appear.
+     */
+    private static final int RANK_CAPTION = 0;
+    private static final int RANK_HEAD = 1;
+    private static final int RANK_BODY = 2;
+    private static final int RANK_FOOT = 3;
+
+    /**
+     * Creates a new empty table.
+     */
+    public Table() {
+        super();
+    }
+
+    /**
+     * Returns this table's caption, creating one if the table has none.
+     *
+     * @return the table's {@code <caption>}.
+     */
+    public TableCaption getCaption() {
+        return findCaption()
+                .orElseGet(() -> insert(new TableCaption(), RANK_CAPTION));
+    }
+
+    /**
+     * Returns this table's caption if it has one, without creating it.
+     *
+     * @return the table's {@code <caption>}, or an empty optional.
+     */
+    public Optional<TableCaption> findCaption() {
+        return findChild(TableCaption.class);
+    }
+
+    /**
+     * Returns the text content of this table's caption, or an empty string if
+     * the table has no caption. Unlike {@link #getCaption()}, this does not
+     * create one.
+     *
+     * @return the caption text, never {@code null}.
+     */
+    public String getCaptionText() {
+        return findCaption().map(TableCaption::getText).orElse("");
+    }
+
+    /**
+     * Sets the text content of this table's caption, creating the caption if
+     * the table has none.
+     *
+     * @param text
+     *            the caption text.
+     */
+    public void setCaptionText(String text) {
+        getCaption().setText(text);
+    }
+
+    /**
+     * Puts the given caption on this table, replacing the one it already has,
+     * if any.
+     *
+     * @param caption
+     *            the caption to use.
+     */
+    public void setCaption(TableCaption caption) {
+        removeCaption();
+        insert(caption, RANK_CAPTION);
+    }
+
+    /**
+     * Removes this table's caption, if it has one.
+     */
+    public void removeCaption() {
+        findCaption().ifPresent(this::removeChild);
+    }
+
+    /**
+     * Returns this table's {@code <thead>}, creating one if the table has none.
+     *
+     * @return the table's {@code <thead>}.
+     */
+    public TableHead getHead() {
+        return findHead().orElseGet(() -> insert(new TableHead(), RANK_HEAD));
+    }
+
+    /**
+     * Returns this table's {@code <thead>} if it has one, without creating it.
+     *
+     * @return the table's {@code <thead>}, or an empty optional.
+     */
+    public Optional<TableHead> findHead() {
+        return findChild(TableHead.class);
+    }
+
+    /**
+     * Puts the given {@code <thead>} on this table, replacing the one it
+     * already has, if any.
+     *
+     * @param head
+     *            the head to use.
+     */
+    public void setHead(TableHead head) {
+        removeHead();
+        insert(head, RANK_HEAD);
+    }
+
+    /**
+     * Removes this table's {@code <thead>}, if it has one.
+     */
+    public void removeHead() {
+        findHead().ifPresent(this::removeChild);
+    }
+
+    /**
+     * Returns this table's {@code <tfoot>}, creating one if the table has none.
+     *
+     * @return the table's {@code <tfoot>}.
+     */
+    public TableFoot getFoot() {
+        return findFoot().orElseGet(() -> insert(new TableFoot(), RANK_FOOT));
+    }
+
+    /**
+     * Returns this table's {@code <tfoot>} if it has one, without creating it.
+     *
+     * @return the table's {@code <tfoot>}, or an empty optional.
+     */
+    public Optional<TableFoot> findFoot() {
+        return findChild(TableFoot.class);
+    }
+
+    /**
+     * Puts the given {@code <tfoot>} on this table, replacing the one it
+     * already has, if any.
+     *
+     * @param foot
+     *            the foot to use.
+     */
+    public void setFoot(TableFoot foot) {
+        removeFoot();
+        insert(foot, RANK_FOOT);
+    }
+
+    /**
+     * Removes this table's {@code <tfoot>}, if it has one.
+     */
+    public void removeFoot() {
+        findFoot().ifPresent(this::removeChild);
+    }
+
+    /**
+     * Returns the {@code <tbody>} elements of this table, in document order. A
+     * table may have several.
+     *
+     * @return the table's bodies.
+     */
+    public List<TableBody> getBodies() {
+        return getChildren().filter(TableBody.class::isInstance)
+                .map(TableBody.class::cast).toList();
+    }
+
+    /**
+     * Returns the first {@code <tbody>} of this table, creating one if the
+     * table has none.
+     *
+     * @return the table's first body.
+     */
+    public TableBody getBody() {
+        return findChild(TableBody.class).orElseGet(this::addBody);
+    }
+
+    /**
+     * Appends a new {@code <tbody>} to this table, after any bodies it already
+     * has and before the {@code <tfoot>}.
+     *
+     * @return the new body.
+     */
+    public TableBody addBody() {
+        return addBody(new TableBody());
+    }
+
+    /**
+     * Appends the given {@code <tbody>} to this table, after any bodies it
+     * already has and before the {@code <tfoot>}.
+     *
+     * @param body
+     *            the body to add.
+     * @return the given body, for chaining.
+     */
+    public TableBody addBody(TableBody body) {
+        return insert(body, RANK_BODY);
+    }
+
+    /**
+     * Removes the given {@code <tbody>} from this table.
+     *
+     * @param body
+     *            the body to remove.
+     */
+    public void removeBody(TableBody body) {
+        removeChild(body);
+    }
+
+    private <T extends Component> Optional<T> findChild(Class<T> type) {
+        return getChildren().filter(type::isInstance).map(type::cast)
+                .findFirst();
+    }
+
+    private void removeChild(Component child) {
+        getElement().removeChild(child.getElement());
+    }
+
+    /**
+     * Inserts the given child at the position its rank calls for, i.e. before
+     * the first child that must come after it.
+     */
+    private <T extends Component> T insert(T child, int rank) {
+        List<Element> children = getElement().getChildren().toList();
+        int index = children.size();
+        for (int i = 0; i < children.size(); i++) {
+            if (rankOf(children.get(i)) > rank) {
+                index = i;
+                break;
+            }
+        }
+        getElement().insertChild(index, child.getElement());
+        return child;
+    }
+
+    private static int rankOf(Element child) {
+        Component component = child.getComponent().orElse(null);
+        if (component instanceof TableCaption) {
+            return RANK_CAPTION;
+        }
+        if (component instanceof TableHead) {
+            return RANK_HEAD;
+        }
+        if (component instanceof TableBody) {
+            return RANK_BODY;
+        }
+        // Anything else, the foot included, sorts last
+        return RANK_FOOT;
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableBody.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableBody.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;tbody&gt;</code> element — a group of data
+ * rows.
+ * <p>
+ * A {@code <tbody>} may only contain rows, so this component exposes the
+ * {@link TableRow} operations rather than a generic {@code add(Component)}.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tbody">MDN:
+ *      &lt;tbody&gt;</a>
+ * @since 25.3
+ */
+@Tag(Tag.TBODY)
+public class TableBody extends HtmlComponent
+        implements TableRowContainer, ClickNotifier<TableBody> {
+
+    /**
+     * Creates a new empty {@code <tbody>}.
+     */
+    public TableBody() {
+        super();
+    }
+
+    /**
+     * Creates a new {@code <tbody>} with the given rows.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public TableBody(TableRow... rows) {
+        super();
+        addRows(rows);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableBody.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableBody.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
@@ -31,6 +33,7 @@ import com.vaadin.flow.component.Tag;
  *      &lt;tbody&gt;</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.TBODY)
 public class TableBody extends HtmlComponent
         implements TableRowContainer, ClickNotifier<TableBody> {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCaption.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCaption.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;caption&gt;</code> element — the title of
+ * a {@link Table}, announced by assistive technologies as the table's name.
+ * <p>
+ * A caption holds flow content, so unlike the table itself it does extend
+ * {@link HtmlContainer}: anything may go inside it.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/caption">MDN:
+ *      &lt;caption&gt; — The Table Caption element</a>
+ * @since 25.3
+ */
+@Tag(Tag.CAPTION)
+public class TableCaption extends HtmlContainer {
+
+    /**
+     * Creates a new empty caption.
+     */
+    public TableCaption() {
+        super();
+    }
+
+    /**
+     * Creates a new caption with the given children.
+     *
+     * @param components
+     *            the children components.
+     */
+    public TableCaption(Component... components) {
+        super(components);
+    }
+
+    /**
+     * Creates a new caption with the given text.
+     *
+     * @param text
+     *            the caption text.
+     */
+    public TableCaption(String text) {
+        super();
+        setText(text);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCaption.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCaption.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
@@ -31,6 +33,7 @@ import com.vaadin.flow.component.Tag;
  *      &lt;caption&gt; — The Table Caption element</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.CAPTION)
 public class TableCaption extends HtmlContainer {
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
 
@@ -30,6 +32,7 @@ import com.vaadin.flow.component.HtmlContainer;
  *
  * @since 25.3
  */
+@NullMarked
 public abstract class TableCell extends HtmlContainer {
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+
+/**
+ * Base class for the two kinds of cell a {@link TableRow} can hold: a
+ * {@link TableDataCell} (<code>&lt;td&gt;</code>) and a {@link TableHeaderCell}
+ * (<code>&lt;th&gt;</code>). It exists so that operations that do not care
+ * which kind a cell is — {@link TableRow#getCells()} and
+ * {@link TableRow#removeCell(TableCell)} — have a type to speak in.
+ * <p>
+ * Cells hold flow content, so this class does extend {@link HtmlContainer}:
+ * anything may go inside a cell.
+ *
+ * @since 25.3
+ */
+public abstract class TableCell extends HtmlContainer {
+
+    /**
+     * Creates a new empty cell.
+     */
+    protected TableCell() {
+        super();
+    }
+
+    /**
+     * Creates a new cell with the given children.
+     *
+     * @param components
+     *            the children components.
+     */
+    protected TableCell(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
@@ -86,11 +86,7 @@ public class TableDataCell extends TableCell
      *            a non-negative integer.
      */
     public void setColspan(int colspan) {
-        if (colspan < 0) {
-            throw new IllegalArgumentException(
-                    "colspan must be a non-negative integer value");
-        }
-        getElement().setAttribute(ATTRIBUTE_COLSPAN, String.valueOf(colspan));
+        setSpan(ATTRIBUTE_COLSPAN, colspan);
     }
 
     /**
@@ -99,11 +95,7 @@ public class TableDataCell extends TableCell
      * @return the current colspan. Default is 1.
      */
     public int getColspan() {
-        String colspan = getElement().getAttribute(ATTRIBUTE_COLSPAN);
-        if (colspan == null) {
-            colspan = "1";
-        }
-        return Integer.parseInt(colspan);
+        return getSpan(ATTRIBUTE_COLSPAN);
     }
 
     /**
@@ -121,11 +113,7 @@ public class TableDataCell extends TableCell
      *            a non-negative integer.
      */
     public void setRowspan(int rowspan) {
-        if (rowspan < 0) {
-            throw new IllegalArgumentException(
-                    "rowspan must be a non-negative integer value");
-        }
-        getElement().setAttribute(ATTRIBUTE_ROWSPAN, String.valueOf(rowspan));
+        setSpan(ATTRIBUTE_ROWSPAN, rowspan);
     }
 
     /**
@@ -134,11 +122,7 @@ public class TableDataCell extends TableCell
      * @return the current rowspan. Default is 1.
      */
     public int getRowspan() {
-        String rowspan = getElement().getAttribute(ATTRIBUTE_ROWSPAN);
-        if (rowspan == null) {
-            rowspan = "1";
-        }
-        return Integer.parseInt(rowspan);
+        return getSpan(ATTRIBUTE_ROWSPAN);
     }
 
     /**
@@ -146,5 +130,18 @@ public class TableDataCell extends TableCell
      */
     public void resetRowspan() {
         getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
+    }
+
+    private void setSpan(String attribute, int span) {
+        if (span < 0) {
+            throw new IllegalArgumentException(
+                    attribute + " must be a non-negative integer value");
+        }
+        getElement().setAttribute(attribute, String.valueOf(span));
+    }
+
+    private int getSpan(String attribute) {
+        String span = getElement().getAttribute(attribute);
+        return span == null ? 1 : Integer.parseInt(span);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
@@ -81,12 +81,23 @@ public class TableDataCell extends TableCell
     /**
      * Sets the {@code colspan} attribute — how many columns this cell spans.
      * The default is {@code 1}.
+     * <p>
+     * Unlike {@link #setRowspan(int)}, zero is not allowed: the "span the rest
+     * of the column group" meaning it once had was dropped from HTML, and
+     * browsers now clamp it back to {@code 1}. Values above 1000 are clamped to
+     * 1000.
      *
      * @param colspan
-     *            a non-negative integer.
+     *            a positive integer.
+     * @throws IllegalArgumentException
+     *             if {@code colspan} is less than 1.
      */
     public void setColspan(int colspan) {
-        setSpan(ATTRIBUTE_COLSPAN, colspan);
+        if (colspan < 1) {
+            throw new IllegalArgumentException(
+                    "colspan must be a positive integer value");
+        }
+        setSpanAttribute(ATTRIBUTE_COLSPAN, colspan);
     }
 
     /**
@@ -108,12 +119,24 @@ public class TableDataCell extends TableCell
     /**
      * Sets the {@code rowspan} attribute — how many rows this cell spans. The
      * default is {@code 1}.
+     * <p>
+     * Zero is allowed and still means something in HTML: the cell extends to
+     * the end of the row group ({@code <thead>}, {@code <tbody>} or
+     * {@code <tfoot>}, even an implicit one) it belongs to. Values above 65534
+     * are clamped to 65534.
      *
      * @param rowspan
-     *            a non-negative integer.
+     *            a non-negative integer, where 0 spans the rest of the row
+     *            group.
+     * @throws IllegalArgumentException
+     *             if {@code rowspan} is negative.
      */
     public void setRowspan(int rowspan) {
-        setSpan(ATTRIBUTE_ROWSPAN, rowspan);
+        if (rowspan < 0) {
+            throw new IllegalArgumentException(
+                    "rowspan must be a non-negative integer value");
+        }
+        setSpanAttribute(ATTRIBUTE_ROWSPAN, rowspan);
     }
 
     /**
@@ -132,11 +155,7 @@ public class TableDataCell extends TableCell
         getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
     }
 
-    private void setSpan(String attribute, int span) {
-        if (span < 0) {
-            throw new IllegalArgumentException(
-                    attribute + " must be a non-negative integer value");
-        }
+    private void setSpanAttribute(String attribute, int span) {
         getElement().setAttribute(attribute, String.valueOf(span));
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.signals.Signal;
+
+/**
+ * Component representing a <code>&lt;td&gt;</code> element — a data cell in a
+ * {@link TableRow}.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td">MDN:
+ *      &lt;td&gt; — The Table Data Cell element</a>
+ * @since 25.3
+ */
+@Tag(Tag.TD)
+public class TableDataCell extends TableCell
+        implements ClickNotifier<TableDataCell> {
+
+    private static final String ATTRIBUTE_COLSPAN = "colspan";
+    private static final String ATTRIBUTE_ROWSPAN = "rowspan";
+
+    /**
+     * Creates a new empty data cell.
+     */
+    public TableDataCell() {
+        super();
+    }
+
+    /**
+     * Creates a new data cell with the given children.
+     *
+     * @param components
+     *            the children components.
+     */
+    public TableDataCell(Component... components) {
+        super(components);
+    }
+
+    /**
+     * Creates a new data cell with the given text.
+     *
+     * @param text
+     *            the text.
+     */
+    public TableDataCell(String text) {
+        super();
+        setText(text);
+    }
+
+    /**
+     * Creates a new data cell with its text content bound to the given signal.
+     *
+     * @param textSignal
+     *            the signal to bind, not {@code null}
+     * @see #bindText(Signal)
+     */
+    public TableDataCell(Signal<String> textSignal) {
+        Objects.requireNonNull(textSignal, "textSignal must not be null");
+        bindText(textSignal);
+    }
+
+    /**
+     * Sets the {@code colspan} attribute — how many columns this cell spans.
+     * The default is {@code 1}.
+     *
+     * @param colspan
+     *            a non-negative integer.
+     */
+    public void setColspan(int colspan) {
+        if (colspan < 0) {
+            throw new IllegalArgumentException(
+                    "colspan must be a non-negative integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_COLSPAN, String.valueOf(colspan));
+    }
+
+    /**
+     * Returns the value of the {@code colspan} attribute.
+     *
+     * @return the current colspan. Default is 1.
+     */
+    public int getColspan() {
+        String colspan = getElement().getAttribute(ATTRIBUTE_COLSPAN);
+        if (colspan == null) {
+            colspan = "1";
+        }
+        return Integer.parseInt(colspan);
+    }
+
+    /**
+     * Resets the colspan to its default value of 1.
+     */
+    public void resetColspan() {
+        getElement().removeAttribute(ATTRIBUTE_COLSPAN);
+    }
+
+    /**
+     * Sets the {@code rowspan} attribute — how many rows this cell spans. The
+     * default is {@code 1}.
+     *
+     * @param rowspan
+     *            a non-negative integer.
+     */
+    public void setRowspan(int rowspan) {
+        if (rowspan < 0) {
+            throw new IllegalArgumentException(
+                    "rowspan must be a non-negative integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_ROWSPAN, String.valueOf(rowspan));
+    }
+
+    /**
+     * Returns the value of the {@code rowspan} attribute.
+     *
+     * @return the current rowspan. Default is 1.
+     */
+    public int getRowspan() {
+        String rowspan = getElement().getAttribute(ATTRIBUTE_ROWSPAN);
+        if (rowspan == null) {
+            rowspan = "1";
+        }
+        return Integer.parseInt(rowspan);
+    }
+
+    /**
+     * Resets the rowspan to its default value of 1.
+     */
+    public void resetRowspan() {
+        getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.html;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
@@ -31,6 +33,7 @@ import com.vaadin.flow.signals.Signal;
  *      &lt;td&gt; — The Table Data Cell element</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.TD)
 public class TableDataCell extends TableCell
         implements ClickNotifier<TableDataCell> {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableFoot.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableFoot.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
@@ -31,6 +33,7 @@ import com.vaadin.flow.component.Tag;
  *      &lt;tfoot&gt;</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.TFOOT)
 public class TableFoot extends HtmlComponent
         implements TableRowContainer, ClickNotifier<TableFoot> {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableFoot.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableFoot.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;tfoot&gt;</code> element — the footer rows
+ * of a table.
+ * <p>
+ * A {@code <tfoot>} may only contain rows, so this component exposes the
+ * {@link TableRow} operations rather than a generic {@code add(Component)}.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tfoot">MDN:
+ *      &lt;tfoot&gt;</a>
+ * @since 25.3
+ */
+@Tag(Tag.TFOOT)
+public class TableFoot extends HtmlComponent
+        implements TableRowContainer, ClickNotifier<TableFoot> {
+
+    /**
+     * Creates a new empty {@code <tfoot>}.
+     */
+    public TableFoot() {
+        super();
+    }
+
+    /**
+     * Creates a new {@code <tfoot>} with the given rows.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public TableFoot(TableRow... rows) {
+        super();
+        addRows(rows);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHead.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHead.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;thead&gt;</code> element — the header rows
+ * of a table.
+ * <p>
+ * A {@code <thead>} may only contain rows, so this component exposes the
+ * {@link TableRow} operations rather than a generic {@code add(Component)}.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/thead">MDN:
+ *      &lt;thead&gt;</a>
+ * @since 25.3
+ */
+@Tag(Tag.THEAD)
+public class TableHead extends HtmlComponent
+        implements TableRowContainer, ClickNotifier<TableHead> {
+
+    /**
+     * Creates a new empty {@code <thead>}.
+     */
+    public TableHead() {
+        super();
+    }
+
+    /**
+     * Creates a new {@code <thead>} with the given rows.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public TableHead(TableRow... rows) {
+        super();
+        addRows(rows);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHead.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHead.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
@@ -31,6 +33,7 @@ import com.vaadin.flow.component.Tag;
  *      &lt;thead&gt;</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.THEAD)
 public class TableHead extends HtmlComponent
         implements TableRowContainer, ClickNotifier<TableHead> {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.signals.Signal;
+
+/**
+ * Component representing a <code>&lt;th&gt;</code> element — a header cell that
+ * labels a row or a column of a {@link Table}.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th">MDN:
+ *      &lt;th&gt; — The Table Header element</a>
+ * @since 25.3
+ */
+@Tag(Tag.TH)
+public class TableHeaderCell extends TableCell
+        implements ClickNotifier<TableHeaderCell> {
+
+    /**
+     * Creates a new empty header cell.
+     */
+    public TableHeaderCell() {
+        super();
+    }
+
+    /**
+     * Creates a new header cell with the given children.
+     *
+     * @param components
+     *            the children components.
+     */
+    public TableHeaderCell(Component... components) {
+        super(components);
+    }
+
+    /**
+     * Creates a new header cell with the given text.
+     *
+     * @param text
+     *            the text.
+     */
+    public TableHeaderCell(String text) {
+        super();
+        setText(text);
+    }
+
+    /**
+     * Creates a new header cell with its text content bound to the given
+     * signal.
+     *
+     * @param textSignal
+     *            the signal to bind, not {@code null}
+     * @see #bindText(Signal)
+     */
+    public TableHeaderCell(Signal<String> textSignal) {
+        Objects.requireNonNull(textSignal, "textSignal must not be null");
+        bindText(textSignal);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.html;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
@@ -31,6 +33,7 @@ import com.vaadin.flow.signals.Signal;
  *      &lt;th&gt; — The Table Header element</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.TH)
 public class TableHeaderCell extends TableCell
         implements ClickNotifier<TableHeaderCell> {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.html;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlComponent;
@@ -35,6 +37,7 @@ import com.vaadin.flow.component.Tag;
  *      &lt;tr&gt; — The Table Row element</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.TR)
 public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.NullMarked;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
 
@@ -173,7 +174,7 @@ public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
     }
 
     private <T extends Component> List<T> cellsOfType(Class<T> type) {
-        return getChildren().filter(type::isInstance).map(type::cast).toList();
+        return ComponentUtil.getChildrenOfType(this, type).toList();
     }
 
     private <T extends TableCell> T append(T cell) {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;tr&gt;</code> element — a row of a
+ * {@link Table}.
+ * <p>
+ * A <code>&lt;tr&gt;</code> may only contain <code>&lt;td&gt;</code> and
+ * <code>&lt;th&gt;</code> cells, so this component has no generic
+ * {@code add(Component)}; put content inside the cells instead.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr">MDN:
+ *      &lt;tr&gt; — The Table Row element</a>
+ * @since 25.3
+ */
+@Tag(Tag.TR)
+public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
+
+    /**
+     * Creates a new empty row.
+     */
+    public TableRow() {
+        super();
+    }
+
+    /**
+     * Creates a new row with the given cells.
+     *
+     * @param cells
+     *            the cells to add.
+     */
+    public TableRow(TableCell... cells) {
+        super();
+        addCells(cells);
+    }
+
+    /**
+     * Appends the given cells to this row.
+     *
+     * @param cells
+     *            the cells to add.
+     */
+    public void addCells(TableCell... cells) {
+        for (TableCell cell : cells) {
+            getElement().appendChild(cell.getElement());
+        }
+    }
+
+    /**
+     * Inserts the given cell at the given position.
+     *
+     * @param position
+     *            the position to insert the cell at, between 0 and the number
+     *            of cells in this row.
+     * @param cell
+     *            the cell to insert.
+     */
+    public void insertCell(int position, TableCell cell) {
+        getElement().insertChild(position, cell.getElement());
+    }
+
+    /**
+     * Appends a new empty header cell to this row.
+     *
+     * @return the new {@code <th>}.
+     */
+    public TableHeaderCell addHeaderCell() {
+        return append(new TableHeaderCell());
+    }
+
+    /**
+     * Inserts a new empty header cell at the given position.
+     *
+     * @param position
+     *            the position to insert the cell at, between 0 and the number
+     *            of cells in this row.
+     * @return the new {@code <th>}.
+     */
+    public TableHeaderCell insertHeaderCell(int position) {
+        return insert(new TableHeaderCell(), position);
+    }
+
+    /**
+     * Appends a new empty data cell to this row.
+     *
+     * @return the new {@code <td>}.
+     */
+    public TableDataCell addDataCell() {
+        return append(new TableDataCell());
+    }
+
+    /**
+     * Inserts a new empty data cell at the given position.
+     *
+     * @param position
+     *            the position to insert the cell at, between 0 and the number
+     *            of cells in this row.
+     * @return the new {@code <td>}.
+     */
+    public TableDataCell insertDataCell(int position) {
+        return insert(new TableDataCell(), position);
+    }
+
+    /**
+     * Returns the header cells of this row, in document order.
+     *
+     * @return this row's {@code <th>} cells.
+     */
+    public List<TableHeaderCell> getHeaderCells() {
+        return cellsOfType(TableHeaderCell.class);
+    }
+
+    /**
+     * Returns the data cells of this row, in document order.
+     *
+     * @return this row's {@code <td>} cells.
+     */
+    public List<TableDataCell> getDataCells() {
+        return cellsOfType(TableDataCell.class);
+    }
+
+    /**
+     * Returns every cell of this row, in document order, both kinds combined.
+     * For kind-specific lists use {@link #getHeaderCells()} or
+     * {@link #getDataCells()}.
+     *
+     * @return this row's cells.
+     */
+    public List<TableCell> getCells() {
+        return cellsOfType(TableCell.class);
+    }
+
+    /**
+     * Removes the given cell from this row.
+     *
+     * @param cell
+     *            the cell to remove.
+     */
+    public void removeCell(TableCell cell) {
+        getElement().removeChild(cell.getElement());
+    }
+
+    /**
+     * Removes every cell from this row.
+     */
+    public void removeAllCells() {
+        getElement().removeAllChildren();
+    }
+
+    private <T extends Component> List<T> cellsOfType(Class<T> type) {
+        return getChildren().filter(type::isInstance).map(type::cast).toList();
+    }
+
+    private <T extends TableCell> T append(T cell) {
+        getElement().appendChild(cell.getElement());
+        return cell;
+    }
+
+    private <T extends TableCell> T insert(T cell, int position) {
+        getElement().insertChild(position, cell.getElement());
+        return cell;
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.html;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 
@@ -32,6 +34,7 @@ import com.vaadin.flow.component.HasElement;
  *
  * @since 25.3
  */
+@NullMarked
 interface TableRowContainer extends HasElement {
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * A container of <code>&lt;tr&gt;</code> elements, implemented by
+ * {@link TableHead}, {@link TableBody} and {@link TableFoot}.
+ * <p>
+ * The WHATWG HTML specification allows nothing but rows inside those three
+ * elements, so the operations here are the only ones offered: there is
+ * deliberately no generic {@code add(Component)}.
+ * <p>
+ * Implementers must be {@link Component} instances.
+ *
+ * @since 25.3
+ */
+interface TableRowContainer extends HasElement {
+
+    /**
+     * Returns the rows in this container, in document order.
+     *
+     * @return the rows in this container.
+     */
+    default List<TableRow> getRows() {
+        return ((Component) this).getChildren()
+                .filter(TableRow.class::isInstance).map(TableRow.class::cast)
+                .toList();
+    }
+
+    /**
+     * Appends a new empty row to this container.
+     *
+     * @return the new row.
+     */
+    default TableRow addRow() {
+        TableRow row = new TableRow();
+        getElement().appendChild(row.getElement());
+        return row;
+    }
+
+    /**
+     * Appends the given rows to this container.
+     *
+     * @param rows
+     *            the rows to append.
+     */
+    default void addRows(TableRow... rows) {
+        for (TableRow row : rows) {
+            getElement().appendChild(row.getElement());
+        }
+    }
+
+    /**
+     * Inserts a new empty row at the given position.
+     *
+     * @param position
+     *            the position to insert the row at, between 0 and the number of
+     *            children in this container.
+     * @return the new row.
+     */
+    default TableRow insertRow(int position) {
+        TableRow row = new TableRow();
+        getElement().insertChild(position, row.getElement());
+        return row;
+    }
+
+    /**
+     * Replaces the row at the given position with the given one.
+     *
+     * @param position
+     *            the position of the row to replace.
+     * @param row
+     *            the row to put there instead.
+     */
+    default void replaceRow(int position, TableRow row) {
+        getElement().setChild(position, row.getElement());
+    }
+
+    /**
+     * Removes the given rows from this container.
+     *
+     * @param rows
+     *            the rows to remove.
+     */
+    default void removeRows(TableRow... rows) {
+        for (TableRow row : rows) {
+            getElement().removeChild(row.getElement());
+        }
+    }
+
+    /**
+     * Removes every row from this container.
+     */
+    default void removeAllRows() {
+        getElement().removeAllChildren();
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.jspecify.annotations.NullMarked;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasElement;
 
 /**
@@ -43,8 +44,7 @@ interface TableRowContainer extends HasElement {
      * @return the rows in this container.
      */
     default List<TableRow> getRows() {
-        return ((Component) this).getChildren()
-                .filter(TableRow.class::isInstance).map(TableRow.class::cast)
+        return ComponentUtil.getChildrenOfType((Component) this, TableRow.class)
                 .toList();
     }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -78,11 +78,6 @@ class HtmlComponentSmokeTest {
                         IFrame.SandboxType.ALLOW_MODALS });
         testValues.put(Component.class, new Paragraph("Component"));
         testValues.put(HasText.WhiteSpace.class, HasText.WhiteSpace.PRE_LINE);
-        // Table.setCaption/setHead/setFoot attach a child rather than write a
-        // property, but the setter/getter round trip still holds
-        testValues.put(TableCaption.class, new TableCaption("Caption"));
-        testValues.put(TableHead.class, new TableHead());
-        testValues.put(TableFoot.class, new TableFoot());
     }
 
     private static final Map<Class<?>, Map<Class<?>, Object>> specialTestValues = new HashMap<>();
@@ -225,6 +220,14 @@ class HtmlComponentSmokeTest {
         if (method.getDeclaringClass() == HasAriaLabel.class
                 && method.getName().equals("setAriaLabelledBy")
                 && method.getParameterTypes()[0] == Component.class) {
+            return true;
+        }
+
+        // Table.setCaption/setHead/setFoot attach a child rather than write a
+        // property; TableTest covers them, and feeding a shared component
+        // instance through this walk would leave it parented
+        if (method.getDeclaringClass() == Table.class && Component.class
+                .isAssignableFrom(method.getParameterTypes()[0])) {
             return true;
         }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -78,6 +78,11 @@ class HtmlComponentSmokeTest {
                         IFrame.SandboxType.ALLOW_MODALS });
         testValues.put(Component.class, new Paragraph("Component"));
         testValues.put(HasText.WhiteSpace.class, HasText.WhiteSpace.PRE_LINE);
+        // Table.setCaption/setHead/setFoot attach a child rather than write a
+        // property, but the setter/getter round trip still holds
+        testValues.put(TableCaption.class, new TableCaption("Caption"));
+        testValues.put(TableHead.class, new TableHead());
+        testValues.put(TableFoot.class, new TableFoot());
     }
 
     private static final Map<Class<?>, Map<Class<?>, Object>> specialTestValues = new HashMap<>();
@@ -425,7 +430,10 @@ class HtmlComponentSmokeTest {
     }
 
     private static boolean isHtmlComponentSubclass(Class<?> cls) {
-        return HtmlComponent.class.isAssignableFrom(cls);
+        // Abstract bases such as TableCell cannot be instantiated; they are
+        // covered through their concrete subclasses
+        return HtmlComponent.class.isAssignableFrom(cls)
+                && !Modifier.isAbstract(cls.getModifiers());
     }
 
     private static Class<? extends HtmlComponent> asHtmlComponentSubclass(

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableBodyTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableBodyTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+class TableBodyTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCaptionTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCaptionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TableCaptionTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+    @Test
+    void constructors_setTextAndChildren() {
+        assertEquals("Planets", new TableCaption("Planets").getText());
+
+        var span = new Span("rich");
+        assertEquals(List.of(span),
+                new TableCaption(span).getChildren().toList());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.SignalsUnitTest;
+import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.local.ValueSignal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Exercises the constructors both {@link TableCell} subclasses inherit, through
+ * each of them.
+ */
+class TableCellTest extends SignalsUnitTest {
+
+    static Stream<Named<Function<Component[], TableCell>>> childrenConstructors() {
+        return Stream.of(Named.of("td", TableDataCell::new),
+                Named.of("th", TableHeaderCell::new));
+    }
+
+    @ParameterizedTest
+    @MethodSource("childrenConstructors")
+    void childrenConstructor_addsGivenChildren(
+            Function<Component[], TableCell> constructor) {
+        Span span = new Span("a");
+        Paragraph paragraph = new Paragraph("b");
+
+        TableCell cell = constructor.apply(new Component[] { span, paragraph });
+
+        assertEquals(List.of(span, paragraph), cell.getChildren().toList());
+    }
+
+    static Stream<Named<Function<String, TableCell>>> textConstructors() {
+        return Stream.of(Named.of("td", TableDataCell::new),
+                Named.of("th", TableHeaderCell::new));
+    }
+
+    @ParameterizedTest
+    @MethodSource("textConstructors")
+    void textConstructor_setsTheText(Function<String, TableCell> constructor) {
+        TableCell cell = constructor.apply("content");
+
+        assertEquals("content", cell.getText());
+    }
+
+    static Stream<Named<Function<Signal<String>, TableCell>>> signalConstructors() {
+        return Stream.of(Named.of("td", TableDataCell::new),
+                Named.of("th", TableHeaderCell::new));
+    }
+
+    @ParameterizedTest
+    @MethodSource("signalConstructors")
+    void signalConstructor_bindsTheText(
+            Function<Signal<String>, TableCell> constructor) {
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+
+        TableCell cell = constructor.apply(signal);
+        UI.getCurrent().add(cell);
+
+        assertEquals("initial", cell.getText());
+        signal.set("updated");
+        assertEquals("updated", cell.getText());
+    }
+
+    @ParameterizedTest
+    @MethodSource("signalConstructors")
+    void signalConstructor_nullSignal_throws(
+            Function<Signal<String>, TableCell> constructor) {
+        assertThrows(NullPointerException.class, () -> constructor.apply(null));
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TableDataCellTest extends ComponentTest {
+    // Property tests in super class
+
+    @Override
+    protected void addProperties() {
+        addProperty("colspan", int.class, 1, 2, false, false);
+        addProperty("rowspan", int.class, 1, 2, false, false);
+    }
+
+    @Test
+    void spansDefaultToOne() {
+        TableDataCell cell = (TableDataCell) getComponent();
+
+        assertEquals(1, cell.getColspan());
+        assertEquals(1, cell.getRowspan());
+    }
+
+    @Test
+    void resetSpans_removeTheAttributes() {
+        TableDataCell cell = (TableDataCell) getComponent();
+        cell.setColspan(2);
+        cell.setRowspan(3);
+
+        cell.resetColspan();
+        cell.resetRowspan();
+
+        assertNull(cell.getElement().getAttribute("colspan"));
+        assertNull(cell.getElement().getAttribute("rowspan"));
+    }
+
+    @Test
+    void spans_rejectNegativeValues() {
+        TableDataCell cell = (TableDataCell) getComponent();
+
+        assertThrows(IllegalArgumentException.class, () -> cell.setColspan(-1));
+        assertThrows(IllegalArgumentException.class, () -> cell.setRowspan(-1));
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
@@ -55,7 +55,11 @@ class TableDataCellTest extends ComponentTest {
     void spans_rejectNegativeValues() {
         TableDataCell cell = (TableDataCell) getComponent();
 
-        assertThrows(IllegalArgumentException.class, () -> cell.setColspan(-1));
-        assertThrows(IllegalArgumentException.class, () -> cell.setRowspan(-1));
+        assertEquals("colspan must be a non-negative integer value",
+                assertThrows(IllegalArgumentException.class,
+                        () -> cell.setColspan(-1)).getMessage());
+        assertEquals("rowspan must be a non-negative integer value",
+                assertThrows(IllegalArgumentException.class,
+                        () -> cell.setRowspan(-1)).getMessage());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
@@ -55,11 +55,24 @@ class TableDataCellTest extends ComponentTest {
     void spans_rejectNegativeValues() {
         TableDataCell cell = (TableDataCell) getComponent();
 
-        assertEquals("colspan must be a non-negative integer value",
+        assertEquals("colspan must be a positive integer value",
                 assertThrows(IllegalArgumentException.class,
                         () -> cell.setColspan(-1)).getMessage());
         assertEquals("rowspan must be a non-negative integer value",
                 assertThrows(IllegalArgumentException.class,
                         () -> cell.setRowspan(-1)).getMessage());
+    }
+
+    @Test
+    void zeroSpan_rejectedForColumnsButNotForRows() {
+        TableDataCell cell = (TableDataCell) getComponent();
+
+        // colspan=0 was dropped from HTML and browsers clamp it back to 1
+        assertThrows(IllegalArgumentException.class, () -> cell.setColspan(0));
+
+        // rowspan=0 still means "to the end of the row group"
+        cell.setRowspan(0);
+        assertEquals("0", cell.getElement().getAttribute("rowspan"));
+        assertEquals(0, cell.getRowspan());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableFootTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableFootTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+class TableFootTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeadTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeadTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+class TableHeadTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+class TableHeaderCellTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowContainerTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowContainerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the {@link TableRowContainer} default methods through each of the
+ * three components implementing them.
+ */
+class TableRowContainerTest {
+
+    static Stream<Named<Supplier<TableRowContainer>>> sections() {
+        return Stream.of(Named.of("thead", TableHead::new),
+                Named.of("tbody", TableBody::new),
+                Named.of("tfoot", TableFoot::new));
+    }
+
+    static Stream<Named<Function<List<TableRow>, TableRowContainer>>> sectionConstructors() {
+        return Stream.of(
+                Named.of("thead",
+                        rows -> new TableHead(rows.toArray(TableRow[]::new))),
+                Named.of("tbody",
+                        rows -> new TableBody(rows.toArray(TableRow[]::new))),
+                Named.of("tfoot",
+                        rows -> new TableFoot(rows.toArray(TableRow[]::new))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("sectionConstructors")
+    void constructor_addsGivenRows(
+            Function<List<TableRow>, TableRowContainer> constructor) {
+        TableRow row0 = new TableRow();
+        TableRow row1 = new TableRow();
+
+        TableRowContainer section = constructor.apply(List.of(row0, row1));
+
+        assertEquals(List.of(row0, row1), section.getRows());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sections")
+    void addRow_appendsANewRow(Supplier<TableRowContainer> factory) {
+        TableRowContainer section = factory.get();
+
+        TableRow first = section.addRow();
+        TableRow second = section.addRow();
+
+        assertEquals(List.of(first, second), section.getRows());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sections")
+    void addRows_appendsExistingRows(Supplier<TableRowContainer> factory) {
+        TableRowContainer section = factory.get();
+        TableRow row0 = new TableRow();
+        TableRow row1 = new TableRow();
+
+        section.addRows(row0, row1);
+
+        assertEquals(List.of(row0, row1), section.getRows());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sections")
+    void insertRow_placesItAtTheGivenPosition(
+            Supplier<TableRowContainer> factory) {
+        TableRowContainer section = factory.get();
+        TableRow first = section.addRow();
+        TableRow last = section.addRow();
+
+        TableRow middle = section.insertRow(1);
+        TableRow leading = section.insertRow(0);
+
+        assertEquals(List.of(leading, first, middle, last), section.getRows());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sections")
+    void replaceRow_swapsTheRowAtThePosition(
+            Supplier<TableRowContainer> factory) {
+        TableRowContainer section = factory.get();
+        TableRow first = section.addRow();
+        TableRow old = section.addRow();
+        TableRow replacement = new TableRow();
+
+        section.replaceRow(1, replacement);
+
+        assertEquals(List.of(first, replacement), section.getRows());
+        assertTrue(old.getParent().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sections")
+    void removeRows_detachesOnlyTheGivenOnes(
+            Supplier<TableRowContainer> factory) {
+        TableRowContainer section = factory.get();
+        TableRow row0 = section.addRow();
+        TableRow row1 = section.addRow();
+        TableRow row2 = section.addRow();
+
+        section.removeRows(row0, row2);
+
+        assertEquals(List.of(row1), section.getRows());
+        assertTrue(row0.getParent().isEmpty());
+        assertTrue(row2.getParent().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sections")
+    void removeAllRows_leavesTheSectionEmpty(
+            Supplier<TableRowContainer> factory) {
+        TableRowContainer section = factory.get();
+        section.addRow();
+        section.addRow();
+
+        section.removeAllRows();
+
+        assertTrue(section.getRows().isEmpty());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TableRowTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+    @Test
+    void addCells_appendThemInCallOrder() {
+        TableRow row = new TableRow();
+
+        TableHeaderCell th = row.addHeaderCell();
+        TableDataCell td = row.addDataCell();
+
+        assertEquals(List.of(th, td), row.getCells());
+        assertEquals(List.of(th), row.getHeaderCells());
+        assertEquals(List.of(td), row.getDataCells());
+    }
+
+    @Test
+    void insertCells_placeThemAtTheGivenPosition() {
+        TableRow row = new TableRow();
+        TableDataCell first = row.addDataCell();
+        TableDataCell last = row.addDataCell();
+
+        TableHeaderCell header = row.insertHeaderCell(1);
+        TableDataCell middle = row.insertDataCell(2);
+        TableHeaderCell leadingHeader = row.insertHeaderCell(0);
+        TableDataCell leadingData = row.insertDataCell(0);
+
+        assertEquals(List.of(leadingData, leadingHeader, first, header, middle,
+                last), row.getCells());
+    }
+
+    @Test
+    void constructorAndAddCells_attachPreBuiltCells() {
+        TableHeaderCell th = new TableHeaderCell("Name");
+        TableDataCell td = new TableDataCell("Mars");
+        TableDataCell appended = new TableDataCell(new Span("rich"));
+
+        TableRow row = new TableRow(th, td);
+        row.addCells(appended);
+
+        assertEquals(List.of(th, td, appended), row.getCells());
+        assertEquals("Name", th.getText());
+        assertEquals("Mars", td.getText());
+    }
+
+    @Test
+    void insertCell_placesAPreBuiltCellAtTheGivenPosition() {
+        TableRow row = new TableRow();
+        TableDataCell first = row.addDataCell();
+        TableDataCell last = row.addDataCell();
+        TableHeaderCell inserted = new TableHeaderCell("Name");
+
+        row.insertCell(1, inserted);
+
+        assertEquals(List.of(first, inserted, last), row.getCells());
+    }
+
+    @Test
+    void removeCell_detachesItFromTheRow() {
+        TableRow row = new TableRow();
+        TableHeaderCell th = row.addHeaderCell();
+        TableDataCell td = row.addDataCell();
+
+        row.removeCell(th);
+
+        assertEquals(List.of(td), row.getCells());
+        assertTrue(th.getParent().isEmpty());
+    }
+
+    @Test
+    void removeAllCells_leavesTheRowEmpty() {
+        TableRow row = new TableRow();
+        row.addHeaderCell();
+        row.addDataCell();
+
+        row.removeAllCells();
+
+        assertTrue(row.getCells().isEmpty());
+        assertEquals(0, row.getChildren().count());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.beans.IntrospectionException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TableTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @BeforeEach
+    @Override
+    void setup() throws IntrospectionException, InstantiationException,
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
+        // Section accessors look like bean properties to the introspector, but
+        // they are components rather than settings
+        whitelistProperty("captionText");
+        whitelistProperty("caption");
+        whitelistProperty("head");
+        whitelistProperty("foot");
+        super.setup();
+    }
+
+    private Table table() {
+        return (Table) getComponent();
+    }
+
+    @Test
+    void newTable_hasNoChildren() {
+        Table table = table();
+
+        assertEquals(0, table.getChildren().count());
+        assertTrue(table.findCaption().isEmpty());
+        assertTrue(table.findHead().isEmpty());
+        assertTrue(table.findFoot().isEmpty());
+        assertTrue(table.getBodies().isEmpty());
+    }
+
+    @Test
+    void getCaptionText_withoutCaption_isEmptyAndCreatesNothing() {
+        Table table = table();
+
+        assertEquals("", table.getCaptionText());
+        assertEquals(0, table.getChildren().count());
+    }
+
+    @Test
+    void setCaptionText_createsTheCaptionAndReadsBack() {
+        Table table = table();
+
+        table.setCaptionText("Planets");
+
+        assertEquals("Planets", table.getCaptionText());
+        assertEquals(List.of(table.getCaption()), table.getChildren().toList());
+    }
+
+    @Test
+    void sectionsAreKeptInSpecificationOrder() {
+        Table table = table();
+        // Created in reverse of the required order to show the result follows
+        // the specification, not the calls.
+        var foot = table.getFoot();
+        var body = table.addBody();
+        var head = table.getHead();
+        var caption = table.getCaption();
+
+        assertEquals(List.of(caption, head, body, foot),
+                table.getChildren().toList());
+    }
+
+    @Test
+    void addBody_appendsAfterExistingBodiesAndBeforeTheFoot() {
+        Table table = table();
+        var head = table.getHead();
+        var first = table.addBody();
+        var foot = table.getFoot();
+
+        var second = table.addBody();
+
+        assertEquals(List.of(head, first, second, foot),
+                table.getChildren().toList());
+        assertEquals(List.of(first, second), table.getBodies());
+    }
+
+    @Test
+    void getBody_returnsTheFirstBodyAndCreatesOneWhenThereIsNone() {
+        Table table = table();
+
+        var created = table.getBody();
+        var second = table.addBody();
+
+        assertEquals(created, table.getBody());
+        assertEquals(List.of(created, second), table.getBodies());
+    }
+
+    @Test
+    void setSections_attachPreBuiltOnesInSpecificationOrder() {
+        Table table = table();
+        var head = new TableHead(new TableRow(), new TableRow());
+        var body = new TableBody(new TableRow());
+        var foot = new TableFoot(new TableRow());
+        var caption = new TableCaption("Planets");
+
+        table.setFoot(foot);
+        table.addBody(body);
+        table.setHead(head);
+        table.setCaption(caption);
+
+        assertEquals(List.of(caption, head, body, foot),
+                table.getChildren().toList());
+        assertEquals("Planets", table.getCaptionText());
+        assertEquals(2, head.getRows().size());
+    }
+
+    @Test
+    void setSections_replaceTheOnesAlreadyThere() {
+        Table table = table();
+        var oldCaption = table.getCaption();
+        var oldHead = table.getHead();
+        var oldFoot = table.getFoot();
+        var caption = new TableCaption("new");
+        var head = new TableHead();
+        var foot = new TableFoot();
+
+        table.setCaption(caption);
+        table.setHead(head);
+        table.setFoot(foot);
+
+        assertEquals(List.of(caption, head, foot),
+                table.getChildren().toList());
+        assertTrue(oldCaption.getParent().isEmpty());
+        assertTrue(oldHead.getParent().isEmpty());
+        assertTrue(oldFoot.getParent().isEmpty());
+    }
+
+    @Test
+    void getSection_calledTwice_doesNotCreateASecondOne() {
+        Table table = table();
+
+        assertEquals(table.getHead(), table.getHead());
+        assertEquals(table.getFoot(), table.getFoot());
+        assertEquals(table.getCaption(), table.getCaption());
+        assertEquals(3, table.getChildren().count());
+    }
+
+    @Test
+    void removeSections_detachThemAndLetTheAccessorsCreateNewOnes() {
+        Table table = table();
+        var caption = table.getCaption();
+        var head = table.getHead();
+        var body = table.addBody();
+        var foot = table.getFoot();
+
+        table.removeCaption();
+        table.removeHead();
+        table.removeBody(body);
+        table.removeFoot();
+
+        assertEquals(0, table.getChildren().count());
+        assertTrue(caption.getParent().isEmpty());
+        assertTrue(head.getParent().isEmpty());
+        assertTrue(body.getParent().isEmpty());
+        assertTrue(foot.getParent().isEmpty());
+        assertTrue(table.getBodies().isEmpty());
+
+        // The accessors create fresh ones rather than handing back the
+        // detached components
+        assertEquals(List.of(table.getCaption(), table.getHead(),
+                table.getBody(), table.getFoot()),
+                table.getChildren().toList());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -51,7 +51,6 @@ class TableTest extends ComponentTest {
         Table table = table();
 
         assertEquals(0, table.getChildren().count());
-        assertTrue(table.findCaption().isEmpty());
         assertTrue(table.findHead().isEmpty());
         assertTrue(table.findFoot().isEmpty());
         assertTrue(table.getBodies().isEmpty());

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -42,6 +42,14 @@ class TableTest extends ComponentTest {
         super.setup();
     }
 
+    @Test
+    @Override
+    protected void testHasAriaLabelIsImplemented() {
+        // <table> takes aria-label and aria-labelledby; a caption is not
+        // always the right way to name a table
+        super.testHasAriaLabelIsImplemented();
+    }
+
     private Table table() {
         return (Table) getComponent();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -812,6 +812,45 @@ public class ComponentUtil {
     }
 
     /**
+     * Gets the child components of the given parent that are instances of the
+     * given type, in child order.
+     * <p>
+     * Useful for components whose children have a known structure, such as the
+     * rows of a table or the items of a list, where the child of interest is
+     * identified by its type rather than by its position.
+     *
+     * @param <T>
+     *            the child component type
+     * @param parent
+     *            the parent component from which to get the child components
+     * @param type
+     *            the type the children must be instances of
+     * @return the children of the given type, in child order
+     */
+    public static <T extends Component> Stream<T> getChildrenOfType(
+            Component parent, Class<T> type) {
+        return parent.getChildren().filter(type::isInstance).map(type::cast);
+    }
+
+    /**
+     * Gets the first child component of the given parent that is an instance of
+     * the given type.
+     *
+     * @param <T>
+     *            the child component type
+     * @param parent
+     *            the parent component from which to get the child component
+     * @param type
+     *            the type the child must be an instance of
+     * @return the first child of the given type, or an empty optional if the
+     *         parent has no such child
+     */
+    public static <T extends Component> Optional<T> getFirstChildOfType(
+            Component parent, Class<T> type) {
+        return getChildrenOfType(parent, type).findFirst();
+    }
+
+    /**
      * Resolves the id of {@code targetComponent} lazily, as described in
      * {@link #resolveOrGenerateIdLater(Element, Component, String, SerializableSupplier, SerializableConsumer)},
      * but without a getter for the current value, so the resolution cannot

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -826,6 +826,7 @@ public class ComponentUtil {
      * @param type
      *            the type the children must be instances of
      * @return the children of the given type, in child order
+     * @since 25.3
      */
     public static <T extends Component> Stream<T> getChildrenOfType(
             Component parent, Class<T> type) {
@@ -844,6 +845,7 @@ public class ComponentUtil {
      *            the type the child must be an instance of
      * @return the first child of the given type, or an empty optional if the
      *         parent has no such child
+     * @since 25.3
      */
     public static <T extends Component> Optional<T> getFirstChildOfType(
             Component parent, Class<T> type) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
@@ -146,6 +146,36 @@ class ComponentUtilTest {
     }
 
     @Test
+    void getChildrenOfType_returnsMatchingChildrenInOrder() {
+        // parent
+        // ├── div1 (TestDiv)
+        // ├── span (TestComponent)
+        // └── div2 (TestDiv)
+        TestComponent parent = new TestComponent(ElementFactory.createDiv());
+        TestDiv div1 = new TestDiv();
+        TestComponent span = new TestComponent(ElementFactory.createSpan());
+        TestDiv div2 = new TestDiv();
+        parent.getElement().appendChild(div1.getElement(), span.getElement(),
+                div2.getElement());
+
+        assertEquals(List.of(div1, div2),
+                ComponentUtil.getChildrenOfType(parent, TestDiv.class).toList(),
+                "Only the children of the given type must be returned, in child order");
+        assertEquals(Optional.of(div1),
+                ComponentUtil.getFirstChildOfType(parent, TestDiv.class));
+    }
+
+    @Test
+    void getFirstChildOfType_withNoMatchingChild_returnsEmpty() {
+        TestComponent parent = new TestComponent(ElementFactory.createDiv());
+        parent.getElement().appendChild(
+                new TestComponent(ElementFactory.createSpan()).getElement());
+
+        assertEquals(Optional.empty(),
+                ComponentUtil.getFirstChildOfType(parent, TestDiv.class));
+    }
+
+    @Test
     void getAllChildren_includesVirtualChildren() {
         // parent
         // ├── regular (direct DOM child)


### PR DESCRIPTION
Picking children out of a component by type is generally useful, and the `Table` components each hand-rolled it over the child stream. It lands as `ComponentUtil.getChildrenOfType` and `getFirstChildOfType` next to the existing `getChildren`, `getAllChildren` and `streamDescendants`, and `Table`, `TableRow` and `TableRowContainer` now read their children through it.

Previously this PR fixed `NativeTable`'s stale section cache. `Table` derives its sections from its children by construction, so there is nothing left to fix — the `Native*` family is left untouched and simply deprecated in #25383.

## Type of change

- [x] Bugfix
