### PR TITLE
feat: colspan and rowspan for header cells

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -35,6 +35,9 @@ import com.vaadin.flow.component.HtmlContainer;
 @NullMarked
 public abstract class TableCell extends HtmlContainer {
 
+    private static final String ATTRIBUTE_COLSPAN = "colspan";
+    private static final String ATTRIBUTE_ROWSPAN = "rowspan";
+
     /**
      * Creates a new empty cell.
      */
@@ -50,5 +53,91 @@ public abstract class TableCell extends HtmlContainer {
      */
     protected TableCell(Component... components) {
         super(components);
+    }
+
+    /**
+     * Sets the {@code colspan} attribute — how many columns this cell spans.
+     * The default is {@code 1}.
+     * <p>
+     * Unlike {@link #setRowspan(int)}, zero is not allowed: the "span the rest
+     * of the column group" meaning it once had was dropped from HTML, and
+     * browsers now clamp it back to {@code 1}. Values above 1000 are clamped to
+     * 1000.
+     *
+     * @param colspan
+     *            a positive integer.
+     * @throws IllegalArgumentException
+     *             if {@code colspan} is less than 1.
+     */
+    public void setColspan(int colspan) {
+        if (colspan < 1) {
+            throw new IllegalArgumentException(
+                    "colspan must be a positive integer value");
+        }
+        setSpanAttribute(ATTRIBUTE_COLSPAN, colspan);
+    }
+
+    /**
+     * Returns the value of the {@code colspan} attribute.
+     *
+     * @return the current colspan. Default is 1.
+     */
+    public int getColspan() {
+        return getSpan(ATTRIBUTE_COLSPAN);
+    }
+
+    /**
+     * Resets the colspan to its default value of 1.
+     */
+    public void resetColspan() {
+        getElement().removeAttribute(ATTRIBUTE_COLSPAN);
+    }
+
+    /**
+     * Sets the {@code rowspan} attribute — how many rows this cell spans. The
+     * default is {@code 1}.
+     * <p>
+     * Zero is allowed and still means something in HTML: the cell extends to
+     * the end of the row group ({@code <thead>}, {@code <tbody>} or
+     * {@code <tfoot>}, even an implicit one) it belongs to. Values above 65534
+     * are clamped to 65534.
+     *
+     * @param rowspan
+     *            a non-negative integer, where 0 spans the rest of the row
+     *            group.
+     * @throws IllegalArgumentException
+     *             if {@code rowspan} is negative.
+     */
+    public void setRowspan(int rowspan) {
+        if (rowspan < 0) {
+            throw new IllegalArgumentException(
+                    "rowspan must be a non-negative integer value");
+        }
+        setSpanAttribute(ATTRIBUTE_ROWSPAN, rowspan);
+    }
+
+    /**
+     * Returns the value of the {@code rowspan} attribute.
+     *
+     * @return the current rowspan. Default is 1.
+     */
+    public int getRowspan() {
+        return getSpan(ATTRIBUTE_ROWSPAN);
+    }
+
+    /**
+     * Resets the rowspan to its default value of 1.
+     */
+    public void resetRowspan() {
+        getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
+    }
+
+    private void setSpanAttribute(String attribute, int span) {
+        getElement().setAttribute(attribute, String.valueOf(span));
+    }
+
+    private int getSpan(String attribute) {
+        String span = getElement().getAttribute(attribute);
+        return span == null ? 1 : Integer.parseInt(span);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
@@ -38,9 +38,6 @@ import com.vaadin.flow.signals.Signal;
 public class TableDataCell extends TableCell
         implements ClickNotifier<TableDataCell> {
 
-    private static final String ATTRIBUTE_COLSPAN = "colspan";
-    private static final String ATTRIBUTE_ROWSPAN = "rowspan";
-
     /**
      * Creates a new empty data cell.
      */
@@ -79,91 +76,5 @@ public class TableDataCell extends TableCell
     public TableDataCell(Signal<String> textSignal) {
         Objects.requireNonNull(textSignal, "textSignal must not be null");
         bindText(textSignal);
-    }
-
-    /**
-     * Sets the {@code colspan} attribute — how many columns this cell spans.
-     * The default is {@code 1}.
-     * <p>
-     * Unlike {@link #setRowspan(int)}, zero is not allowed: the "span the rest
-     * of the column group" meaning it once had was dropped from HTML, and
-     * browsers now clamp it back to {@code 1}. Values above 1000 are clamped to
-     * 1000.
-     *
-     * @param colspan
-     *            a positive integer.
-     * @throws IllegalArgumentException
-     *             if {@code colspan} is less than 1.
-     */
-    public void setColspan(int colspan) {
-        if (colspan < 1) {
-            throw new IllegalArgumentException(
-                    "colspan must be a positive integer value");
-        }
-        setSpanAttribute(ATTRIBUTE_COLSPAN, colspan);
-    }
-
-    /**
-     * Returns the value of the {@code colspan} attribute.
-     *
-     * @return the current colspan. Default is 1.
-     */
-    public int getColspan() {
-        return getSpan(ATTRIBUTE_COLSPAN);
-    }
-
-    /**
-     * Resets the colspan to its default value of 1.
-     */
-    public void resetColspan() {
-        getElement().removeAttribute(ATTRIBUTE_COLSPAN);
-    }
-
-    /**
-     * Sets the {@code rowspan} attribute — how many rows this cell spans. The
-     * default is {@code 1}.
-     * <p>
-     * Zero is allowed and still means something in HTML: the cell extends to
-     * the end of the row group ({@code <thead>}, {@code <tbody>} or
-     * {@code <tfoot>}, even an implicit one) it belongs to. Values above 65534
-     * are clamped to 65534.
-     *
-     * @param rowspan
-     *            a non-negative integer, where 0 spans the rest of the row
-     *            group.
-     * @throws IllegalArgumentException
-     *             if {@code rowspan} is negative.
-     */
-    public void setRowspan(int rowspan) {
-        if (rowspan < 0) {
-            throw new IllegalArgumentException(
-                    "rowspan must be a non-negative integer value");
-        }
-        setSpanAttribute(ATTRIBUTE_ROWSPAN, rowspan);
-    }
-
-    /**
-     * Returns the value of the {@code rowspan} attribute.
-     *
-     * @return the current rowspan. Default is 1.
-     */
-    public int getRowspan() {
-        return getSpan(ATTRIBUTE_ROWSPAN);
-    }
-
-    /**
-     * Resets the rowspan to its default value of 1.
-     */
-    public void resetRowspan() {
-        getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
-    }
-
-    private void setSpanAttribute(String attribute, int span) {
-        getElement().setAttribute(attribute, String.valueOf(span));
-    }
-
-    private int getSpan(String attribute) {
-        String span = getElement().getAttribute(attribute);
-        return span == null ? 1 : Integer.parseInt(span);
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Named;
@@ -30,6 +31,7 @@ import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.local.ValueSignal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -92,5 +94,67 @@ class TableCellTest extends SignalsUnitTest {
     void signalConstructor_nullSignal_throws(
             Function<Signal<String>, TableCell> constructor) {
         assertThrows(NullPointerException.class, () -> constructor.apply(null));
+    }
+
+    static Stream<Named<Supplier<TableCell>>> cellKinds() {
+        return Stream.of(Named.of("td", TableDataCell::new),
+                Named.of("th", TableHeaderCell::new));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void spansDefaultToOneAndReadBackWhatIsSet(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        assertEquals(1, cell.getColspan());
+        assertEquals(1, cell.getRowspan());
+
+        cell.setColspan(2);
+        cell.setRowspan(3);
+
+        assertEquals("2", cell.getElement().getAttribute("colspan"));
+        assertEquals("3", cell.getElement().getAttribute("rowspan"));
+        assertEquals(2, cell.getColspan());
+        assertEquals(3, cell.getRowspan());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void resetSpans_removeTheAttributes(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        cell.setColspan(2);
+        cell.setRowspan(3);
+
+        cell.resetColspan();
+        cell.resetRowspan();
+
+        assertNull(cell.getElement().getAttribute("colspan"));
+        assertNull(cell.getElement().getAttribute("rowspan"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void spans_rejectNegativeValues(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+
+        assertEquals("colspan must be a positive integer value",
+                assertThrows(IllegalArgumentException.class,
+                        () -> cell.setColspan(-1)).getMessage());
+        assertEquals("rowspan must be a non-negative integer value",
+                assertThrows(IllegalArgumentException.class,
+                        () -> cell.setRowspan(-1)).getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void zeroSpan_rejectedForColumnsButNotForRows(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+
+        // colspan=0 was dropped from HTML and browsers clamp it back to 1
+        assertThrows(IllegalArgumentException.class, () -> cell.setColspan(0));
+
+        // rowspan=0 still means "to the end of the row group"
+        cell.setRowspan(0);
+        assertEquals("0", cell.getElement().getAttribute("rowspan"));
+        assertEquals(0, cell.getRowspan());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
@@ -15,12 +15,6 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 class TableDataCellTest extends ComponentTest {
     // Property tests in super class
 
@@ -28,51 +22,5 @@ class TableDataCellTest extends ComponentTest {
     protected void addProperties() {
         addProperty("colspan", int.class, 1, 2, false, false);
         addProperty("rowspan", int.class, 1, 2, false, false);
-    }
-
-    @Test
-    void spansDefaultToOne() {
-        TableDataCell cell = (TableDataCell) getComponent();
-
-        assertEquals(1, cell.getColspan());
-        assertEquals(1, cell.getRowspan());
-    }
-
-    @Test
-    void resetSpans_removeTheAttributes() {
-        TableDataCell cell = (TableDataCell) getComponent();
-        cell.setColspan(2);
-        cell.setRowspan(3);
-
-        cell.resetColspan();
-        cell.resetRowspan();
-
-        assertNull(cell.getElement().getAttribute("colspan"));
-        assertNull(cell.getElement().getAttribute("rowspan"));
-    }
-
-    @Test
-    void spans_rejectNegativeValues() {
-        TableDataCell cell = (TableDataCell) getComponent();
-
-        assertEquals("colspan must be a positive integer value",
-                assertThrows(IllegalArgumentException.class,
-                        () -> cell.setColspan(-1)).getMessage());
-        assertEquals("rowspan must be a non-negative integer value",
-                assertThrows(IllegalArgumentException.class,
-                        () -> cell.setRowspan(-1)).getMessage());
-    }
-
-    @Test
-    void zeroSpan_rejectedForColumnsButNotForRows() {
-        TableDataCell cell = (TableDataCell) getComponent();
-
-        // colspan=0 was dropped from HTML and browsers clamp it back to 1
-        assertThrows(IllegalArgumentException.class, () -> cell.setColspan(0));
-
-        // rowspan=0 still means "to the end of the row group"
-        cell.setRowspan(0);
-        assertEquals("0", cell.getElement().getAttribute("rowspan"));
-        assertEquals(0, cell.getRowspan());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
@@ -28,7 +28,8 @@ class TableHeaderCellTest extends ComponentTest {
 
     @Override
     protected void addProperties() {
-        // Component defines no new properties
+        addProperty("colspan", int.class, 1, 2, false, false);
+        addProperty("rowspan", int.class, 1, 2, false, false);
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Table;
 import com.vaadin.flow.component.html.TableColumn;
 import com.vaadin.flow.component.html.TableColumnGroup;
+import com.vaadin.flow.component.html.TableHeaderCell;
 import com.vaadin.flow.component.html.TableHeaderCell.Scope;
 import com.vaadin.flow.component.html.TableRow;
 import com.vaadin.flow.dom.Element;
@@ -31,9 +32,8 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * Replicates the examples from the MDN "HTML table basics" tutorial:
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
- * The examples are added as the table API they need becomes available; the ones
- * still missing need {@code colspan}/{@code rowspan} on <code>&lt;th&gt;</code>
- * and caption content API.
+ * The examples are added as the table API they need becomes available; the one
+ * still missing needs caption content API.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
 public class HtmlTableTutorialView extends Div {
@@ -84,6 +84,11 @@ public class HtmlTableTutorialView extends Div {
         dogs.setId("dogs-table");
         add(dogs);
 
+        add(new H3("3. Allowing cells to span multiple rows and columns"));
+        AnimalsTable animals = new AnimalsTable();
+        animals.setId("animals-table");
+        add(animals);
+
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
         timetable.setId("school-timetable");
@@ -122,6 +127,30 @@ public class HtmlTableTutorialView extends Div {
             TableRow row = addRow();
             row.addHeaderCell(header).setScope(Scope.ROW);
             row.addDataCells(data);
+        }
+    }
+
+    /** Example 3: colspan / rowspan on both {@code <td>} and {@code <th>}. */
+    static class AnimalsTable extends Table {
+        {
+            addRow().addHeaderCell("Animals").setColspan(2);
+            addRow().addHeaderCell("Hippopotamus").setColspan(2);
+
+            TableRow horseRow = addRow();
+            TableHeaderCell horse = horseRow.addHeaderCell("Horse");
+            horse.setScope(Scope.ROW);
+            horse.setRowspan(2);
+            horseRow.addDataCell("Mare");
+            addRow("Stallion");
+
+            addRow().addHeaderCell("Crocodile").setColspan(2);
+
+            TableRow chickenRow = addRow();
+            TableHeaderCell chicken = chickenRow.addHeaderCell("Chicken");
+            chicken.setScope(Scope.ROW);
+            chicken.setRowspan(2);
+            chickenRow.addDataCell("Hen");
+            addRow("Rooster");
         }
     }
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -82,22 +82,19 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     @Test
     public void animalsTableSpansColumnsAndRowsOnHeaderCells() {
         TableElement table = $(TableElement.class).id("animals-table");
-        List<TableRowElement> rows = table.$(TableRowElement.class).all();
+        List<TableRowElement> rows = table.getRows();
 
-        TableHeaderCellElement animals = rows.get(0)
-                .$(TableHeaderCellElement.class).first();
+        TableHeaderCellElement animals = rows.get(0).getHeaderCells().get(0);
         Assert.assertEquals("Animals", animals.getText());
         Assert.assertEquals("2", animals.getDomAttribute("colspan"));
 
-        TableHeaderCellElement horse = rows.get(2)
-                .$(TableHeaderCellElement.class).first();
+        TableHeaderCellElement horse = rows.get(2).getHeaderCells().get(0);
         Assert.assertEquals("Horse", horse.getText());
         Assert.assertEquals("2", horse.getDomAttribute("rowspan"));
         Assert.assertEquals("row", horse.getDomAttribute("scope"));
 
         // The <th rowspan=2> means the following row holds only its own cell.
-        Assert.assertEquals(1,
-                rows.get(3).$(TableDataCellElement.class).all().size());
+        Assert.assertEquals(1, rows.get(3).getDataCells().size());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -80,6 +80,27 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void animalsTableSpansColumnsAndRowsOnHeaderCells() {
+        TableElement table = $(TableElement.class).id("animals-table");
+        List<TableRowElement> rows = table.$(TableRowElement.class).all();
+
+        TableHeaderCellElement animals = rows.get(0)
+                .$(TableHeaderCellElement.class).first();
+        Assert.assertEquals("Animals", animals.getText());
+        Assert.assertEquals("2", animals.getDomAttribute("colspan"));
+
+        TableHeaderCellElement horse = rows.get(2)
+                .$(TableHeaderCellElement.class).first();
+        Assert.assertEquals("Horse", horse.getText());
+        Assert.assertEquals("2", horse.getDomAttribute("rowspan"));
+        Assert.assertEquals("row", horse.getDomAttribute("scope"));
+
+        // The <th rowspan=2> means the following row holds only its own cell.
+        Assert.assertEquals(1,
+                rows.get(3).$(TableDataCellElement.class).all().size());
+    }
+
+    @Test
     public void colgroupRendered_withColumnsInDocumentOrder() {
         List<TableColumnGroupElement> groups = timetable.getColumnGroups();
         Assert.assertEquals(1, groups.size());


### PR DESCRIPTION
colspan and rowspan apply to <th> exactly as they do to <td>, but they lived on NativeTableCell, so a header cell could not span anything. Any table with a header covering two columns had to fall back to the element API.

AbstractNativeTableCell now holds the two attributes and both cell components extend it. Callers of NativeTableCell.setColspan and friends are unaffected: the methods resolve through the superclass, in source and in bytecode alike.

HtmlComponentSmokeTest walks the component package and instantiates what it finds, so it now skips abstract classes; they are covered through their concrete subclasses.

The MDN animals example, which spans both a <th> and a <td>, now builds as written in the browser test.
