### PR TITLE
feat: row and cell content shortcuts for Table

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -15,8 +15,10 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -304,6 +306,166 @@ public class Table extends HtmlComponent
      */
     public void removeBody(TableBody body) {
         removeChild(body);
+    }
+
+    /**
+     * Returns every row of this table, in document order: the
+     * <code>&lt;thead&gt;</code> rows, then the rows of each
+     * <code>&lt;tbody&gt;</code>, then the <code>&lt;tfoot&gt;</code> rows.
+     *
+     * @return all the rows of this table.
+     */
+    public List<TableRow> getRows() {
+        return sections().flatMap(section -> section.getRows().stream())
+                .toList();
+    }
+
+    /**
+     * Removes every row from this table, leaving its sections in place.
+     */
+    public void removeAllRows() {
+        sections().forEach(TableRowContainer::removeAllRows);
+    }
+
+    /**
+     * Appends a new empty row to this table's <code>&lt;tbody&gt;</code>,
+     * creating the body if the table has none. This mirrors what a browser does
+     * with a <code>&lt;tr&gt;</code> written straight inside a
+     * <code>&lt;table&gt;</code>.
+     *
+     * @return the new row.
+     */
+    public TableRow addRow() {
+        return getBody().addRow();
+    }
+
+    /**
+     * Appends a row of data cells with the given texts to this table's
+     * <code>&lt;tbody&gt;</code>.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the new row.
+     */
+    public TableRow addRow(String... cellTexts) {
+        return addRow(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addRow(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the new row.
+     */
+    public TableRow addRow(List<String> cellTexts) {
+        return addRow().addDataCells(cellTexts);
+    }
+
+    /**
+     * Appends the given rows to this table's <code>&lt;tbody&gt;</code>.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addRows(TableRow... rows) {
+        getBody().addRows(rows);
+    }
+
+    /**
+     * Appends a new empty row to this table's <code>&lt;thead&gt;</code>,
+     * creating it if the table has none.
+     *
+     * @return the new row.
+     */
+    public TableRow addHeaderRow() {
+        return getHead().addRow();
+    }
+
+    /**
+     * Appends a row of header cells with the given texts to this table's
+     * <code>&lt;thead&gt;</code>.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return the new row.
+     */
+    public TableRow addHeaderRow(String... cellTexts) {
+        return addHeaderRow(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addHeaderRow(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return the new row.
+     */
+    public TableRow addHeaderRow(List<String> cellTexts) {
+        return addHeaderRow().addHeaderCells(cellTexts);
+    }
+
+    /**
+     * Appends the given rows to this table's <code>&lt;thead&gt;</code>.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addHeaderRows(TableRow... rows) {
+        getHead().addRows(rows);
+    }
+
+    /**
+     * Appends a new empty row to this table's <code>&lt;tfoot&gt;</code>,
+     * creating it if the table has none.
+     *
+     * @return the new row.
+     */
+    public TableRow addFooterRow() {
+        return getFoot().addRow();
+    }
+
+    /**
+     * Appends a row of data cells with the given texts to this table's
+     * <code>&lt;tfoot&gt;</code>.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the new row.
+     */
+    public TableRow addFooterRow(String... cellTexts) {
+        return addFooterRow(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addFooterRow(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the new row.
+     */
+    public TableRow addFooterRow(List<String> cellTexts) {
+        return addFooterRow().addDataCells(cellTexts);
+    }
+
+    /**
+     * Appends the given rows to this table's <code>&lt;tfoot&gt;</code>.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addFooterRows(TableRow... rows) {
+        getFoot().addRows(rows);
+    }
+
+    /**
+     * The row containers of this table — head, bodies and foot — in document
+     * order. TableRowContainer is not a Component subtype, so this cannot go
+     * through ComponentUtil.getChildrenOfType.
+     */
+    private Stream<TableRowContainer> sections() {
+        return getChildren().filter(TableRowContainer.class::isInstance)
+                .map(TableRowContainer.class::cast);
     }
 
     private void removeChild(Component child) {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
@@ -50,26 +51,94 @@ public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
     }
 
     /**
-     * Creates a new row with the given cells.
+     * Creates a new row with the given content, following the rules of
+     * {@link #addCells(Component...)}.
      *
-     * @param cells
-     *            the cells to add.
+     * @param components
+     *            the cells, or the content to wrap in cells.
      */
-    public TableRow(TableCell... cells) {
+    public TableRow(Component... components) {
         super();
-        addCells(cells);
+        addCells(components);
     }
 
     /**
-     * Appends the given cells to this row.
+     * Appends the given components to this row. A {@link TableCell} is added
+     * as-is; anything else is wrapped in a new {@link TableDataCell}, since a
+     * <code>&lt;tr&gt;</code> may only contain cells.
      *
-     * @param cells
-     *            the cells to add.
+     * @param components
+     *            the cells, or the content to wrap in cells.
+     * @return this row, for fluent chaining.
      */
-    public void addCells(TableCell... cells) {
-        for (TableCell cell : cells) {
-            getElement().appendChild(cell.getElement());
+    public TableRow addCells(Component... components) {
+        return addCells(Arrays.asList(components));
+    }
+
+    /**
+     * List equivalent of {@link #addCells(Component...)}.
+     *
+     * @param components
+     *            the cells, or the content to wrap in cells.
+     * @return this row, for fluent chaining.
+     */
+    public TableRow addCells(List<? extends Component> components) {
+        for (Component component : components) {
+            if (component instanceof TableCell cell) {
+                append(cell);
+            } else {
+                append(new TableDataCell(component));
+            }
         }
+        return this;
+    }
+
+    /**
+     * Appends a sequence of data cells (<code>&lt;td&gt;</code>) with the given
+     * text contents to this row.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return this row, for fluent chaining.
+     */
+    public TableRow addDataCells(String... cellTexts) {
+        return addDataCells(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addDataCells(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return this row, for fluent chaining.
+     */
+    public TableRow addDataCells(List<String> cellTexts) {
+        cellTexts.forEach(this::addDataCell);
+        return this;
+    }
+
+    /**
+     * Appends a sequence of header cells (<code>&lt;th&gt;</code>) with the
+     * given text contents to this row.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return this row, for fluent chaining.
+     */
+    public TableRow addHeaderCells(String... cellTexts) {
+        return addHeaderCells(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addHeaderCells(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return this row, for fluent chaining.
+     */
+    public TableRow addHeaderCells(List<String> cellTexts) {
+        cellTexts.forEach(this::addHeaderCell);
+        return this;
     }
 
     /**
@@ -95,6 +164,17 @@ public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
     }
 
     /**
+     * Appends a new header cell with the given text to this row.
+     *
+     * @param text
+     *            the text content.
+     * @return the new {@code <th>}.
+     */
+    public TableHeaderCell addHeaderCell(String text) {
+        return append(new TableHeaderCell(text));
+    }
+
+    /**
      * Inserts a new empty header cell at the given position.
      *
      * @param position
@@ -113,6 +193,17 @@ public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
      */
     public TableDataCell addDataCell() {
         return append(new TableDataCell());
+    }
+
+    /**
+     * Appends a new data cell with the given text to this row.
+     *
+     * @param text
+     *            the text content.
+     * @return the new {@code <td>}.
+     */
+    public TableDataCell addDataCell(String text) {
+        return append(new TableDataCell(text));
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
@@ -84,6 +84,34 @@ class TableRowTest extends ComponentTest {
     }
 
     @Test
+    void addCells_keepsCellsAsIsAndWrapsAnythingElse() {
+        TableRow row = new TableRow();
+        TableHeaderCell th = new TableHeaderCell("header");
+        TableDataCell td = new TableDataCell("data");
+        Span span = new Span("wrapped");
+
+        assertEquals(row, row.addCells(th, td, span));
+
+        List<TableCell> cells = row.getCells();
+        assertEquals(th, cells.get(0));
+        assertEquals(td, cells.get(1));
+        assertEquals(span,
+                cells.get(2).getChildren().findFirst().orElseThrow());
+    }
+
+    @Test
+    void addTextCells_appendOnePerText() {
+        TableRow row = new TableRow();
+
+        row.addHeaderCells("a", "b").addDataCells("c", "d");
+
+        assertEquals(List.of("a", "b"), row.getHeaderCells().stream()
+                .map(TableHeaderCell::getText).toList());
+        assertEquals(List.of("c", "d"), row.getDataCells().stream()
+                .map(TableDataCell::getText).toList());
+    }
+
+    @Test
     void removeCell_detachesItFromTheRow() {
         TableRow row = new TableRow();
         TableHeaderCell th = row.addHeaderCell();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -190,6 +190,73 @@ class TableTest extends ComponentTest {
     }
 
     @Test
+    void addRow_appendsToTheBodyAndCreatesItIfMissing() {
+        Table table = table();
+
+        var row = table.addRow("a", "b");
+
+        assertEquals(List.of(row), table.getBody().getRows());
+        assertEquals(List.of("a", "b"), row.getDataCells().stream()
+                .map(TableDataCell::getText).toList());
+    }
+
+    @Test
+    void addHeaderAndFooterRows_landInTheirOwnSections() {
+        Table table = table();
+
+        var headerRow = table.addHeaderRow("h");
+        var footerRow = table.addFooterRow("f");
+
+        assertEquals(List.of(headerRow), table.getHead().getRows());
+        assertEquals(List.of(footerRow), table.getFoot().getRows());
+        assertEquals(List.of("h"), headerRow.getHeaderCells().stream()
+                .map(TableHeaderCell::getText).toList());
+        assertEquals(List.of("f"), footerRow.getDataCells().stream()
+                .map(TableDataCell::getText).toList());
+    }
+
+    @Test
+    void getRows_returnsHeadThenBodiesThenFootRows() {
+        Table table = table();
+        // Added out of document order to show the result follows the table,
+        // not the calls.
+        var footRow = table.addFooterRow();
+        var bodyRow = table.addRow();
+        var headRow = table.addHeaderRow();
+        var secondBodyRow = table.addBody().addRow();
+
+        assertEquals(List.of(headRow, bodyRow, secondBodyRow, footRow),
+                table.getRows());
+    }
+
+    @Test
+    void removeAllRows_keepsTheSections() {
+        Table table = table();
+        table.addHeaderRow();
+        table.addRow();
+        table.addFooterRow();
+
+        table.removeAllRows();
+
+        assertTrue(table.getRows().isEmpty());
+        assertEquals(3, table.getChildren().count());
+    }
+
+    @Test
+    void addRows_appendPreBuiltRowsToTheMatchingSection() {
+        Table table = table();
+        var head = new TableRow();
+        var body = new TableRow();
+        var foot = new TableRow();
+
+        table.addHeaderRows(head);
+        table.addRows(body);
+        table.addFooterRows(foot);
+
+        assertEquals(List.of(head, body, foot), table.getRows());
+    }
+
+    @Test
     void getSection_calledTwice_doesNotCreateASecondOne() {
         Table table = table();
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -21,8 +21,6 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Table;
 import com.vaadin.flow.component.html.TableColumn;
 import com.vaadin.flow.component.html.TableColumnGroup;
-import com.vaadin.flow.component.html.TableDataCell;
-import com.vaadin.flow.component.html.TableHeaderCell;
 import com.vaadin.flow.component.html.TableRow;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
@@ -32,8 +30,9 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * Replicates the examples from the MDN "HTML table basics" tutorial:
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
- * Only the {@code <colgroup>}/{@code <col>} example is present so far; the
- * remaining examples need table API that does not exist yet.
+ * The examples are added as the table API they need becomes available; the ones
+ * still missing need {@code scope}, {@code colspan} on <code>&lt;th&gt;</code>
+ * and caption content API.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
 public class HtmlTableTutorialView extends Div {
@@ -74,10 +73,24 @@ public class HtmlTableTutorialView extends Div {
 
         add(new H2("HTML table basics — examples from MDN"));
 
+        add(new H3("1. Basic table with rows and cells"));
+        BasicTable basic = new BasicTable();
+        basic.setId("basic-table");
+        add(basic);
+
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
         timetable.setId("school-timetable");
         add(timetable);
+    }
+
+    /** Example 1: minimal 2-row, 4-column table — no header. */
+    static class BasicTable extends Table {
+        {
+            addRow("Hi, I'm your first cell.", "I'm your second cell.",
+                    "I'm your third cell.", "I'm your fourth cell.");
+            addRow("Second row, first cell.", "Cell 2.", "Cell 3.", "Cell 4.");
+        }
     }
 
     /**
@@ -97,9 +110,9 @@ public class HtmlTableTutorialView extends Div {
             TableColumn rightPair = group.addColumn(2);
             rightPair.addClassName("column-fixed-width");
 
-            TableRow header = addBodyRow();
+            TableRow header = addRow();
             header.addDataCell();
-            addHeaderCells(header, "Mon", "Tues", "Wed", "Thurs", "Fri", "Sat",
+            header.addHeaderCells("Mon", "Tues", "Wed", "Thurs", "Fri", "Sat",
                     "Sun");
 
             addPeriodRow("1st period", "English", "", "", "German", "Dutch", "",
@@ -113,42 +126,9 @@ public class HtmlTableTutorialView extends Div {
         }
 
         private void addPeriodRow(String period, String... days) {
-            TableRow row = addBodyRow();
-            addHeaderCells(row, period);
-            addDataCells(row, days);
-        }
-
-        /**
-         * Appends a row to the table body.
-         * <p>
-         * Stands in for {@code Table.addRow()}.
-         */
-        private TableRow addBodyRow() {
-            return getBody().addRow();
-        }
-
-        /**
-         * Appends a header cell per text.
-         * <p>
-         * Stands in for {@code TableRow.addHeaderCells(String...)}. The MDN
-         * example also gives these cells a {@code scope}, which needs
-         * {@code TableHeaderCell.setScope}.
-         */
-        private static void addHeaderCells(TableRow row, String... texts) {
-            for (String text : texts) {
-                row.addCells(new TableHeaderCell(text));
-            }
-        }
-
-        /**
-         * Appends a data cell per text.
-         * <p>
-         * Stands in for {@code TableRow.addDataCells(String...)}.
-         */
-        private static void addDataCells(TableRow row, String... texts) {
-            for (String text : texts) {
-                row.addCells(new TableDataCell(text));
-            }
+            // The MDN example also gives the row header a scope, which needs
+            // TableHeaderCell.setScope
+            addRow().addHeaderCells(period).addDataCells(days);
         }
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -44,15 +44,14 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     @Test
     public void basicTableRendersRowsAndCells() {
         TableElement table = $(TableElement.class).id("basic-table");
-        List<TableRowElement> rows = table.$(TableRowElement.class).all();
+        List<TableRowElement> rows = table.getRows();
 
         Assert.assertEquals(2, rows.size());
-        Assert.assertEquals(4,
-                rows.get(0).$(TableDataCellElement.class).all().size());
+        Assert.assertEquals(4, rows.get(0).getDataCells().size());
         Assert.assertEquals("Hi, I'm your first cell.",
-                rows.get(0).$(TableDataCellElement.class).first().getText());
+                rows.get(0).getDataCells().get(0).getText());
         Assert.assertEquals("Second row, first cell.",
-                rows.get(1).$(TableDataCellElement.class).first().getText());
+                rows.get(1).getDataCells().get(0).getText());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -42,6 +42,28 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void basicTableRendersRowsAndCells() {
+        TableElement table = $(TableElement.class).id("basic-table");
+        List<TableRowElement> rows = table.$(TableRowElement.class).all();
+
+        Assert.assertEquals(2, rows.size());
+        Assert.assertEquals(4,
+                rows.get(0).$(TableDataCellElement.class).all().size());
+        Assert.assertEquals("Hi, I'm your first cell.",
+                rows.get(0).$(TableDataCellElement.class).first().getText());
+        Assert.assertEquals("Second row, first cell.",
+                rows.get(1).$(TableDataCellElement.class).first().getText());
+    }
+
+    @Test
+    public void rowsAddedWithAddRowLandInTheImplicitBody() {
+        TableElement table = $(TableElement.class).id("basic-table");
+
+        Assert.assertEquals("tbody",
+                table.getPropertyElement("firstElementChild").getTagName());
+    }
+
+    @Test
     public void colgroupRendered_withColumnsInDocumentOrder() {
         List<TableColumnGroupElement> groups = timetable.getColumnGroups();
         Assert.assertEquals(1, groups.size());


### PR DESCRIPTION
Building a table meant creating every cell by hand and setting its text afterwards, and rows could only be reached through the section they belong to. TableRow gains addHeaderCell(String), addDataCell(String), addHeaderCells, addDataCells and addCells; Table gains addRow, addRows, addHeaderRow(s), addFooterRow(s), getRows and removeAllRows.

addRow appends to the table's body and creates an implicit <tbody> when there is none, mirroring what a browser does with a <tr> written directly inside a <table>. addCells wraps anything that is not already a cell in a <td>, since a <tr> may only contain <td> and <th>; the TableRow(Component...) constructor still adds its arguments as-is, as changing that would change the behaviour of existing code.

The MDN basic-table example now builds as written in the browser test, and the school timetable no longer needs stand-in helpers for its rows.
