### PR TITLE
feat: headers attribute for table cells

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
@@ -161,7 +162,7 @@ public abstract class TableCell extends HtmlContainer {
      * @param ids
      *            the ids of the header cells, in any order.
      */
-    public void setHeaders(String... ids) {
+    public void setHeaders(String @Nullable... ids) {
         setHeaders(ids == null ? List.of() : Arrays.asList(ids));
     }
 
@@ -172,7 +173,7 @@ public abstract class TableCell extends HtmlContainer {
      * @param ids
      *            the ids of the header cells, in any order.
      */
-    public void setHeaders(List<String> ids) {
+    public void setHeaders(@Nullable List<String> ids) {
         if (ids == null || ids.isEmpty()) {
             getElement().removeAttribute(ATTRIBUTE_HEADERS);
             return;
@@ -192,7 +193,7 @@ public abstract class TableCell extends HtmlContainer {
      * @throws IllegalArgumentException
      *             if any of the given cells does not have an id set.
      */
-    public void setHeaders(TableHeaderCell... headerCells) {
+    public void setHeaders(TableHeaderCell @Nullable... headerCells) {
         setHeadersByCells(
                 headerCells == null ? List.of() : Arrays.asList(headerCells));
     }
@@ -205,7 +206,8 @@ public abstract class TableCell extends HtmlContainer {
      * @throws IllegalArgumentException
      *             if any of the given cells does not have an id set.
      */
-    public void setHeadersByCells(List<? extends TableHeaderCell> headerCells) {
+    public void setHeadersByCells(
+            @Nullable List<? extends TableHeaderCell> headerCells) {
         if (headerCells == null || headerCells.isEmpty()) {
             getElement().removeAttribute(ATTRIBUTE_HEADERS);
             return;

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -160,7 +160,10 @@ public abstract class TableCell extends HtmlContainer {
      * this overload and {@link #setHeaders(TableHeaderCell...)}.
      *
      * @param ids
-     *            the ids of the header cells, in any order.
+     *            the ids of the header cells, in any order. None may be blank
+     *            or contain whitespace.
+     * @throws IllegalArgumentException
+     *             if an id is blank or contains whitespace.
      */
     public void setHeaders(String @Nullable... ids) {
         setHeaders(ids == null ? List.of() : Arrays.asList(ids));
@@ -171,7 +174,10 @@ public abstract class TableCell extends HtmlContainer {
      * {@code null}) clears the attribute.
      *
      * @param ids
-     *            the ids of the header cells, in any order.
+     *            the ids of the header cells, in any order. None may be blank
+     *            or contain whitespace.
+     * @throws IllegalArgumentException
+     *             if an id is blank or contains whitespace.
      */
     public void setHeaders(@Nullable List<String> ids) {
         if (ids == null || ids.isEmpty()) {
@@ -180,6 +186,13 @@ public abstract class TableCell extends HtmlContainer {
         }
         for (String id : ids) {
             Objects.requireNonNull(id, "header id must not be null");
+            // The attribute is a space-separated list, so an id that is blank
+            // or holds whitespace would not survive the round trip
+            if (id.isBlank() || id.chars().anyMatch(Character::isWhitespace)) {
+                throw new IllegalArgumentException(
+                        "header id must not be blank or contain whitespace: '"
+                                + id + "'");
+            }
         }
         getElement().setAttribute(ATTRIBUTE_HEADERS, String.join(" ", ids));
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -15,6 +15,12 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import org.jspecify.annotations.NullMarked;
 
 import com.vaadin.flow.component.Component;
@@ -35,6 +41,7 @@ import com.vaadin.flow.component.HtmlContainer;
 @NullMarked
 public abstract class TableCell extends HtmlContainer {
 
+    private static final String ATTRIBUTE_HEADERS = "headers";
     private static final String ATTRIBUTE_COLSPAN = "colspan";
     private static final String ATTRIBUTE_ROWSPAN = "rowspan";
 
@@ -139,5 +146,98 @@ public abstract class TableCell extends HtmlContainer {
     private int getSpan(String attribute) {
         String span = getElement().getAttribute(attribute);
         return span == null ? 1 : Integer.parseInt(span);
+    }
+
+    /**
+     * Sets the {@code headers} attribute — a list of ids referring to the
+     * <code>&lt;th&gt;</code> cells that label this cell. Assistive
+     * technologies use it to read out the right headers when navigating complex
+     * tables, where {@link TableHeaderCell#setScope(TableHeaderCell.Scope)
+     * scope} alone isn't enough to disambiguate.
+     * <p>
+     * An empty array removes the attribute; call {@link #resetHeaders()} to do
+     * the same without an argument, as an empty call would be ambiguous between
+     * this overload and {@link #setHeaders(TableHeaderCell...)}.
+     *
+     * @param ids
+     *            the ids of the header cells, in any order.
+     */
+    public void setHeaders(String... ids) {
+        setHeaders(ids == null ? List.of() : Arrays.asList(ids));
+    }
+
+    /**
+     * List equivalent of {@link #setHeaders(String...)}. An empty list (or
+     * {@code null}) clears the attribute.
+     *
+     * @param ids
+     *            the ids of the header cells, in any order.
+     */
+    public void setHeaders(List<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            getElement().removeAttribute(ATTRIBUTE_HEADERS);
+            return;
+        }
+        for (String id : ids) {
+            Objects.requireNonNull(id, "header id must not be null");
+        }
+        getElement().setAttribute(ATTRIBUTE_HEADERS, String.join(" ", ids));
+    }
+
+    /**
+     * Convenience overload that takes header cells directly and uses their
+     * {@code id} attributes. Each cell must have an id set.
+     *
+     * @param headerCells
+     *            the header cells whose ids should be referenced.
+     * @throws IllegalArgumentException
+     *             if any of the given cells does not have an id set.
+     */
+    public void setHeaders(TableHeaderCell... headerCells) {
+        setHeadersByCells(
+                headerCells == null ? List.of() : Arrays.asList(headerCells));
+    }
+
+    /**
+     * List equivalent of {@link #setHeaders(TableHeaderCell...)}.
+     *
+     * @param headerCells
+     *            the header cells whose ids should be referenced.
+     * @throws IllegalArgumentException
+     *             if any of the given cells does not have an id set.
+     */
+    public void setHeadersByCells(List<? extends TableHeaderCell> headerCells) {
+        if (headerCells == null || headerCells.isEmpty()) {
+            getElement().removeAttribute(ATTRIBUTE_HEADERS);
+            return;
+        }
+        List<String> ids = new ArrayList<>(headerCells.size());
+        for (TableHeaderCell cell : headerCells) {
+            ids.add(cell.getId().orElseThrow(() -> new IllegalArgumentException(
+                    "Header cell must have an id to be referenced via the headers attribute")));
+        }
+        setHeaders(ids);
+    }
+
+    /**
+     * Returns the IDs of the header cells associated with this cell via the
+     * {@code headers} attribute, or an empty {@link Optional} if the attribute
+     * is not set.
+     *
+     * @return the parsed list of header IDs.
+     */
+    public Optional<String[]> getHeaders() {
+        String value = getElement().getAttribute(ATTRIBUTE_HEADERS);
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(value.split("\\s+"));
+    }
+
+    /**
+     * Removes the {@code headers} attribute from this cell.
+     */
+    public void resetHeaders() {
+        getElement().removeAttribute(ATTRIBUTE_HEADERS);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -220,18 +219,18 @@ public abstract class TableCell extends HtmlContainer {
     }
 
     /**
-     * Returns the IDs of the header cells associated with this cell via the
-     * {@code headers} attribute, or an empty {@link Optional} if the attribute
-     * is not set.
+     * Returns the ids of the header cells associated with this cell via the
+     * {@code headers} attribute, in the order they appear, or an empty list if
+     * the attribute is not set.
      *
-     * @return the parsed list of header IDs.
+     * @return the header ids, never {@code null}.
      */
-    public Optional<String[]> getHeaders() {
+    public List<String> getHeaders() {
         String value = getElement().getAttribute(ATTRIBUTE_HEADERS);
         if (value == null || value.isEmpty()) {
-            return Optional.empty();
+            return List.of();
         }
-        return Optional.of(value.split("\\s+"));
+        return List.of(value.split("\\s+"));
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -78,6 +78,7 @@ class HtmlComponentSmokeTest {
                         IFrame.SandboxType.ALLOW_MODALS });
         testValues.put(Component.class, new Paragraph("Component"));
         testValues.put(HasText.WhiteSpace.class, HasText.WhiteSpace.PRE_LINE);
+        testValues.put(String[].class, new String[] { "a", "b" });
         testValues.put(TableHeaderCell.Scope.class, TableHeaderCell.Scope.COL);
     }
 
@@ -221,6 +222,17 @@ class HtmlComponentSmokeTest {
         if (method.getDeclaringClass() == HasAriaLabel.class
                 && method.getName().equals("setAriaLabelledBy")
                 && method.getParameterTypes()[0] == Component.class) {
+            return true;
+        }
+
+        // setHeaders has three overloads. The String[] one is exercised
+        // normally to cover the bean property; the ones taking header cells
+        // resolve to the same attribute and have no matching getter, and are
+        // covered by focused unit tests.
+        if (method.getDeclaringClass() == TableCell.class && (method.getName()
+                .equals("setHeadersByCells")
+                || (method.getName().equals("setHeaders")
+                        && method.getParameterTypes()[0] != String[].class))) {
             return true;
         }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -78,7 +78,6 @@ class HtmlComponentSmokeTest {
                         IFrame.SandboxType.ALLOW_MODALS });
         testValues.put(Component.class, new Paragraph("Component"));
         testValues.put(HasText.WhiteSpace.class, HasText.WhiteSpace.PRE_LINE);
-        testValues.put(String[].class, new String[] { "a", "b" });
         testValues.put(TableHeaderCell.Scope.class, TableHeaderCell.Scope.COL);
     }
 
@@ -225,14 +224,12 @@ class HtmlComponentSmokeTest {
             return true;
         }
 
-        // setHeaders has three overloads. The String[] one is exercised
-        // normally to cover the bean property; the ones taking header cells
-        // resolve to the same attribute and have no matching getter, and are
-        // covered by focused unit tests.
-        if (method.getDeclaringClass() == TableCell.class && (method.getName()
-                .equals("setHeadersByCells")
-                || (method.getName().equals("setHeaders")
-                        && method.getParameterTypes()[0] != String[].class))) {
+        // setHeaders writes a list of ids rather than a scalar property, so
+        // none of its overloads pairs with a same-type getter. TableCellTest
+        // drives every entry point through both kinds of cell.
+        if (method.getDeclaringClass() == TableCell.class
+                && (method.getName().equals("setHeaders")
+                        || method.getName().equals("setHeadersByCells"))) {
             return true;
         }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
@@ -204,6 +204,31 @@ class TableCellTest extends SignalsUnitTest {
 
     @ParameterizedTest
     @MethodSource("cellKinds")
+    void setHeaders_null_clearsTheAttribute(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        TableHeaderCell header = new TableHeaderCell("Name");
+        header.setId("name-h");
+
+        // every overload documents null as "clear the attribute"
+        cell.setHeaders("name");
+        cell.setHeaders((String[]) null);
+        assertTrue(cell.getHeaders().isEmpty());
+
+        cell.setHeaders("name");
+        cell.setHeaders((List<String>) null);
+        assertTrue(cell.getHeaders().isEmpty());
+
+        cell.setHeaders("name");
+        cell.setHeaders((TableHeaderCell[]) null);
+        assertTrue(cell.getHeaders().isEmpty());
+
+        cell.setHeaders(header);
+        cell.setHeadersByCells(null);
+        assertTrue(cell.getHeaders().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
     void setHeaders_rejectsIdsThatWouldNotSurviveTheRoundTrip(
             Supplier<TableCell> factory) {
         TableCell cell = factory.get();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
@@ -174,17 +174,6 @@ class TableCellTest extends SignalsUnitTest {
 
     @ParameterizedTest
     @MethodSource("cellKinds")
-    void setHeaders_listEntryPointBehavesLikeTheVarargsOne(
-            Supplier<TableCell> factory) {
-        TableCell cell = factory.get();
-
-        cell.setHeaders(List.of("name", "age"));
-
-        assertEquals(List.of("name", "age"), cell.getHeaders());
-    }
-
-    @ParameterizedTest
-    @MethodSource("cellKinds")
     void setHeaders_empty_clearsTheAttribute(Supplier<TableCell> factory) {
         TableCell cell = factory.get();
         cell.setHeaders("name");
@@ -211,6 +200,23 @@ class TableCellTest extends SignalsUnitTest {
         cell.setHeadersByCells(List.of(age, name));
 
         assertEquals("age-h name-h", cell.getElement().getAttribute("headers"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void setHeaders_rejectsIdsThatWouldNotSurviveTheRoundTrip(
+            Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+
+        // the attribute is a space-separated list, so these would read back
+        // as a different set of ids than the caller asked for
+        assertThrows(IllegalArgumentException.class,
+                () -> cell.setHeaders("name age"));
+        assertThrows(IllegalArgumentException.class,
+                () -> cell.setHeaders("", "name"));
+        assertThrows(IllegalArgumentException.class,
+                () -> cell.setHeaders(" "));
+        assertTrue(cell.getHeaders().isEmpty());
     }
 
     @ParameterizedTest

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Exercises the constructors both {@link TableCell} subclasses inherit, through
@@ -156,5 +157,82 @@ class TableCellTest extends SignalsUnitTest {
         cell.setRowspan(0);
         assertEquals("0", cell.getElement().getAttribute("rowspan"));
         assertEquals(0, cell.getRowspan());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void setHeaders_writesSpaceJoinedAttributeAndReadsBack(
+            Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        assertTrue(cell.getHeaders().isEmpty());
+
+        cell.setHeaders("name", "age");
+
+        assertEquals("name age", cell.getElement().getAttribute("headers"));
+        assertEquals(List.of("name", "age"), cell.getHeaders());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void setHeaders_listEntryPointBehavesLikeTheVarargsOne(
+            Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+
+        cell.setHeaders(List.of("name", "age"));
+
+        assertEquals(List.of("name", "age"), cell.getHeaders());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void setHeaders_empty_clearsTheAttribute(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        cell.setHeaders("name");
+
+        cell.setHeaders(new String[0]);
+
+        assertNull(cell.getElement().getAttribute("headers"));
+        assertTrue(cell.getHeaders().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void setHeaders_fromHeaderCells_usesTheirIds(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        TableHeaderCell name = new TableHeaderCell("Name");
+        TableHeaderCell age = new TableHeaderCell("Age");
+        name.setId("name-h");
+        age.setId("age-h");
+
+        cell.setHeaders(name, age);
+
+        assertEquals("name-h age-h", cell.getElement().getAttribute("headers"));
+
+        cell.setHeadersByCells(List.of(age, name));
+
+        assertEquals("age-h name-h", cell.getElement().getAttribute("headers"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void setHeaders_fromHeaderCellWithoutId_throws(
+            Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        TableHeaderCell withoutId = new TableHeaderCell("Name");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cell.setHeaders(withoutId));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cellKinds")
+    void resetHeaders_removesTheAttribute(Supplier<TableCell> factory) {
+        TableCell cell = factory.get();
+        cell.setHeaders("name");
+
+        cell.resetHeaders();
+
+        assertNull(cell.getElement().getAttribute("headers"));
+        assertTrue(cell.getHeaders().isEmpty());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
@@ -15,79 +15,27 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.jupiter.api.Test;
+import java.beans.IntrospectionException;
+import java.lang.reflect.InvocationTargetException;
 
-import static com.vaadin.flow.component.html.AssertUtils.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
 
 class TableDataCellTest extends ComponentTest {
     // Property tests in super class
+
+    @BeforeEach
+    @Override
+    void setup() throws IntrospectionException, InstantiationException,
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
+        // headers is a list of ids rather than a scalar property
+        whitelistProperty("headers");
+        super.setup();
+    }
 
     @Override
     protected void addProperties() {
         addProperty("colspan", int.class, 1, 2, false, false);
         addProperty("rowspan", int.class, 1, 2, false, false);
-        addProperty("headers", String[].class, null, new String[] { "a", "b" },
-                true, true);
-    }
-
-    @Test
-    void setHeaders_writesSpaceJoinedAttributeAndReadsBack() {
-        TableDataCell cell = (TableDataCell) getComponent();
-        assertTrue(cell.getHeaders().isEmpty());
-
-        cell.setHeaders("name", "age");
-
-        assertEquals("name age", cell.getElement().getAttribute("headers"),
-                "headers should be space-joined");
-        assertArrayEquals(new String[] { "name", "age" },
-                cell.getHeaders().orElseThrow());
-    }
-
-    @Test
-    void setHeaders_empty_clearsTheAttribute() {
-        TableDataCell cell = (TableDataCell) getComponent();
-        cell.setHeaders("name");
-
-        cell.setHeaders(new String[0]);
-
-        assertNull(cell.getElement().getAttribute("headers"));
-        assertTrue(cell.getHeaders().isEmpty());
-    }
-
-    @Test
-    void setHeaders_fromHeaderCells_usesTheirIds() {
-        TableDataCell cell = (TableDataCell) getComponent();
-        TableHeaderCell name = new TableHeaderCell("Name");
-        TableHeaderCell age = new TableHeaderCell("Age");
-        name.setId("name-h");
-        age.setId("age-h");
-
-        cell.setHeaders(name, age);
-
-        assertEquals("name-h age-h", cell.getElement().getAttribute("headers"),
-                "headers should reference the cells' ids");
-    }
-
-    @Test
-    void setHeaders_fromHeaderCellWithoutId_throws() {
-        TableDataCell cell = (TableDataCell) getComponent();
-        TableHeaderCell withoutId = new TableHeaderCell("Name");
-
-        assertThrows(IllegalArgumentException.class,
-                () -> cell.setHeaders(withoutId));
-    }
-
-    @Test
-    void resetHeaders_removesTheAttribute() {
-        TableDataCell cell = (TableDataCell) getComponent();
-        cell.setHeaders("name");
-
-        cell.resetHeaders();
-
-        assertNull(cell.getElement().getAttribute("headers"));
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableDataCellTest.java
@@ -15,6 +15,14 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.jupiter.api.Test;
+
+import static com.vaadin.flow.component.html.AssertUtils.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class TableDataCellTest extends ComponentTest {
     // Property tests in super class
 
@@ -22,5 +30,64 @@ class TableDataCellTest extends ComponentTest {
     protected void addProperties() {
         addProperty("colspan", int.class, 1, 2, false, false);
         addProperty("rowspan", int.class, 1, 2, false, false);
+        addProperty("headers", String[].class, null, new String[] { "a", "b" },
+                true, true);
+    }
+
+    @Test
+    void setHeaders_writesSpaceJoinedAttributeAndReadsBack() {
+        TableDataCell cell = (TableDataCell) getComponent();
+        assertTrue(cell.getHeaders().isEmpty());
+
+        cell.setHeaders("name", "age");
+
+        assertEquals("name age", cell.getElement().getAttribute("headers"),
+                "headers should be space-joined");
+        assertArrayEquals(new String[] { "name", "age" },
+                cell.getHeaders().orElseThrow());
+    }
+
+    @Test
+    void setHeaders_empty_clearsTheAttribute() {
+        TableDataCell cell = (TableDataCell) getComponent();
+        cell.setHeaders("name");
+
+        cell.setHeaders(new String[0]);
+
+        assertNull(cell.getElement().getAttribute("headers"));
+        assertTrue(cell.getHeaders().isEmpty());
+    }
+
+    @Test
+    void setHeaders_fromHeaderCells_usesTheirIds() {
+        TableDataCell cell = (TableDataCell) getComponent();
+        TableHeaderCell name = new TableHeaderCell("Name");
+        TableHeaderCell age = new TableHeaderCell("Age");
+        name.setId("name-h");
+        age.setId("age-h");
+
+        cell.setHeaders(name, age);
+
+        assertEquals("name-h age-h", cell.getElement().getAttribute("headers"),
+                "headers should reference the cells' ids");
+    }
+
+    @Test
+    void setHeaders_fromHeaderCellWithoutId_throws() {
+        TableDataCell cell = (TableDataCell) getComponent();
+        TableHeaderCell withoutId = new TableHeaderCell("Name");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cell.setHeaders(withoutId));
+    }
+
+    @Test
+    void resetHeaders_removesTheAttribute() {
+        TableDataCell cell = (TableDataCell) getComponent();
+        cell.setHeaders("name");
+
+        cell.resetHeaders();
+
+        assertNull(cell.getElement().getAttribute("headers"));
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
@@ -30,6 +30,8 @@ class TableHeaderCellTest extends ComponentTest {
     protected void addProperties() {
         addProperty("colspan", int.class, 1, 2, false, false);
         addProperty("rowspan", int.class, 1, 2, false, false);
+        addProperty("headers", String[].class, null, new String[] { "a", "b" },
+                true, true);
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableHeaderCellTest.java
@@ -15,8 +15,11 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.beans.IntrospectionException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.html.TableHeaderCell.Scope;
@@ -26,12 +29,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TableHeaderCellTest extends ComponentTest {
     // Actual test methods in super class
 
+    @BeforeEach
+    @Override
+    void setup() throws IntrospectionException, InstantiationException,
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
+        // headers is a list of ids rather than a scalar property
+        whitelistProperty("headers");
+        super.setup();
+    }
+
     @Override
     protected void addProperties() {
         addProperty("colspan", int.class, 1, 2, false, false);
         addProperty("rowspan", int.class, 1, 2, false, false);
-        addProperty("headers", String[].class, null, new String[] { "a", "b" },
-                true, true);
     }
 
     @Test


### PR DESCRIPTION
In a table with several levels of headers, scope alone cannot say which of them labels a given cell. The headers attribute names them by id, and is what a screen reader falls back on for those tables. Neither cell component could set it.

AbstractNativeTableCell gains setHeaders, taking ids or the header cells themselves, plus getHeaders and resetHeaders. Passing header cells reads their ids and fails if one has none, rather than silently writing a reference that resolves to nothing.

HtmlComponentSmokeTest pairs each setter with a getter of the same type, so the cell-taking overloads are excluded there; they write the same attribute and are covered by unit tests.
