### PR TITLE
feat: scope attribute on TableHeaderCell

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.html;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -77,5 +78,106 @@ public class TableHeaderCell extends TableCell
     public TableHeaderCell(Signal<String> textSignal) {
         Objects.requireNonNull(textSignal, "textSignal must not be null");
         bindText(textSignal);
+    }
+
+    /**
+     * Defines the cells that a <code>&lt;th&gt;</code> header relates to —
+     * effectively the answer to "which other cells does this header label?".
+     * Setting it correctly is what lets a screen reader read out the right
+     * column or row header when a user navigates into a data cell.
+     * <p>
+     * If no scope is set (or the value is unrecognized), browsers automatically
+     * infer the scope from the table structure. Per the <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th#scope">HTML
+     * spec</a>, the standard keywords are {@link #ROW row}, {@link #COL col},
+     * {@link #ROWGROUP rowgroup}, and {@link #COLGROUP colgroup}; {@link #AUTO
+     * auto} writes the literal {@code "auto"} attribute value, which browsers
+     * treat the same as omitting the attribute.
+     */
+    public enum Scope {
+        /**
+         * The header relates to all cells of the row it belongs to. Use this
+         * for a leading <code>&lt;th&gt;</code> that labels its row (e.g. the
+         * row's name or category).
+         */
+        ROW("row"),
+        /**
+         * The header relates to all cells of the column it belongs to. Use this
+         * for a header at the top of a column (the most common case in
+         * <code>&lt;thead&gt;</code>).
+         */
+        COL("col"),
+        /**
+         * The header belongs to a row group ({@code <tbody>} or
+         * {@code <thead>}/{@code <tfoot>}) and relates to all cells in that
+         * group.
+         */
+        ROWGROUP("rowgroup"),
+        /**
+         * The header belongs to a column group ({@link TableColumnGroup}) and
+         * relates to all cells in that group.
+         */
+        COLGROUP("colgroup"),
+        /**
+         * Writes the literal {@code "auto"} value. Behaves the same as leaving
+         * the attribute unset — the browser infers the scope from the table
+         * structure.
+         */
+        AUTO("auto");
+
+        private final String value;
+
+        Scope(String value) {
+            this.value = value;
+        }
+
+        /**
+         * Returns the attribute value as it appears in the rendered HTML.
+         */
+        public String getValue() {
+            return value;
+        }
+
+        static Scope fromValue(String value) {
+            if (value == null) {
+                return null;
+            }
+            for (Scope s : values()) {
+                if (s.value.equals(value)) {
+                    return s;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Sets the {@code scope} attribute, declaring which cells this header
+     * labels. Critical for accessibility — screen readers use this to announce
+     * the right header when a user navigates into a data cell. Pass
+     * {@code null} to remove the attribute (browsers will then infer scope from
+     * structure).
+     *
+     * @param scope
+     *            the scope, or {@code null} to clear the attribute.
+     * @see Scope
+     */
+    public void setScope(Scope scope) {
+        if (scope == null) {
+            getElement().removeAttribute("scope");
+        } else {
+            getElement().setAttribute("scope", scope.getValue());
+        }
+    }
+
+    /**
+     * Returns the {@code scope} attribute value, if set.
+     *
+     * @return the scope wrapped in an {@link Optional}, or empty if unset (or
+     *         the value is unrecognized).
+     */
+    public Optional<Scope> getScope() {
+        return Optional.ofNullable(
+                Scope.fromValue(getElement().getAttribute("scope")));
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
@@ -138,7 +139,7 @@ public class TableHeaderCell extends TableCell
             return value;
         }
 
-        static Scope fromValue(String value) {
+        static @Nullable Scope fromValue(@Nullable String value) {
             if (value == null) {
                 return null;
             }
@@ -162,7 +163,7 @@ public class TableHeaderCell extends TableCell
      *            the scope, or {@code null} to clear the attribute.
      * @see Scope
      */
-    public void setScope(Scope scope) {
+    public void setScope(@Nullable Scope scope) {
         if (scope == null) {
             getElement().removeAttribute("scope");
         } else {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -78,6 +78,7 @@ class HtmlComponentSmokeTest {
                         IFrame.SandboxType.ALLOW_MODALS });
         testValues.put(Component.class, new Paragraph("Component"));
         testValues.put(HasText.WhiteSpace.class, HasText.WhiteSpace.PRE_LINE);
+        testValues.put(TableHeaderCell.Scope.class, TableHeaderCell.Scope.COL);
     }
 
     private static final Map<Class<?>, Map<Class<?>, Object>> specialTestValues = new HashMap<>();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
@@ -15,11 +15,49 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.html.TableHeaderCell.Scope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class TableHeaderCellTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    void setScope_writesTheAttributeAndReadsBack() {
+        TableHeaderCell cell = new TableHeaderCell();
+        assertEquals(Optional.empty(), cell.getScope());
+
+        cell.setScope(Scope.ROWGROUP);
+
+        assertEquals("rowgroup", cell.getElement().getAttribute("scope"));
+        assertEquals(Optional.of(Scope.ROWGROUP), cell.getScope());
+    }
+
+    @Test
+    void setScope_null_removesTheAttribute() {
+        TableHeaderCell cell = new TableHeaderCell();
+        cell.setScope(Scope.COL);
+
+        cell.setScope(null);
+
+        assertEquals(null, cell.getElement().getAttribute("scope"));
+        assertEquals(Optional.empty(), cell.getScope());
+    }
+
+    @Test
+    void getScope_unrecognizedAttributeValue_isEmpty() {
+        TableHeaderCell cell = new TableHeaderCell();
+        cell.getElement().setAttribute("scope", "nonsense");
+
+        assertEquals(Optional.empty(), cell.getScope());
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Table;
 import com.vaadin.flow.component.html.TableColumn;
 import com.vaadin.flow.component.html.TableColumnGroup;
+import com.vaadin.flow.component.html.TableHeaderCell.Scope;
 import com.vaadin.flow.component.html.TableRow;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
@@ -31,7 +32,7 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
  * The examples are added as the table API they need becomes available; the ones
- * still missing need {@code scope}, {@code colspan} on <code>&lt;th&gt;</code>
+ * still missing need {@code colspan}/{@code rowspan} on <code>&lt;th&gt;</code>
  * and caption content API.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
@@ -78,6 +79,11 @@ public class HtmlTableTutorialView extends Div {
         basic.setId("basic-table");
         add(basic);
 
+        add(new H3("2. Adding headers with <th>"));
+        DogsTable dogs = new DogsTable();
+        dogs.setId("dogs-table");
+        add(dogs);
+
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
         timetable.setId("school-timetable");
@@ -90,6 +96,32 @@ public class HtmlTableTutorialView extends Div {
             addRow("Hi, I'm your first cell.", "I'm your second cell.",
                     "I'm your third cell.", "I'm your fourth cell.");
             addRow("Second row, first cell.", "Cell 2.", "Cell 3.", "Cell 4.");
+        }
+    }
+
+    /** Example 2: row-headers and column-headers in the same table. */
+    static class DogsTable extends Table {
+        {
+            TableRow headerRow = addRow();
+            headerRow.addDataCell();
+            for (String name : new String[] { "Knocky", "Flor", "Ella",
+                    "Juan" }) {
+                headerRow.addHeaderCell(name).setScope(Scope.COL);
+            }
+            addRowWithRowHeader("Breed", "Jack Russell", "Poodle", "Streetdog",
+                    "Cocker Spaniel");
+            addRowWithRowHeader("Age", "16", "9", "10", "5");
+            addRowWithRowHeader("Owner", "Mother-in-law", "Me", "Me",
+                    "Sister-in-law");
+            addRowWithRowHeader("Eating habits", "Eats everyone's leftovers",
+                    "Nibbles at food", "Hearty eater",
+                    "Will eat till he explodes");
+        }
+
+        private void addRowWithRowHeader(String header, String... data) {
+            TableRow row = addRow();
+            row.addHeaderCell(header).setScope(Scope.ROW);
+            row.addDataCells(data);
         }
     }
 
@@ -126,9 +158,9 @@ public class HtmlTableTutorialView extends Div {
         }
 
         private void addPeriodRow(String period, String... days) {
-            // The MDN example also gives the row header a scope, which needs
-            // TableHeaderCell.setScope
-            addRow().addHeaderCells(period).addDataCells(days);
+            TableRow row = addRow();
+            row.addHeaderCell(period).setScope(Scope.ROW);
+            row.addDataCells(days);
         }
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -66,16 +66,15 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     @Test
     public void dogsTableHasColumnAndRowScopedHeaders() {
         TableElement table = $(TableElement.class).id("dogs-table");
-        List<TableRowElement> rows = table.$(TableRowElement.class).all();
+        List<TableRowElement> rows = table.getRows();
 
         List<TableHeaderCellElement> columnHeaders = rows.get(0)
-                .$(TableHeaderCellElement.class).all();
+                .getHeaderCells();
         Assert.assertEquals(4, columnHeaders.size());
         columnHeaders.forEach(header -> Assert.assertEquals("col",
                 header.getDomAttribute("scope")));
 
-        TableHeaderCellElement rowHeader = rows.get(1)
-                .$(TableHeaderCellElement.class).first();
+        TableHeaderCellElement rowHeader = rows.get(1).getHeaderCells().get(0);
         Assert.assertEquals("row", rowHeader.getDomAttribute("scope"));
         Assert.assertEquals("Breed", rowHeader.getText());
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.html.testbench.TableColumnElement;
 import com.vaadin.flow.component.html.testbench.TableColumnGroupElement;
 import com.vaadin.flow.component.html.testbench.TableElement;
+import com.vaadin.flow.component.html.testbench.TableHeaderCellElement;
 import com.vaadin.flow.component.html.testbench.TableRowElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -60,6 +61,23 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
 
         Assert.assertEquals("tbody",
                 table.getPropertyElement("firstElementChild").getTagName());
+    }
+
+    @Test
+    public void dogsTableHasColumnAndRowScopedHeaders() {
+        TableElement table = $(TableElement.class).id("dogs-table");
+        List<TableRowElement> rows = table.$(TableRowElement.class).all();
+
+        List<TableHeaderCellElement> columnHeaders = rows.get(0)
+                .$(TableHeaderCellElement.class).all();
+        Assert.assertEquals(4, columnHeaders.size());
+        columnHeaders.forEach(header -> Assert.assertEquals("col",
+                header.getDomAttribute("scope")));
+
+        TableHeaderCellElement rowHeader = rows.get(1)
+                .$(TableHeaderCellElement.class).first();
+        Assert.assertEquals("row", rowHeader.getDomAttribute("scope"));
+        Assert.assertEquals("Breed", rowHeader.getText());
     }
 
     @Test


### PR DESCRIPTION
A <th> only helps a screen reader if the browser can tell which cells it labels. Without a scope attribute the browser guesses from the table structure, which goes wrong as soon as a table has both row headers and column headers. TableHeaderCell had no way to set it.

setScope takes a Scope constant and getScope reads it back, with null clearing the attribute and an unrecognized value reading back as empty, matching how browsers treat it.

The MDN dogs example, which exists to show row and column headers in one table, now builds as written in the browser test, and the school timetable no longer omits the scope on its row headers.
