### PR TITLE
feat: add col and colgroup support to Table

### DIFF
--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableCellElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableCellElement.java
@@ -15,13 +15,17 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
-import com.vaadin.testbench.elementsbase.Element;
+import com.vaadin.testbench.TestBenchElement;
 
 /**
- * A TestBench element representing a <code>&lt;th&gt;</code> element.
+ * A TestBench element representing either kind of table cell, a
+ * <code>&lt;td&gt;</code> or a <code>&lt;th&gt;</code>. It carries no
+ * {@code @Element} annotation of its own: it is the type
+ * {@link TableRowElement#getCells()} speaks in when the kind of cell does not
+ * matter, mirroring {@link com.vaadin.flow.component.html.TableCell} on the
+ * component side.
  *
  * @since 25.3
  */
-@Element("th")
-public class TableHeaderCellElement extends TableCellElement {
+public class TableCellElement extends TestBenchElement {
 }

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableColumnElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableColumnElement.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;col&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("col")
+public class TableColumnElement extends TestBenchElement {
+
+    /**
+     * Returns the number of columns this <code>&lt;col&gt;</code> spans.
+     *
+     * @return the value of the {@code span} attribute, or 1 if it is not set.
+     */
+    public int getSpan() {
+        String span = getDomAttribute("span");
+        return span == null ? 1 : Integer.parseInt(span);
+    }
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableColumnGroupElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableColumnGroupElement.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import java.util.List;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;colgroup&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("colgroup")
+public class TableColumnGroupElement extends TestBenchElement {
+
+    /**
+     * Returns the <code>&lt;col&gt;</code> children of this group, in document
+     * order.
+     *
+     * @return the columns of this group.
+     */
+    public List<TableColumnElement> getColumns() {
+        return $(TableColumnElement.class).all();
+    }
+
+    /**
+     * Returns the number of columns this <code>&lt;colgroup&gt;</code> spans
+     * when it is used without <code>&lt;col&gt;</code> children.
+     *
+     * @return the value of the {@code span} attribute, or 1 if it is not set.
+     */
+    public int getSpan() {
+        String span = getDomAttribute("span");
+        return span == null ? 1 : Integer.parseInt(span);
+    }
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableDataCellElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableDataCellElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;td&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("td")
+public class TableDataCellElement extends TestBenchElement {
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableDataCellElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableDataCellElement.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
-import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
 /**
@@ -24,5 +23,5 @@ import com.vaadin.testbench.elementsbase.Element;
  * @since 25.3
  */
 @Element("td")
-public class TableDataCellElement extends TestBenchElement {
+public class TableDataCellElement extends TableCellElement {
 }

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;table&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("table")
+public class TableElement extends TestBenchElement {
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.vaadin.testbench.TestBenchElement;
@@ -36,7 +37,8 @@ public class TableElement extends TestBenchElement {
      * @return the rows of this table.
      */
     public List<TableRowElement> getRows() {
-        return $(TableRowElement.class).all();
+        return childrenNamed("thead", "tbody", "tfoot").stream()
+                .flatMap(section -> rowsOf(section).stream()).toList();
     }
 
     /**
@@ -70,6 +72,27 @@ public class TableElement extends TestBenchElement {
      * @return the table's <code>&lt;colgroup&gt;</code> elements.
      */
     public List<TableColumnGroupElement> getColumnGroups() {
-        return $(TableColumnGroupElement.class).all();
+        return childrenNamed("colgroup").stream()
+                .map(child -> child.wrap(TableColumnGroupElement.class))
+                .toList();
+    }
+
+    /**
+     * The caption, column groups and sections of this table are its direct
+     * children; a descendant query would also pick up those of a table nested
+     * inside a cell.
+     */
+    private List<TestBenchElement> childrenNamed(String... tagNames) {
+        List<String> wanted = Arrays.asList(tagNames);
+        return getChildren().stream()
+                .filter(child -> wanted.stream().anyMatch(
+                        tag -> tag.equalsIgnoreCase(child.getTagName())))
+                .toList();
+    }
+
+    private static List<TableRowElement> rowsOf(TestBenchElement section) {
+        return section.getChildren().stream()
+                .filter(child -> "tr".equalsIgnoreCase(child.getTagName()))
+                .map(child -> child.wrap(TableRowElement.class)).toList();
     }
 }

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
+import java.util.List;
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -25,4 +27,49 @@ import com.vaadin.testbench.elementsbase.Element;
  */
 @Element("table")
 public class TableElement extends TestBenchElement {
+
+    /**
+     * Returns every row of this table, in document order: the
+     * <code>&lt;thead&gt;</code> rows, then the rows of each
+     * <code>&lt;tbody&gt;</code>, then the <code>&lt;tfoot&gt;</code> rows.
+     *
+     * @return the rows of this table.
+     */
+    public List<TableRowElement> getRows() {
+        return $(TableRowElement.class).all();
+    }
+
+    /**
+     * Returns the row at the given position among all the rows of this table.
+     *
+     * @param index
+     *            the position of the row.
+     * @return the row at that position.
+     */
+    public TableRowElement getRow(int index) {
+        return getRows().get(index);
+    }
+
+    /**
+     * Returns the cell at the given row and column of this table, counting
+     * across all its rows.
+     *
+     * @param row
+     *            the position of the row.
+     * @param column
+     *            the position of the cell within that row.
+     * @return the cell at that position.
+     */
+    public TableCellElement getCell(int row, int column) {
+        return getRow(row).getCell(column);
+    }
+
+    /**
+     * Returns the column groups of this table, in document order.
+     *
+     * @return the table's <code>&lt;colgroup&gt;</code> elements.
+     */
+    public List<TableColumnGroupElement> getColumnGroups() {
+        return $(TableColumnGroupElement.class).all();
+    }
 }

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableHeaderCellElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableHeaderCellElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;th&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("th")
+public class TableHeaderCellElement extends TestBenchElement {
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableRowElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableRowElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;tr&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("tr")
+public class TableRowElement extends TestBenchElement {
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableRowElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableRowElement.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
+import java.util.List;
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -25,4 +27,49 @@ import com.vaadin.testbench.elementsbase.Element;
  */
 @Element("tr")
 public class TableRowElement extends TestBenchElement {
+
+    /**
+     * Returns every cell of this row, in document order, both
+     * <code>&lt;td&gt;</code> and <code>&lt;th&gt;</code>.
+     *
+     * @return the cells of this row.
+     */
+    public List<TableCellElement> getCells() {
+        return getChildren().stream().filter(TableRowElement::isCell)
+                .map(child -> child.wrap(TableCellElement.class)).toList();
+    }
+
+    /**
+     * Returns the cell at the given position among all the cells of this row.
+     *
+     * @param index
+     *            the position of the cell.
+     * @return the cell at that position.
+     */
+    public TableCellElement getCell(int index) {
+        return getCells().get(index);
+    }
+
+    /**
+     * Returns the data cells of this row, in document order.
+     *
+     * @return this row's <code>&lt;td&gt;</code> cells.
+     */
+    public List<TableDataCellElement> getDataCells() {
+        return $(TableDataCellElement.class).all();
+    }
+
+    /**
+     * Returns the header cells of this row, in document order.
+     *
+     * @return this row's <code>&lt;th&gt;</code> cells.
+     */
+    public List<TableHeaderCellElement> getHeaderCells() {
+        return $(TableHeaderCellElement.class).all();
+    }
+
+    private static boolean isCell(TestBenchElement child) {
+        String tag = child.getTagName();
+        return "td".equalsIgnoreCase(tag) || "th".equalsIgnoreCase(tag);
+    }
 }

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableRowElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableRowElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.vaadin.testbench.TestBenchElement;
@@ -35,8 +36,7 @@ public class TableRowElement extends TestBenchElement {
      * @return the cells of this row.
      */
     public List<TableCellElement> getCells() {
-        return getChildren().stream().filter(TableRowElement::isCell)
-                .map(child -> child.wrap(TableCellElement.class)).toList();
+        return cells("td", "th");
     }
 
     /**
@@ -56,7 +56,8 @@ public class TableRowElement extends TestBenchElement {
      * @return this row's <code>&lt;td&gt;</code> cells.
      */
     public List<TableDataCellElement> getDataCells() {
-        return $(TableDataCellElement.class).all();
+        return cells("td").stream()
+                .map(cell -> cell.wrap(TableDataCellElement.class)).toList();
     }
 
     /**
@@ -65,11 +66,19 @@ public class TableRowElement extends TestBenchElement {
      * @return this row's <code>&lt;th&gt;</code> cells.
      */
     public List<TableHeaderCellElement> getHeaderCells() {
-        return $(TableHeaderCellElement.class).all();
+        return cells("th").stream()
+                .map(cell -> cell.wrap(TableHeaderCellElement.class)).toList();
     }
 
-    private static boolean isCell(TestBenchElement child) {
-        String tag = child.getTagName();
-        return "td".equalsIgnoreCase(tag) || "th".equalsIgnoreCase(tag);
+    /**
+     * The cells of this row are its direct children; a descendant query would
+     * also pick up the cells of a table nested inside one of them.
+     */
+    private List<TableCellElement> cells(String... tagNames) {
+        List<String> wanted = Arrays.asList(tagNames);
+        return getChildren().stream()
+                .filter(child -> wanted.stream().anyMatch(
+                        tag -> tag.equalsIgnoreCase(child.getTagName())))
+                .map(child -> child.wrap(TableCellElement.class)).toList();
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -34,9 +34,9 @@ import com.vaadin.flow.dom.Element;
  * Unlike the deprecated {@link NativeTable}, this component does not extend
  * {@link com.vaadin.flow.component.HtmlContainer}, so it has no generic
  * {@code add(Component)}. A <code>&lt;table&gt;</code> may only contain a
- * {@code <caption>}, {@code <thead>}, {@code <tbody>} and {@code <tfoot>}, and
- * those are reached through the accessors below, which also keep them in the
- * order the WHATWG HTML specification requires.
+ * {@code <caption>}, {@code <colgroup>}, {@code <thead>}, {@code <tbody>} and
+ * {@code <tfoot>}, and those are reached through the accessors below, which
+ * also keep them in the order the WHATWG HTML specification requires.
  *
  * @see <a href="https://html.spec.whatwg.org/multipage/tables.html">WHATWG
  *      HTML: Tabular data</a>
@@ -55,9 +55,10 @@ public class Table extends HtmlComponent
      * HTML specification requires them to appear.
      */
     private static final int RANK_CAPTION = 0;
-    private static final int RANK_HEAD = 1;
-    private static final int RANK_BODY = 2;
-    private static final int RANK_FOOT = 3;
+    private static final int RANK_COLUMN_GROUP = 1;
+    private static final int RANK_HEAD = 2;
+    private static final int RANK_BODY = 3;
+    private static final int RANK_FOOT = 4;
 
     /**
      * Creates a new empty table.
@@ -124,6 +125,58 @@ public class Table extends HtmlComponent
      */
     public void removeCaption() {
         findCaption().ifPresent(this::removeChild);
+    }
+
+    /**
+     * Appends a new empty {@code <colgroup>} to this table, after the caption
+     * and any column groups it already has, and before the {@code <thead>}.
+     *
+     * @return the new column group.
+     */
+    public TableColumnGroup addColumnGroup() {
+        return addColumnGroup(new TableColumnGroup());
+    }
+
+    /**
+     * Appends the given {@code <colgroup>} to this table.
+     *
+     * @param group
+     *            the column group to add.
+     * @return the given group, for chaining.
+     */
+    public TableColumnGroup addColumnGroup(TableColumnGroup group) {
+        return insert(group, RANK_COLUMN_GROUP);
+    }
+
+    /**
+     * Appends a new {@code <colgroup>} holding the given columns to this table.
+     *
+     * @param columns
+     *            the columns the new group should hold.
+     * @return the new column group.
+     */
+    public TableColumnGroup addColumnGroup(TableColumn... columns) {
+        return addColumnGroup(new TableColumnGroup(columns));
+    }
+
+    /**
+     * Returns the column groups of this table, in document order.
+     *
+     * @return the table's {@code <colgroup>} elements.
+     */
+    public List<TableColumnGroup> getColumnGroups() {
+        return ComponentUtil.getChildrenOfType(this, TableColumnGroup.class)
+                .toList();
+    }
+
+    /**
+     * Removes the given column group from this table.
+     *
+     * @param group
+     *            the column group to remove.
+     */
+    public void removeColumnGroup(TableColumnGroup group) {
+        removeChild(group);
     }
 
     /**
@@ -278,6 +331,9 @@ public class Table extends HtmlComponent
         Component component = child.getComponent().orElse(null);
         if (component instanceof TableCaption) {
             return RANK_CAPTION;
+        }
+        if (component instanceof TableColumnGroup) {
+            return RANK_COLUMN_GROUP;
         }
         if (component instanceof TableHead) {
             return RANK_HEAD;

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumn.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumn.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;col&gt;</code> element — a column (or
+ * range of columns, via {@link #setSpan(int)}) inside a
+ * {@link TableColumnGroup}. Use it to apply column-wide styling without
+ * repeating it on every cell: a class or id on a {@code <col>} can target all
+ * the data cells in that column.
+ * <p>
+ * {@code <col>} is a void element (no children, no end tag) and is only valid
+ * inside a {@code <colgroup>} that does not itself carry a {@code span}
+ * attribute. Only a limited subset of CSS applies to columns:
+ * {@code background}, {@code border} (with {@code border-collapse: collapse}),
+ * {@code visibility: collapse} and {@code width}. Text and font properties do
+ * not inherit into the cells — style those on <code>&lt;td&gt;</code> or
+ * <code>&lt;th&gt;</code> instead.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/col">MDN:
+ *      &lt;col&gt; — The Table Column element</a>
+ * @since 25.3
+ */
+@Tag(Tag.COL)
+public class TableColumn extends HtmlComponent implements TableColumnSpan {
+
+    /**
+     * Creates a new column component spanning a single column.
+     */
+    public TableColumn() {
+        super();
+    }
+
+    /**
+     * Creates a new column component spanning the given number of columns.
+     *
+     * @param span
+     *            the number of consecutive columns this {@code <col>} element
+     *            applies to. Must be a positive integer.
+     */
+    public TableColumn(int span) {
+        super();
+        setSpan(span);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumn.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumn.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
 
@@ -38,6 +40,7 @@ import com.vaadin.flow.component.Tag;
  *      &lt;col&gt; — The Table Column element</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.COL)
 public class TableColumn extends HtmlComponent implements TableColumnSpan {
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnGroup.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnGroup.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;colgroup&gt;</code> element — a group of
+ * columns inside a {@link Table}, used to apply attributes (most often a class
+ * for CSS) to several columns at once. Only a limited subset of CSS applies to
+ * column groups: {@code background}, {@code border} (with
+ * {@code border-collapse: collapse}), {@code visibility: collapse} and
+ * {@code width}.
+ * <p>
+ * Per the <a href="https://html.spec.whatwg.org/multipage/tables.html">WHATWG
+ * HTML specification</a>, a {@code <colgroup>} is used in one of two modes:
+ * either it carries a {@code span} attribute and has no children, or it
+ * contains zero or more {@code <col>} children and has no {@code span}
+ * attribute. {@code <colgroup>} elements must be placed after the optional
+ * {@code <caption>} and before any {@code <thead>}, {@code <tbody>},
+ * {@code <tfoot>} or <code>&lt;tr&gt;</code>; {@link Table} inserts them at the
+ * correct position automatically.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/colgroup">MDN:
+ *      &lt;colgroup&gt; — The Table Column Group element</a>
+ * @since 25.3
+ */
+@Tag(Tag.COLGROUP)
+public class TableColumnGroup extends HtmlComponent implements TableColumnSpan {
+
+    /**
+     * Creates a new empty column group.
+     */
+    public TableColumnGroup() {
+        super();
+    }
+
+    /**
+     * Creates a new column group with the given columns appended.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public TableColumnGroup(TableColumn... columns) {
+        super();
+        addColumns(columns);
+    }
+
+    /**
+     * Appends a new empty {@code <col>} child to this group.
+     *
+     * @return the new column.
+     */
+    public TableColumn addColumn() {
+        return addColumn(new TableColumn());
+    }
+
+    /**
+     * Appends a new {@code <col>} child with the given span to this group.
+     *
+     * @param span
+     *            the number of columns to span.
+     * @return the new column.
+     */
+    public TableColumn addColumn(int span) {
+        return addColumn(new TableColumn(span));
+    }
+
+    /**
+     * Appends the given columns to this group.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public void addColumns(TableColumn... columns) {
+        for (TableColumn column : columns) {
+            addColumn(column);
+        }
+    }
+
+    /**
+     * Returns the columns inside this group.
+     *
+     * @return the list of {@code <col>} children.
+     */
+    public List<TableColumn> getColumns() {
+        return ComponentUtil.getChildrenOfType(this, TableColumn.class)
+                .toList();
+    }
+
+    /**
+     * Removes a column from this group.
+     *
+     * @param column
+     *            the column to remove.
+     */
+    public void removeColumn(TableColumn column) {
+        getElement().removeChild(column.getElement());
+    }
+
+    /**
+     * Removes all columns from this group.
+     */
+    public void removeAllColumns() {
+        getElement().removeAllChildren();
+    }
+
+    private TableColumn addColumn(TableColumn column) {
+        getElement().appendChild(column.getElement());
+        return column;
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnGroup.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnGroup.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.html;
 
 import java.util.List;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.Tag;
@@ -43,6 +45,7 @@ import com.vaadin.flow.component.Tag;
  *      &lt;colgroup&gt; — The Table Column Group element</a>
  * @since 25.3
  */
+@NullMarked
 @Tag(Tag.COLGROUP)
 public class TableColumnGroup extends HtmlComponent implements TableColumnSpan {
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnSpan.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnSpan.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.jspecify.annotations.NullMarked;
+
 import com.vaadin.flow.component.HasElement;
 
 /**
@@ -23,6 +25,7 @@ import com.vaadin.flow.component.HasElement;
  *
  * @since 25.3
  */
+@NullMarked
 interface TableColumnSpan extends HasElement {
 
     String ATTRIBUTE_SPAN = "span";

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnSpan.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnSpan.java
@@ -28,8 +28,6 @@ import com.vaadin.flow.component.HasElement;
 @NullMarked
 interface TableColumnSpan extends HasElement {
 
-    String ATTRIBUTE_SPAN = "span";
-
     /**
      * Sets the {@code span} attribute — how many consecutive columns this
      * element covers. The default is {@code 1}. Use it to apply the same
@@ -44,7 +42,7 @@ interface TableColumnSpan extends HasElement {
             throw new IllegalArgumentException(
                     "span must be a positive integer value");
         }
-        getElement().setAttribute(ATTRIBUTE_SPAN, String.valueOf(span));
+        getElement().setAttribute(spanAttribute(), String.valueOf(span));
     }
 
     /**
@@ -53,7 +51,7 @@ interface TableColumnSpan extends HasElement {
      * @return the current span. Default is 1.
      */
     default int getSpan() {
-        String span = getElement().getAttribute(ATTRIBUTE_SPAN);
+        String span = getElement().getAttribute(spanAttribute());
         if (span == null) {
             span = "1";
         }
@@ -64,6 +62,10 @@ interface TableColumnSpan extends HasElement {
      * Removes the {@code span} attribute, restoring the default value of 1.
      */
     default void resetSpan() {
-        getElement().removeAttribute(ATTRIBUTE_SPAN);
+        getElement().removeAttribute(spanAttribute());
+    }
+
+    private static String spanAttribute() {
+        return "span";
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnSpan.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnSpan.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * A table column definition carrying a {@code span} attribute, i.e. either a
+ * <code>&lt;col&gt;</code> or a <code>&lt;colgroup&gt;</code>.
+ *
+ * @since 25.3
+ */
+interface TableColumnSpan extends HasElement {
+
+    String ATTRIBUTE_SPAN = "span";
+
+    /**
+     * Sets the {@code span} attribute — how many consecutive columns this
+     * element covers. The default is {@code 1}. Use it to apply the same
+     * styling or attributes across a range of columns without writing one
+     * element per column.
+     *
+     * @param span
+     *            a positive integer.
+     */
+    default void setSpan(int span) {
+        if (span < 1) {
+            throw new IllegalArgumentException(
+                    "span must be a positive integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_SPAN, String.valueOf(span));
+    }
+
+    /**
+     * Returns the value of the {@code span} attribute.
+     *
+     * @return the current span. Default is 1.
+     */
+    default int getSpan() {
+        String span = getElement().getAttribute(ATTRIBUTE_SPAN);
+        if (span == null) {
+            span = "1";
+        }
+        return Integer.parseInt(span);
+    }
+
+    /**
+     * Removes the {@code span} attribute, restoring the default value of 1.
+     */
+    default void resetSpan() {
+        getElement().removeAttribute(ATTRIBUTE_SPAN);
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableColumnGroupTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableColumnGroupTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TableColumnGroupTest extends ComponentTest {
+    // Property tests in super class
+
+    @Override
+    protected void addProperties() {
+        addProperty("span", int.class, 1, 2, false, false);
+    }
+
+    private TableColumnGroup group() {
+        return (TableColumnGroup) getComponent();
+    }
+
+    @Test
+    void addColumn_appendsAChild() {
+        TableColumnGroup group = group();
+
+        TableColumn plain = group.addColumn();
+        TableColumn spanning = group.addColumn(2);
+
+        assertEquals(List.of(plain, spanning), group.getColumns());
+        assertEquals(1, plain.getSpan());
+        assertEquals(2, spanning.getSpan());
+    }
+
+    @Test
+    void constructorAndAddColumns_attachPreBuiltColumns() {
+        TableColumn first = new TableColumn();
+        TableColumn second = new TableColumn(3);
+        TableColumn third = new TableColumn();
+
+        TableColumnGroup group = new TableColumnGroup(first, second);
+        group.addColumns(third);
+
+        assertEquals(List.of(first, second, third), group.getColumns());
+    }
+
+    @Test
+    void removeColumn_detachesOnlyThatColumn() {
+        TableColumnGroup group = group();
+        TableColumn first = group.addColumn();
+        TableColumn second = group.addColumn();
+
+        group.removeColumn(first);
+
+        assertEquals(List.of(second), group.getColumns());
+        assertTrue(first.getParent().isEmpty());
+    }
+
+    @Test
+    void removeAllColumns_leavesTheGroupEmpty() {
+        TableColumnGroup group = group();
+        group.addColumn();
+        group.addColumn();
+
+        group.removeAllColumns();
+
+        assertTrue(group.getColumns().isEmpty());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableColumnTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableColumnTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TableColumnTest extends ComponentTest {
+    // Property tests in super class
+
+    @Override
+    protected void addProperties() {
+        addProperty("span", int.class, 1, 2, false, false);
+    }
+
+    @Test
+    void defaultSpanIsOne() {
+        TableColumn col = (TableColumn) getComponent();
+
+        assertEquals(1, col.getSpan());
+        assertNull(col.getElement().getAttribute("span"));
+    }
+
+    @Test
+    void spanConstructor_writesTheAttribute() {
+        TableColumn col = new TableColumn(3);
+
+        assertEquals("3", col.getElement().getAttribute("span"));
+        assertEquals(3, col.getSpan());
+    }
+
+    @Test
+    void setSpan_rejectsNonPositive() {
+        TableColumn col = (TableColumn) getComponent();
+
+        assertThrows(IllegalArgumentException.class, () -> col.setSpan(0));
+        assertThrows(IllegalArgumentException.class, () -> col.setSpan(-1));
+    }
+
+    @Test
+    void resetSpan_removesTheAttribute() {
+        TableColumn col = (TableColumn) getComponent();
+        col.setSpan(4);
+
+        col.resetSpan();
+
+        assertNull(col.getElement().getAttribute("span"));
+        assertEquals(1, col.getSpan());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -162,6 +162,34 @@ class TableTest extends ComponentTest {
     }
 
     @Test
+    void columnGroups_sitAfterTheCaptionAndBeforeTheHead() {
+        Table table = table();
+        var head = table.getHead();
+        var caption = table.getCaption();
+
+        var first = table.addColumnGroup();
+        var second = table.addColumnGroup(new TableColumn(2),
+                new TableColumn());
+
+        assertEquals(List.of(caption, first, second, head),
+                table.getChildren().toList());
+        assertEquals(List.of(first, second), table.getColumnGroups());
+        assertEquals(2, second.getColumns().size());
+    }
+
+    @Test
+    void removeColumnGroup_detachesOnlyThatGroup() {
+        Table table = table();
+        var first = table.addColumnGroup();
+        var second = table.addColumnGroup();
+
+        table.removeColumnGroup(first);
+
+        assertEquals(List.of(second), table.getColumnGroups());
+        assertTrue(first.getParent().isEmpty());
+    }
+
+    @Test
     void getSection_calledTwice_doesNotCreateASecondOne() {
         Table table = table();
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.Table;
+import com.vaadin.flow.component.html.TableColumn;
+import com.vaadin.flow.component.html.TableColumnGroup;
+import com.vaadin.flow.component.html.TableDataCell;
+import com.vaadin.flow.component.html.TableHeaderCell;
+import com.vaadin.flow.component.html.TableRow;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Replicates the examples from the MDN "HTML table basics" tutorial:
+ * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
+ * <p>
+ * Only the {@code <colgroup>}/{@code <col>} example is present so far; the
+ * remaining examples need table API that does not exist yet.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
+public class HtmlTableTutorialView extends Div {
+
+    public HtmlTableTutorialView() {
+        Element style = new Element("style");
+        style.setText("""
+                table {
+                  border-collapse: collapse;
+                  border: 2px solid rgb(200 200 200);
+                  letter-spacing: 1px;
+                  font-size: 0.8rem;
+                }
+
+                td,
+                th {
+                  border: 1px solid rgb(190 190 190);
+                  padding: 10px 20px;
+                }
+
+                td {
+                  text-align: center;
+                }
+                .column-background {
+                  background-color: #97db9a;
+                }
+
+                .column-fixed-width {
+                  width: 40px;
+                }
+
+                .column-background-border {
+                  background-color: #dcc48e;
+                  border: 4px solid #c1437a;
+                }
+                """);
+        getElement().appendChild(style);
+
+        add(new H2("HTML table basics — examples from MDN"));
+
+        add(new H3("5. School timetable styled with <colgroup>/<col>"));
+        SchoolTimetable timetable = new SchoolTimetable();
+        timetable.setId("school-timetable");
+        add(timetable);
+    }
+
+    /**
+     * Example 5: school timetable, demonstrating column-level styling via
+     * {@code <colgroup>}/{@code <col>}.
+     */
+    static class SchoolTimetable extends Table {
+        {
+            // Mirrors the MDN colgroup: 2 plain cols, then a sequence of styled
+            // cols, ending with a 2-col fixed-width group on the right.
+            TableColumnGroup group = addColumnGroup();
+            group.addColumn(2);
+            group.addColumn().addClassName("column-background");
+            group.addColumn().addClassName("column-fixed-width");
+            group.addColumn().addClassName("column-background");
+            group.addColumn().addClassName("column-background-border");
+            TableColumn rightPair = group.addColumn(2);
+            rightPair.addClassName("column-fixed-width");
+
+            TableRow header = addBodyRow();
+            header.addDataCell();
+            addHeaderCells(header, "Mon", "Tues", "Wed", "Thurs", "Fri", "Sat",
+                    "Sun");
+
+            addPeriodRow("1st period", "English", "", "", "German", "Dutch", "",
+                    "");
+            addPeriodRow("2nd period", "English", "English", "", "German",
+                    "Dutch", "", "");
+            addPeriodRow("3rd period", "", "German", "German", "", "Dutch", "",
+                    "");
+            addPeriodRow("4th period", "", "English", "English", "", "Dutch",
+                    "", "");
+        }
+
+        private void addPeriodRow(String period, String... days) {
+            TableRow row = addBodyRow();
+            addHeaderCells(row, period);
+            addDataCells(row, days);
+        }
+
+        /**
+         * Appends a row to the table body.
+         * <p>
+         * Stands in for {@code Table.addRow()}.
+         */
+        private TableRow addBodyRow() {
+            return getBody().addRow();
+        }
+
+        /**
+         * Appends a header cell per text.
+         * <p>
+         * Stands in for {@code TableRow.addHeaderCells(String...)}. The MDN
+         * example also gives these cells a {@code scope}, which needs
+         * {@code TableHeaderCell.setScope}.
+         */
+        private static void addHeaderCells(TableRow row, String... texts) {
+            for (String text : texts) {
+                row.addCells(new TableHeaderCell(text));
+            }
+        }
+
+        /**
+         * Appends a data cell per text.
+         * <p>
+         * Stands in for {@code TableRow.addDataCells(String...)}.
+         */
+        private static void addDataCells(TableRow row, String... texts) {
+            for (String text : texts) {
+                row.addCells(new TableDataCell(text));
+            }
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.html.testbench.TableColumnElement;
 import com.vaadin.flow.component.html.testbench.TableColumnGroupElement;
-import com.vaadin.flow.component.html.testbench.TableDataCellElement;
 import com.vaadin.flow.component.html.testbench.TableElement;
 import com.vaadin.flow.component.html.testbench.TableRowElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -44,8 +43,7 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
 
     @Test
     public void colgroupRendered_withColumnsInDocumentOrder() {
-        List<TableColumnGroupElement> groups = timetable
-                .$(TableColumnGroupElement.class).all();
+        List<TableColumnGroupElement> groups = timetable.getColumnGroups();
         Assert.assertEquals(1, groups.size());
 
         List<TableColumnElement> columns = groups.get(0).getColumns();
@@ -94,17 +92,16 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
 
     @Test
     public void tableBodyHasOneRowPerPeriodPlusTheHeaderRow() {
-        Assert.assertEquals(5, timetable.$(TableRowElement.class).all().size());
-        Assert.assertEquals(7,
-                firstPeriodRow().$(TableDataCellElement.class).all().size());
+        Assert.assertEquals(5, timetable.getRows().size());
+        Assert.assertEquals(7, firstPeriodRow().getDataCells().size());
     }
 
     private List<TableColumnElement> columns() {
-        return timetable.$(TableColumnGroupElement.class).first().getColumns();
+        return timetable.getColumnGroups().get(0).getColumns();
     }
 
     private TableRowElement firstPeriodRow() {
         // Row 0 is the Mon..Sun header row, row 1 is "1st period".
-        return timetable.$(TableRowElement.class).all().get(1);
+        return timetable.getRow(1);
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.TableColumnElement;
+import com.vaadin.flow.component.html.testbench.TableColumnGroupElement;
+import com.vaadin.flow.component.html.testbench.TableDataCellElement;
+import com.vaadin.flow.component.html.testbench.TableElement;
+import com.vaadin.flow.component.html.testbench.TableRowElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class HtmlTableTutorialIT extends ChromeBrowserTest {
+
+    private static final String BACKGROUND = "rgba(151, 219, 154, 1)";
+    private static final String BACKGROUND_BORDER = "rgba(220, 196, 142, 1)";
+    private static final String TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+    private TableElement timetable;
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        open();
+        timetable = $(TableElement.class).id("school-timetable");
+    }
+
+    @Test
+    public void colgroupRendered_withColumnsInDocumentOrder() {
+        List<TableColumnGroupElement> groups = timetable
+                .$(TableColumnGroupElement.class).all();
+        Assert.assertEquals(1, groups.size());
+
+        List<TableColumnElement> columns = groups.get(0).getColumns();
+        Assert.assertEquals(6, columns.size());
+        Assert.assertEquals(2, columns.get(0).getSpan());
+        Assert.assertEquals(1, columns.get(1).getSpan());
+        Assert.assertEquals(2, columns.get(5).getSpan());
+    }
+
+    @Test
+    public void colgroupIsFirstChildOfTable() {
+        Assert.assertEquals("colgroup",
+                timetable.getPropertyElement("firstElementChild").getTagName());
+    }
+
+    @Test
+    public void columnsCarryTheStylingClasses() {
+        List<TableColumnElement> columns = columns();
+
+        Assert.assertNull(columns.get(0).getDomAttribute("class"));
+        Assert.assertEquals("column-background",
+                columns.get(1).getDomAttribute("class"));
+        Assert.assertEquals("column-fixed-width",
+                columns.get(2).getDomAttribute("class"));
+        Assert.assertEquals("column-background",
+                columns.get(3).getDomAttribute("class"));
+        Assert.assertEquals("column-background-border",
+                columns.get(4).getDomAttribute("class"));
+        Assert.assertEquals("column-fixed-width",
+                columns.get(5).getDomAttribute("class"));
+    }
+
+    @Test
+    public void columnStylesResolveInTheBrowser() {
+        // A <col> paints behind the cells of its column, so the styling has to
+        // be read off the <col> itself rather than off the <td> elements.
+        List<TableColumnElement> columns = columns();
+
+        Assert.assertEquals(TRANSPARENT,
+                columns.get(0).getCssValue("background-color"));
+        Assert.assertEquals(BACKGROUND,
+                columns.get(1).getCssValue("background-color"));
+        Assert.assertEquals(BACKGROUND_BORDER,
+                columns.get(4).getCssValue("background-color"));
+    }
+
+    @Test
+    public void tableBodyHasOneRowPerPeriodPlusTheHeaderRow() {
+        Assert.assertEquals(5, timetable.$(TableRowElement.class).all().size());
+        Assert.assertEquals(7,
+                firstPeriodRow().$(TableDataCellElement.class).all().size());
+    }
+
+    private List<TableColumnElement> columns() {
+        return timetable.$(TableColumnGroupElement.class).first().getColumns();
+    }
+
+    private TableRowElement firstPeriodRow() {
+        // Row 0 is the Mon..Sun header row, row 1 is "1st period".
+        return timetable.$(TableRowElement.class).all().get(1);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -94,6 +94,12 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     public void tableBodyHasOneRowPerPeriodPlusTheHeaderRow() {
         Assert.assertEquals(5, timetable.getRows().size());
         Assert.assertEquals(7, firstPeriodRow().getDataCells().size());
+        // The row leads with a <th> for the period, so the mixed list is one
+        // longer than the data cells alone
+        Assert.assertEquals(8, firstPeriodRow().getCells().size());
+        Assert.assertEquals("1st period",
+                firstPeriodRow().getCell(0).getText());
+        Assert.assertEquals("English", timetable.getCell(1, 1).getText());
     }
 
     private List<TableColumnElement> columns() {


### PR DESCRIPTION
A <colgroup> applies attributes to several columns at once — most often
a class for CSS — without repeating them on every cell. Table had
no way to produce one.

TableColumnGroup and TableColumn wrap the two elements, and
Table gains addColumnGroup, getColumnGroups and removeColumnGroup.
TableColumn extends HtmlComponent rather than HtmlContainer
because <col> is a void element.

The spec requires <colgroup> after the optional <caption> and before
<thead>, <tbody> and <tfoot>, so the ad-hoc index arithmetic in
getCaption, getHead, getFoot and addBody is replaced by a single
insertion index derived from the ranks of the current children. That
also fixes the placement of a <tbody> added to a table whose children
include components the old counting did not know about.
