### PR TITLE
feat: caption content and a row-header shortcut for Table

### DIFF
--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableBodyElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableBodyElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;tbody&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("tbody")
+public class TableBodyElement extends TestBenchElement {
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableCaptionElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableCaptionElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;caption&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("caption")
+public class TableCaptionElement extends TestBenchElement {
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html.testbench;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
@@ -64,6 +65,54 @@ public class TableElement extends TestBenchElement {
      */
     public TableCellElement getCell(int row, int column) {
         return getRow(row).getCell(column);
+    }
+
+    /**
+     * Returns the rows of this table's <code>&lt;thead&gt;</code>.
+     *
+     * @return the header rows, or an empty list if the table has no
+     *         <code>&lt;thead&gt;</code>.
+     */
+    public List<TableRowElement> getHeaderRows() {
+        return rowsOf($(TableHeadElement.class).all());
+    }
+
+    /**
+     * Returns the rows of this table's <code>&lt;tbody&gt;</code> elements, in
+     * document order.
+     *
+     * @return the body rows, or an empty list if the table has no
+     *         <code>&lt;tbody&gt;</code>.
+     */
+    public List<TableRowElement> getBodyRows() {
+        return rowsOf($(TableBodyElement.class).all());
+    }
+
+    /**
+     * Returns the rows of this table's <code>&lt;tfoot&gt;</code>.
+     *
+     * @return the footer rows, or an empty list if the table has no
+     *         <code>&lt;tfoot&gt;</code>.
+     */
+    public List<TableRowElement> getFooterRows() {
+        return rowsOf($(TableFootElement.class).all());
+    }
+
+    /**
+     * Returns this table's caption.
+     *
+     * @return the <code>&lt;caption&gt;</code>, or an empty optional if the
+     *         table has none.
+     */
+    public Optional<TableCaptionElement> getCaption() {
+        return $(TableCaptionElement.class).all().stream().findFirst();
+    }
+
+    private static List<TableRowElement> rowsOf(
+            List<? extends TestBenchElement> sections) {
+        return sections.stream().flatMap(
+                section -> section.$(TableRowElement.class).all().stream())
+                .toList();
     }
 
     /**

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableElement.java
@@ -74,7 +74,7 @@ public class TableElement extends TestBenchElement {
      *         <code>&lt;thead&gt;</code>.
      */
     public List<TableRowElement> getHeaderRows() {
-        return rowsOf($(TableHeadElement.class).all());
+        return rowsOfSections("thead");
     }
 
     /**
@@ -85,7 +85,7 @@ public class TableElement extends TestBenchElement {
      *         <code>&lt;tbody&gt;</code>.
      */
     public List<TableRowElement> getBodyRows() {
-        return rowsOf($(TableBodyElement.class).all());
+        return rowsOfSections("tbody");
     }
 
     /**
@@ -95,7 +95,7 @@ public class TableElement extends TestBenchElement {
      *         <code>&lt;tfoot&gt;</code>.
      */
     public List<TableRowElement> getFooterRows() {
-        return rowsOf($(TableFootElement.class).all());
+        return rowsOfSections("tfoot");
     }
 
     /**
@@ -105,14 +105,13 @@ public class TableElement extends TestBenchElement {
      *         table has none.
      */
     public Optional<TableCaptionElement> getCaption() {
-        return $(TableCaptionElement.class).all().stream().findFirst();
+        return childrenNamed("caption").stream().findFirst()
+                .map(child -> child.wrap(TableCaptionElement.class));
     }
 
-    private static List<TableRowElement> rowsOf(
-            List<? extends TestBenchElement> sections) {
-        return sections.stream().flatMap(
-                section -> section.$(TableRowElement.class).all().stream())
-                .toList();
+    private List<TableRowElement> rowsOfSections(String tagName) {
+        return childrenNamed(tagName).stream()
+                .flatMap(section -> rowsOf(section).stream()).toList();
     }
 
     /**

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableFootElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableFootElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;tfoot&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("tfoot")
+public class TableFootElement extends TestBenchElement {
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableHeadElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/TableHeadElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;thead&gt;</code> element.
+ *
+ * @since 25.3
+ */
+@Element("thead")
+public class TableHeadElement extends TestBenchElement {
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -123,6 +123,31 @@ public class Table extends HtmlComponent
     }
 
     /**
+     * Appends the given components to this table's caption, creating it if none
+     * exists yet. Useful for richer captions containing inline markup.
+     *
+     * @param components
+     *            the components to append.
+     * @return the caption.
+     */
+    public TableCaption addCaption(Component... components) {
+        return addCaption(Arrays.asList(components));
+    }
+
+    /**
+     * List equivalent of {@link #addCaption(Component...)}.
+     *
+     * @param components
+     *            the components to append.
+     * @return the caption.
+     */
+    public TableCaption addCaption(List<? extends Component> components) {
+        TableCaption caption = getCaption();
+        caption.add(components.toArray(Component[]::new));
+        return caption;
+    }
+
+    /**
      * Removes this table's caption, if it has one.
      */
     public void removeCaption() {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
@@ -187,6 +187,23 @@ public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
     }
 
     /**
+     * Appends a header cell to this row that labels the row itself, with
+     * {@code scope="row"} set on the resulting <code>&lt;th&gt;</code>. This is
+     * a shortcut for the common pattern of using a leading
+     * <code>&lt;th&gt;</code> as a row label, which assistive technologies
+     * announce as the header for the data cells in the same row.
+     *
+     * @param text
+     *            the text content.
+     * @return the new {@code <th>} with {@code scope="row"}.
+     */
+    public TableHeaderCell addRowHeaderCell(String text) {
+        TableHeaderCell cell = addHeaderCell(text);
+        cell.setScope(TableHeaderCell.Scope.ROW);
+        return cell;
+    }
+
+    /**
      * Appends a new empty data cell to this row.
      *
      * @return the new {@code <td>}.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
@@ -112,6 +112,17 @@ class TableRowTest extends ComponentTest {
     }
 
     @Test
+    void addRowHeaderCell_setsRowScope() {
+        TableRow row = new TableRow();
+
+        TableHeaderCell cell = row.addRowHeaderCell("Breed");
+
+        assertEquals("Breed", cell.getText());
+        assertEquals(java.util.Optional.of(TableHeaderCell.Scope.ROW),
+                cell.getScope());
+    }
+
+    @Test
     void removeCell_detachesItFromTheRow() {
         TableRow row = new TableRow();
         TableHeaderCell th = row.addHeaderCell();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -257,6 +257,18 @@ class TableTest extends ComponentTest {
     }
 
     @Test
+    void addCaption_appendsToTheCaptionAndCreatesItIfMissing() {
+        Table table = table();
+        var span = new Span("rich");
+
+        var caption = table.addCaption(span);
+
+        assertEquals(caption, table.getCaption());
+        assertEquals(List.of(span), caption.getChildren().toList());
+        assertEquals(List.of(caption), table.getChildren().toList());
+    }
+
+    @Test
     void getSection_calledTwice_doesNotCreateASecondOne() {
         Table table = table();
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -131,7 +131,7 @@ public class HtmlTableTutorialView extends Div {
 
         private void addRowWithRowHeader(String header, String... data) {
             TableRow row = addRow();
-            row.addHeaderCell(header).setScope(Scope.ROW);
+            row.addRowHeaderCell(header);
             row.addDataCells(data);
         }
     }
@@ -300,7 +300,7 @@ public class HtmlTableTutorialView extends Div {
 
         private void addPeriodRow(String period, String... days) {
             TableRow row = addRow();
-            row.addHeaderCell(period).setScope(Scope.ROW);
+            row.addRowHeaderCell(period);
             row.addDataCells(days);
         }
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -15,12 +15,14 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Table;
 import com.vaadin.flow.component.html.TableColumn;
 import com.vaadin.flow.component.html.TableColumnGroup;
+import com.vaadin.flow.component.html.TableHead;
 import com.vaadin.flow.component.html.TableHeaderCell;
 import com.vaadin.flow.component.html.TableHeaderCell.Scope;
 import com.vaadin.flow.component.html.TableRow;
@@ -32,8 +34,7 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * Replicates the examples from the MDN "HTML table basics" tutorial:
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
- * The examples are added as the table API they need becomes available; the one
- * still missing needs caption content API.
+ * All five examples from the tutorial are covered.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
 public class HtmlTableTutorialView extends Div {
@@ -88,6 +89,11 @@ public class HtmlTableTutorialView extends Div {
         AnimalsTable animals = new AnimalsTable();
         animals.setId("animals-table");
         add(animals);
+
+        add(new H3("4. Adding a caption with <caption>, plus <thead>/<tbody>"));
+        PlanetsTable planets = new PlanetsTable();
+        planets.setId("planets-table");
+        add(planets);
 
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
@@ -154,6 +160,112 @@ public class HtmlTableTutorialView extends Div {
         }
     }
 
+    /** Example 4: planet data with caption, thead and rowgroup spans. */
+    static class PlanetsTable extends Table {
+        {
+            addCaption(new Html("<span>Data about the planets of our solar"
+                    + " system (Source: <a href=\"https://nssdc.gsfc.nasa.gov/"
+                    + "planetary/factsheet/\">Nasa's Planetary Fact Sheet -"
+                    + " Metric</a>).</span>"));
+
+            TableHead head = getHead();
+            TableRow headerRow = head.addRow();
+            headerRow.addDataCell().setColspan(2);
+            addColHeader(headerRow, new Html("<span>Name</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Mass (10<sup>24</sup>kg)</span>"));
+            addColHeader(headerRow, new Html("<span>Diameter (km)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Density (kg/m<sup>3</sup>)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Gravity (m/s<sup>2</sup>)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Length of day (hours)</span>"));
+            addColHeader(headerRow, new Html(
+                    "<span>Distance from Sun (10<sup>6</sup>km)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Mean temperature (\u00b0C)</span>"));
+            addColHeader(headerRow, new Html("<span>Number of moons</span>"));
+            addColHeader(headerRow, new Html("<span>Notes</span>"));
+
+            TableRow mercury = addRow();
+            TableHeaderCell terrestrial = mercury
+                    .addHeaderCell("Terrestrial planets");
+            terrestrial.setScope(Scope.ROWGROUP);
+            terrestrial.setColspan(2);
+            terrestrial.setRowspan(4);
+            addRowHeader(mercury, "Mercury");
+            mercury.addDataCells("0.330", "4,879", "5427", "3.7", "4222.6",
+                    "57.9", "167", "0", "Closest to the Sun");
+
+            TableRow venus = addRow();
+            addRowHeader(venus, "Venus");
+            venus.addDataCells("4.87", "12,104", "5243", "8.9", "2802.0",
+                    "108.2", "464", "0", "");
+
+            TableRow earth = addRow();
+            addRowHeader(earth, "Earth");
+            earth.addDataCells("5.97", "12,756", "5514", "9.8", "24.0",
+                    "149.6", "15", "1", "Our world");
+
+            TableRow mars = addRow();
+            addRowHeader(mars, "Mars");
+            mars.addDataCells("0.642", "6,792", "3933", "3.7", "24.7", "227.9",
+                    "-65", "2", "The red planet");
+
+            TableRow jupiter = addRow();
+            TableHeaderCell jovian = jupiter
+                    .addHeaderCell("Jovian planets");
+            jovian.setScope(Scope.ROWGROUP);
+            jovian.setRowspan(4);
+            TableHeaderCell gasGiants = jupiter
+                    .addHeaderCell("Gas giants");
+            gasGiants.setScope(Scope.ROWGROUP);
+            gasGiants.setRowspan(2);
+            addRowHeader(jupiter, "Jupiter");
+            jupiter.addDataCells("1898", "142,984", "1326", "23.1", "9.9",
+                    "778.6", "-110", "67", "The largest planet");
+
+            TableRow saturn = addRow();
+            addRowHeader(saturn, "Saturn");
+            saturn.addDataCells("568", "120,536", "687", "9.0", "10.7",
+                    "1433.5", "-140", "62", "");
+
+            TableRow uranus = addRow();
+            TableHeaderCell iceGiants = uranus
+                    .addHeaderCell("Ice giants");
+            iceGiants.setScope(Scope.ROWGROUP);
+            iceGiants.setRowspan(2);
+            addRowHeader(uranus, "Uranus");
+            uranus.addDataCells("86.8", "51,118", "1271", "8.7", "17.2",
+                    "2872.5", "-195", "27", "");
+
+            TableRow neptune = addRow();
+            addRowHeader(neptune, "Neptune");
+            neptune.addDataCells("102", "49,528", "1638", "11.0", "16.1",
+                    "4495.1", "-200", "14", "");
+
+            TableRow pluto = addRow();
+            TableHeaderCell dwarf = pluto
+                    .addHeaderCell("Dwarf planets");
+            dwarf.setScope(Scope.ROWGROUP);
+            dwarf.setColspan(2);
+            addRowHeader(pluto, "Pluto");
+            pluto.addDataCells("0.0146", "2,370", "2095", "0.7", "153.3",
+                    "5906.4", "-225", "5", "Declassified as a planet in 2006,"
+                            + " but this remains controversial.");
+        }
+
+        private static void addColHeader(TableRow row, Html content) {
+            TableHeaderCell th = row.addHeaderCell();
+            th.setScope(Scope.COL);
+            th.add(content);
+        }
+
+        private static void addRowHeader(TableRow row, String text) {
+            row.addRowHeaderCell(text);
+        }
+    }
     /**
      * Example 5: school timetable, demonstrating column-level styling via
      * {@code <colgroup>}/{@code <col>}.

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -113,6 +113,11 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
 
         Assert.assertEquals(10,
                 table.getHeaderRows().get(0).getHeaderCells().size());
+        // the example builds a thead and a tbody but no tfoot
+        Assert.assertTrue(table.getFooterRows().isEmpty());
+        Assert.assertEquals(
+                table.getHeaderRows().size() + table.getBodyRows().size(),
+                table.getRows().size());
 
         TableHeaderCellElement terrestrial = table.getBodyRows().get(0)
                 .getHeaderCells().get(0);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -20,9 +20,12 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.html.testbench.TableBodyElement;
+import com.vaadin.flow.component.html.testbench.TableCaptionElement;
 import com.vaadin.flow.component.html.testbench.TableColumnElement;
 import com.vaadin.flow.component.html.testbench.TableColumnGroupElement;
 import com.vaadin.flow.component.html.testbench.TableElement;
+import com.vaadin.flow.component.html.testbench.TableHeadElement;
 import com.vaadin.flow.component.html.testbench.TableHeaderCellElement;
 import com.vaadin.flow.component.html.testbench.TableRowElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -95,6 +98,32 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
 
         // The <th rowspan=2> means the following row holds only its own cell.
         Assert.assertEquals(1, rows.get(3).getDataCells().size());
+    }
+
+    @Test
+    public void planetsTableHasCaptionAndHeadWithRowgroupSpans() {
+        TableElement table = $(TableElement.class).id("planets-table");
+
+        TableCaptionElement caption = table.$(TableCaptionElement.class)
+                .first();
+        Assert.assertEquals("caption",
+                table.getPropertyElement("firstElementChild").getTagName());
+        Assert.assertTrue(caption.getText()
+                .startsWith("Data about the planets of our solar system"));
+        // The caption holds real markup, not just text.
+        Assert.assertEquals("Nasa's Planetary Fact Sheet - Metric",
+                caption.$("a").first().getText());
+
+        TableHeadElement head = table.$(TableHeadElement.class).first();
+        Assert.assertEquals(10,
+                head.$(TableHeaderCellElement.class).all().size());
+
+        TableHeaderCellElement terrestrial = table.$(TableBodyElement.class)
+                .first().$(TableHeaderCellElement.class).first();
+        Assert.assertEquals("Terrestrial planets", terrestrial.getText());
+        Assert.assertEquals("rowgroup", terrestrial.getDomAttribute("scope"));
+        Assert.assertEquals("4", terrestrial.getDomAttribute("rowspan"));
+        Assert.assertEquals("2", terrestrial.getDomAttribute("colspan"));
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -20,12 +20,10 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.component.html.testbench.TableBodyElement;
 import com.vaadin.flow.component.html.testbench.TableCaptionElement;
 import com.vaadin.flow.component.html.testbench.TableColumnElement;
 import com.vaadin.flow.component.html.testbench.TableColumnGroupElement;
 import com.vaadin.flow.component.html.testbench.TableElement;
-import com.vaadin.flow.component.html.testbench.TableHeadElement;
 import com.vaadin.flow.component.html.testbench.TableHeaderCellElement;
 import com.vaadin.flow.component.html.testbench.TableRowElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -104,8 +102,7 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     public void planetsTableHasCaptionAndHeadWithRowgroupSpans() {
         TableElement table = $(TableElement.class).id("planets-table");
 
-        TableCaptionElement caption = table.$(TableCaptionElement.class)
-                .first();
+        TableCaptionElement caption = table.getCaption().orElseThrow();
         Assert.assertEquals("caption",
                 table.getPropertyElement("firstElementChild").getTagName());
         Assert.assertTrue(caption.getText()
@@ -114,12 +111,11 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
         Assert.assertEquals("Nasa's Planetary Fact Sheet - Metric",
                 caption.$("a").first().getText());
 
-        TableHeadElement head = table.$(TableHeadElement.class).first();
         Assert.assertEquals(10,
-                head.$(TableHeaderCellElement.class).all().size());
+                table.getHeaderRows().get(0).getHeaderCells().size());
 
-        TableHeaderCellElement terrestrial = table.$(TableBodyElement.class)
-                .first().$(TableHeaderCellElement.class).first();
+        TableHeaderCellElement terrestrial = table.getBodyRows().get(0)
+                .getHeaderCells().get(0);
         Assert.assertEquals("Terrestrial planets", terrestrial.getText());
         Assert.assertEquals("rowgroup", terrestrial.getDomAttribute("scope"));
         Assert.assertEquals("4", terrestrial.getDomAttribute("rowspan"));


### PR DESCRIPTION
A caption could only be given plain text through setCaptionText, so a caption containing a link or any other markup meant reaching for getCaption().add(...). addCaption takes components directly and creates the <caption> if the table has none.

TableRow.addRowHeaderCell adds a <th scope="row">, the leading cell that labels its row, which otherwise takes two statements.

The MDN planets example, the one with a captioned table and rowgroup headers, now builds as written, so the browser test covers all five examples from the tutorial.
