### PR TITLE
refactor: drop redundant indexed accessors from the table API

### DIFF
--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeTableColumnElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeTableColumnElement.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;col&gt;</code> element.
+ */
+@Element("col")
+public class NativeTableColumnElement extends TestBenchElement {
+
+    /**
+     * Returns the number of columns this <code>&lt;col&gt;</code> spans.
+     *
+     * @return the value of the {@code span} attribute, or 1 if it is not set.
+     */
+    public int getSpan() {
+        String span = getDomAttribute("span");
+        return span == null ? 1 : Integer.parseInt(span);
+    }
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeTableColumnGroupElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeTableColumnGroupElement.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import java.util.List;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;colgroup&gt;</code> element.
+ */
+@Element("colgroup")
+public class NativeTableColumnGroupElement extends TestBenchElement {
+
+    /**
+     * Returns the <code>&lt;col&gt;</code> children of this group, in document
+     * order.
+     *
+     * @return the columns of this group.
+     */
+    public List<NativeTableColumnElement> getColumns() {
+        return $(NativeTableColumnElement.class).all();
+    }
+
+    /**
+     * Returns the number of columns this <code>&lt;colgroup&gt;</code> spans
+     * when it is used without <code>&lt;col&gt;</code> children.
+     *
+     * @return the value of the {@code span} attribute, or 1 if it is not set.
+     */
+    public int getSpan() {
+        String span = getDomAttribute("span");
+        return span == null ? 1 : Integer.parseInt(span);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AbstractNativeTableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AbstractNativeTableCell.java
@@ -143,7 +143,9 @@ public abstract class AbstractNativeTableCell extends HtmlContainer {
      * {@link NativeTableHeaderCell#setScope(NativeTableHeaderCell.Scope) scope}
      * alone isn't enough to disambiguate.
      * <p>
-     * Passing no arguments (or an empty array) removes the attribute.
+     * An empty array removes the attribute; call {@link #resetHeaders()} to do
+     * the same without an argument, as an empty call would be ambiguous between
+     * this overload and {@link #setHeaders(NativeTableHeaderCell...)}.
      *
      * @param ids
      *            the ids of the header cells, in any order.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AbstractNativeTableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AbstractNativeTableCell.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+
+/**
+ * Common superclass for table cell components ({@link NativeTableCell} and
+ * {@link NativeTableHeaderCell}). Provides shared support for the attributes
+ * that apply equally to <code>&lt;td&gt;</code> and <code>&lt;th&gt;</code> per
+ * the <a href="https://html.spec.whatwg.org/multipage/tables.html">WHATWG HTML
+ * specification</a>: {@code colspan} and {@code rowspan}.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td">MDN:
+ *      &lt;td&gt;</a>
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th">MDN:
+ *      &lt;th&gt;</a>
+ */
+public abstract class AbstractNativeTableCell extends HtmlContainer {
+
+    private static final String ATTRIBUTE_COLSPAN = "colspan";
+    private static final String ATTRIBUTE_ROWSPAN = "rowspan";
+
+    /**
+     * Creates a new empty cell component.
+     */
+    protected AbstractNativeTableCell() {
+        super();
+    }
+
+    /**
+     * Creates a new cell with the given children components.
+     *
+     * @param components
+     *            the children components.
+     */
+    protected AbstractNativeTableCell(Component... components) {
+        super(components);
+    }
+
+    /**
+     * Sets the {@code colspan} attribute — how many columns this cell spans.
+     * The default is {@code 1}. Browsers clamp values higher than 1000 back to
+     * {@code 1}.
+     *
+     * @param colspan
+     *            a non-negative integer.
+     */
+    public void setColspan(int colspan) {
+        if (colspan < 0) {
+            throw new IllegalArgumentException(
+                    "colspan must be a non-negative integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_COLSPAN, String.valueOf(colspan));
+    }
+
+    /**
+     * Returns the colspan value of this cell.
+     *
+     * @return the current value of the colspan attribute. Default is 1.
+     */
+    public int getColspan() {
+        String colspan = getElement().getAttribute(ATTRIBUTE_COLSPAN);
+        if (colspan == null) {
+            colspan = "1";
+        }
+        return Integer.parseInt(colspan);
+    }
+
+    /**
+     * Reset colspan to its default value of 1.
+     */
+    public void resetColspan() {
+        getElement().removeAttribute(ATTRIBUTE_COLSPAN);
+    }
+
+    /**
+     * Sets the {@code rowspan} attribute — how many rows this cell spans. The
+     * default is {@code 1}. A value of {@code 0} extends the cell until the end
+     * of its grouping section ({@code <thead>}, {@code <tbody>} or
+     * {@code <tfoot>}, even if implicitly defined). Browsers clip values above
+     * 65534.
+     *
+     * @param rowspan
+     *            a non-negative integer.
+     */
+    public void setRowspan(int rowspan) {
+        if (rowspan < 0) {
+            throw new IllegalArgumentException(
+                    "rowspan must be a non-negative integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_ROWSPAN, String.valueOf(rowspan));
+    }
+
+    /**
+     * Returns the rowspan value of this cell.
+     *
+     * @return the current value of the rowspan attribute. Default is 1.
+     */
+    public int getRowspan() {
+        String rowspan = getElement().getAttribute(ATTRIBUTE_ROWSPAN);
+        if (rowspan == null) {
+            rowspan = "1";
+        }
+        return Integer.parseInt(rowspan);
+    }
+
+    /**
+     * Resets the rowspan to its default value of 1.
+     */
+    public void resetRowspan() {
+        getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AbstractNativeTableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AbstractNativeTableCell.java
@@ -15,6 +15,12 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
 
@@ -23,7 +29,7 @@ import com.vaadin.flow.component.HtmlContainer;
  * {@link NativeTableHeaderCell}). Provides shared support for the attributes
  * that apply equally to <code>&lt;td&gt;</code> and <code>&lt;th&gt;</code> per
  * the <a href="https://html.spec.whatwg.org/multipage/tables.html">WHATWG HTML
- * specification</a>: {@code colspan} and {@code rowspan}.
+ * specification</a>: {@code colspan}, {@code rowspan} and {@code headers}.
  *
  * @see <a href=
  *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td">MDN:
@@ -36,6 +42,7 @@ public abstract class AbstractNativeTableCell extends HtmlContainer {
 
     private static final String ATTRIBUTE_COLSPAN = "colspan";
     private static final String ATTRIBUTE_ROWSPAN = "rowspan";
+    private static final String ATTRIBUTE_HEADERS = "headers";
 
     /**
      * Creates a new empty cell component.
@@ -126,5 +133,98 @@ public abstract class AbstractNativeTableCell extends HtmlContainer {
      */
     public void resetRowspan() {
         getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
+    }
+
+    /**
+     * Sets the {@code headers} attribute — a list of ids referring to the
+     * <code>&lt;th&gt;</code> cells that label this cell. Assistive
+     * technologies use it to read out the right headers when navigating complex
+     * tables, where
+     * {@link NativeTableHeaderCell#setScope(NativeTableHeaderCell.Scope) scope}
+     * alone isn't enough to disambiguate.
+     * <p>
+     * Passing no arguments (or an empty array) removes the attribute.
+     *
+     * @param ids
+     *            the ids of the header cells, in any order.
+     */
+    public void setHeaders(String... ids) {
+        setHeaders(ids == null ? List.of() : Arrays.asList(ids));
+    }
+
+    /**
+     * List equivalent of {@link #setHeaders(String...)}. An empty list (or
+     * {@code null}) clears the attribute.
+     *
+     * @param ids
+     *            the ids of the header cells, in any order.
+     */
+    public void setHeaders(List<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            getElement().removeAttribute(ATTRIBUTE_HEADERS);
+            return;
+        }
+        for (String id : ids) {
+            Objects.requireNonNull(id, "header id must not be null");
+        }
+        getElement().setAttribute(ATTRIBUTE_HEADERS, String.join(" ", ids));
+    }
+
+    /**
+     * Convenience overload that takes header cells directly and uses their
+     * {@code id} attributes. Each cell must have an id set.
+     *
+     * @param headerCells
+     *            the header cells whose ids should be referenced.
+     * @throws IllegalArgumentException
+     *             if any of the given cells does not have an id set.
+     */
+    public void setHeaders(NativeTableHeaderCell... headerCells) {
+        setHeadersByCells(
+                headerCells == null ? List.of() : Arrays.asList(headerCells));
+    }
+
+    /**
+     * List equivalent of {@link #setHeaders(NativeTableHeaderCell...)}.
+     *
+     * @param headerCells
+     *            the header cells whose ids should be referenced.
+     * @throws IllegalArgumentException
+     *             if any of the given cells does not have an id set.
+     */
+    public void setHeadersByCells(
+            List<? extends NativeTableHeaderCell> headerCells) {
+        if (headerCells == null || headerCells.isEmpty()) {
+            getElement().removeAttribute(ATTRIBUTE_HEADERS);
+            return;
+        }
+        List<String> ids = new ArrayList<>(headerCells.size());
+        for (NativeTableHeaderCell cell : headerCells) {
+            ids.add(cell.getId().orElseThrow(() -> new IllegalArgumentException(
+                    "Header cell must have an id to be referenced via the headers attribute")));
+        }
+        setHeaders(ids);
+    }
+
+    /**
+     * Returns the IDs of the header cells associated with this cell via the
+     * {@code headers} attribute, or an empty {@link Optional} if the attribute
+     * is not set.
+     *
+     * @return the parsed list of header IDs.
+     */
+    public Optional<String[]> getHeaders() {
+        String value = getElement().getAttribute(ATTRIBUTE_HEADERS);
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(value.split("\\s+"));
+    }
+
+    /**
+     * Removes the {@code headers} attribute from this cell.
+     */
+    public void resetHeaders() {
+        getElement().removeAttribute(ATTRIBUTE_HEADERS);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
@@ -15,12 +15,13 @@
  */
 package com.vaadin.flow.component.html;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -32,26 +33,6 @@ import com.vaadin.flow.component.Tag;
 @Tag(Tag.TABLE)
 public class NativeTable extends HtmlContainer
         implements ClickNotifier<NativeTable> {
-
-    /**
-     * The table's caption.
-     */
-    private NativeTableCaption caption;
-
-    /**
-     * The {@code <thead>} element of this table.
-     */
-    private NativeTableHeader head;
-
-    /**
-     * The list of {@code <tbody>} elements of the table.
-     */
-    private final List<NativeTableBody> bodies = new LinkedList<>();
-
-    /**
-     * The {@code <tfoot>} element of this table.
-     */
-    private NativeTableFooter foot;
 
     /**
      * Creates a new empty table.
@@ -77,11 +58,11 @@ public class NativeTable extends HtmlContainer
      * @return the table's caption.
      */
     public NativeTableCaption getCaption() {
-        if (caption == null) {
-            caption = new NativeTableCaption();
+        return findCaption().orElseGet(() -> {
+            NativeTableCaption caption = new NativeTableCaption();
             addComponentAsFirst(caption);
-        }
-        return caption;
+            return caption;
+        });
     }
 
     /**
@@ -107,10 +88,7 @@ public class NativeTable extends HtmlContainer
      * Remove the caption from this table.
      */
     public void removeCaption() {
-        if (caption != null) {
-            remove(caption);
-            caption = null;
-        }
+        findCaption().ifPresent(this::remove);
     }
 
     /**
@@ -120,22 +98,18 @@ public class NativeTable extends HtmlContainer
      *         element was present.
      */
     public NativeTableHeader getHead() {
-        if (head == null) {
-            head = new NativeTableHeader();
-            int index = caption == null ? 0 : 1;
-            addComponentAtIndex(index, head);
-        }
-        return head;
+        return findHead().orElseGet(() -> {
+            NativeTableHeader head = new NativeTableHeader();
+            addComponentAtIndex(findCaption().isPresent() ? 1 : 0, head);
+            return head;
+        });
     }
 
     /**
      * Remove the head from this table, if present.
      */
     public void removeHead() {
-        if (head != null) {
-            remove(head);
-            head = null;
-        }
+        findHead().ifPresent(this::remove);
     }
 
     /**
@@ -145,21 +119,18 @@ public class NativeTable extends HtmlContainer
      *         none was present.
      */
     public NativeTableFooter getFoot() {
-        if (foot == null) {
-            foot = new NativeTableFooter();
+        return findFoot().orElseGet(() -> {
+            NativeTableFooter foot = new NativeTableFooter();
             add(foot);
-        }
-        return foot;
+            return foot;
+        });
     }
 
     /**
      * Removes the foot from this table, if present.
      */
     public void removeFoot() {
-        if (foot != null) {
-            remove(foot);
-            foot = null;
-        }
+        findFoot().ifPresent(this::remove);
     }
 
     /**
@@ -168,7 +139,8 @@ public class NativeTable extends HtmlContainer
      * @return the list of table body elements of this table.
      */
     public List<NativeTableBody> getBodies() {
-        return new ArrayList<>(bodies);
+        return ComponentUtil.getChildrenOfType(this, NativeTableBody.class)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -179,10 +151,8 @@ public class NativeTable extends HtmlContainer
      *         there's none.
      */
     public NativeTableBody getBody() {
-        if (bodies.isEmpty()) {
-            return addBody();
-        }
-        return bodies.get(0);
+        return ComponentUtil.getFirstChildOfType(this, NativeTableBody.class)
+                .orElseGet(this::addBody);
     }
 
     /**
@@ -200,7 +170,7 @@ public class NativeTable extends HtmlContainer
         if (index == 0) {
             return getBody();
         }
-        return bodies.get(index);
+        return getBodies().get(index);
     }
 
     /**
@@ -210,15 +180,14 @@ public class NativeTable extends HtmlContainer
      */
     public NativeTableBody addBody() {
         NativeTableBody body = new NativeTableBody();
-        int index = bodies.size();
-        if (caption != null) {
+        int index = getBodies().size();
+        if (findCaption().isPresent()) {
             index++;
         }
-        if (head != null) {
+        if (findHead().isPresent()) {
             index++;
         }
         addComponentAtIndex(index, body);
-        bodies.add(body);
         return body;
     }
 
@@ -230,7 +199,6 @@ public class NativeTable extends HtmlContainer
      */
     public void removeBody(NativeTableBody body) {
         remove(body);
-        bodies.remove(body);
     }
 
     /**
@@ -249,6 +217,19 @@ public class NativeTable extends HtmlContainer
      */
     public void removeBody() {
         removeBody(0);
+    }
+
+    private Optional<NativeTableCaption> findCaption() {
+        return ComponentUtil.getFirstChildOfType(this,
+                NativeTableCaption.class);
+    }
+
+    private Optional<NativeTableHeader> findHead() {
+        return ComponentUtil.getFirstChildOfType(this, NativeTableHeader.class);
+    }
+
+    private Optional<NativeTableFooter> findFoot() {
+        return ComponentUtil.getFirstChildOfType(this, NativeTableFooter.class);
     }
 
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
@@ -75,12 +75,13 @@ public class NativeTable extends HtmlContainer
     }
 
     /**
-     * Return the caption text for this table.
+     * Returns the caption text for this table, or an empty string if no caption
+     * has been set.
      *
      * @return the table's caption text.
      */
     public String getCaptionText() {
-        return getCaption().getText();
+        return findCaption().map(NativeTableCaption::getText).orElse("");
     }
 
     /**
@@ -254,24 +255,6 @@ public class NativeTable extends HtmlContainer
     }
 
     /**
-     * Returns the {@code <tbody>} element at a given position relative to other
-     * {@code <tbody>} elements.
-     *
-     * @param index
-     *            The position of the body element relative to other body
-     *            elements.
-     * @return The table body component at the given position. If the position
-     *         is 0 and there are no body elements present, a new one is created
-     *         and returned.
-     */
-    public NativeTableBody getBody(int index) {
-        if (index == 0) {
-            return getBody();
-        }
-        return getBodies().get(index);
-    }
-
-    /**
      * Adds a new body element to the table.
      *
      * @return The new body.
@@ -290,24 +273,6 @@ public class NativeTable extends HtmlContainer
      */
     public void removeBody(NativeTableBody body) {
         remove(body);
-    }
-
-    /**
-     * Removes a body element at a given position.
-     *
-     * @param index
-     *            The position of the body element to remove.
-     */
-    public void removeBody(int index) {
-        NativeTableBody body = getBody(index);
-        removeBody(body);
-    }
-
-    /**
-     * Removes the first body element in the list of bodies of this table.
-     */
-    public void removeBody() {
-        removeBody(0);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
@@ -15,7 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -281,6 +283,175 @@ public class NativeTable extends HtmlContainer
      */
     public void removeBody() {
         removeBody(0);
+    }
+
+    /**
+     * Returns every {@link NativeTableRow} in this table — the head's rows,
+     * then the rows of each body in order, then the foot's rows — matching the
+     * document order exposed by the browser DOM's
+     * {@code HTMLTableElement.rows}. Useful for "iterate all rows" or "count
+     * rows" cases; for structural work go through {@link #getHead()},
+     * {@link #getBody()} or {@link #getFoot()} directly.
+     *
+     * @return an unmodifiable list of all rows in the table.
+     */
+    public List<NativeTableRow> getRows() {
+        List<NativeTableRow> all = new ArrayList<>();
+        findHead().ifPresent(head -> all.addAll(head.getRows()));
+        getBodies().forEach(body -> all.addAll(body.getRows()));
+        findFoot().ifPresent(foot -> all.addAll(foot.getRows()));
+        return Collections.unmodifiableList(all);
+    }
+
+    /**
+     * Removes every row from this table's head, bodies and foot. The section
+     * elements themselves ({@code <thead>}, {@code <tbody>}, {@code <tfoot>})
+     * and any column groups are kept; use {@link #removeHead()},
+     * {@link #removeBody(NativeTableBody)} or {@link #removeFoot()} to drop
+     * those.
+     */
+    public void removeAllRows() {
+        findHead().ifPresent(NativeTableHeader::removeAllRows);
+        getBodies().forEach(NativeTableBody::removeAllRows);
+        findFoot().ifPresent(NativeTableFooter::removeAllRows);
+    }
+
+    /**
+     * Appends a new empty row to this table's body, creating an implicit
+     * {@code <tbody>} if none exists yet. Mirrors the HTML pattern of placing
+     * <code>&lt;tr&gt;</code> elements directly inside a
+     * <code>&lt;table&gt;</code> (the browser auto-wraps them in
+     * {@code <tbody>}).
+     *
+     * @return the newly created row.
+     */
+    public NativeTableRow addRow() {
+        return getBody().addRow();
+    }
+
+    /**
+     * Appends a new row containing the given texts as data cells
+     * (<code>&lt;td&gt;</code>) to this table's body, creating an implicit
+     * {@code <tbody>} if none exists yet.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the newly created row.
+     */
+    public NativeTableRow addRow(String... cellTexts) {
+        return addRow(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addRow(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the newly created row.
+     */
+    public NativeTableRow addRow(List<String> cellTexts) {
+        return getBody().addRow().addDataCells(cellTexts);
+    }
+
+    /**
+     * Appends the given rows to this table's body, creating an implicit
+     * {@code <tbody>} if none exists yet.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addRows(NativeTableRow... rows) {
+        getBody().addRows(rows);
+    }
+
+    /**
+     * Appends a new empty row to this table's {@code <thead>}, creating it if
+     * none exists yet.
+     *
+     * @return the newly created row.
+     */
+    public NativeTableRow addHeaderRow() {
+        return getHead().addRow();
+    }
+
+    /**
+     * Appends a new row containing the given texts as header cells
+     * (<code>&lt;th&gt;</code>) to this table's {@code <thead>}, creating it if
+     * none exists yet.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return the newly created row.
+     */
+    public NativeTableRow addHeaderRow(String... cellTexts) {
+        return addHeaderRow(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addHeaderRow(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return the newly created row.
+     */
+    public NativeTableRow addHeaderRow(List<String> cellTexts) {
+        return getHead().addRow().addHeaderCells(cellTexts);
+    }
+
+    /**
+     * Appends the given rows to this table's {@code <thead>}, creating it if
+     * none exists yet.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addHeaderRows(NativeTableRow... rows) {
+        getHead().addRows(rows);
+    }
+
+    /**
+     * Appends a new empty row to this table's {@code <tfoot>}, creating it if
+     * none exists yet.
+     *
+     * @return the newly created row.
+     */
+    public NativeTableRow addFooterRow() {
+        return getFoot().addRow();
+    }
+
+    /**
+     * Appends a new row containing the given texts as data cells
+     * (<code>&lt;td&gt;</code>) to this table's {@code <tfoot>}, creating it if
+     * none exists yet.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the newly created row.
+     */
+    public NativeTableRow addFooterRow(String... cellTexts) {
+        return addFooterRow(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addFooterRow(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return the newly created row.
+     */
+    public NativeTableRow addFooterRow(List<String> cellTexts) {
+        return getFoot().addRow().addDataCells(cellTexts);
+    }
+
+    /**
+     * Appends the given rows to this table's {@code <tfoot>}, creating it if
+     * none exists yet.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addFooterRows(NativeTableRow... rows) {
+        getFoot().addRows(rows);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -33,6 +34,12 @@ import com.vaadin.flow.component.Tag;
 @Tag(Tag.TABLE)
 public class NativeTable extends HtmlContainer
         implements ClickNotifier<NativeTable> {
+
+    private static final int RANK_CAPTION = 0;
+    private static final int RANK_COLUMN_GROUP = 1;
+    private static final int RANK_HEAD = 2;
+    private static final int RANK_BODY = 3;
+    private static final int RANK_FOOT = 4;
 
     /**
      * Creates a new empty table.
@@ -60,7 +67,7 @@ public class NativeTable extends HtmlContainer
     public NativeTableCaption getCaption() {
         return findCaption().orElseGet(() -> {
             NativeTableCaption caption = new NativeTableCaption();
-            addComponentAsFirst(caption);
+            addComponentAtIndex(getInsertionIndex(RANK_CAPTION), caption);
             return caption;
         });
     }
@@ -92,6 +99,70 @@ public class NativeTable extends HtmlContainer
     }
 
     /**
+     * Appends a new empty {@code <colgroup>} to this table.
+     *
+     * @return the newly created column group.
+     */
+    public NativeTableColumnGroup addColumnGroup() {
+        return addColumnGroup(new NativeTableColumnGroup());
+    }
+
+    /**
+     * Appends an existing {@code <colgroup>} to this table.
+     *
+     * @param group
+     *            the column group to add.
+     * @return the same group, for fluent chaining.
+     */
+    public NativeTableColumnGroup addColumnGroup(NativeTableColumnGroup group) {
+        addComponentAtIndex(getInsertionIndex(RANK_COLUMN_GROUP), group);
+        return group;
+    }
+
+    /**
+     * Appends a new {@code <colgroup>} populated with the given columns.
+     *
+     * @param columns
+     *            the columns to place inside the new group.
+     * @return the newly created column group.
+     */
+    public NativeTableColumnGroup addColumnGroup(NativeTableColumn... columns) {
+        return addColumnGroup(Arrays.asList(columns));
+    }
+
+    /**
+     * List equivalent of {@link #addColumnGroup(NativeTableColumn...)}.
+     *
+     * @param columns
+     *            the columns to place inside the new group.
+     * @return the newly created column group.
+     */
+    public NativeTableColumnGroup addColumnGroup(
+            List<? extends NativeTableColumn> columns) {
+        return addColumnGroup(new NativeTableColumnGroup(columns));
+    }
+
+    /**
+     * Returns the column groups attached to this table, in document order.
+     *
+     * @return an unmodifiable list of column groups.
+     */
+    public List<NativeTableColumnGroup> getColumnGroups() {
+        return ComponentUtil
+                .getChildrenOfType(this, NativeTableColumnGroup.class).toList();
+    }
+
+    /**
+     * Removes a column group from this table.
+     *
+     * @param group
+     *            the group to remove.
+     */
+    public void removeColumnGroup(NativeTableColumnGroup group) {
+        remove(group);
+    }
+
+    /**
      * Returns the head of this table.
      *
      * @return This table's {@code <thead>} element. Creates a new one if no
@@ -100,7 +171,7 @@ public class NativeTable extends HtmlContainer
     public NativeTableHeader getHead() {
         return findHead().orElseGet(() -> {
             NativeTableHeader head = new NativeTableHeader();
-            addComponentAtIndex(findCaption().isPresent() ? 1 : 0, head);
+            addComponentAtIndex(getInsertionIndex(RANK_HEAD), head);
             return head;
         });
     }
@@ -121,7 +192,7 @@ public class NativeTable extends HtmlContainer
     public NativeTableFooter getFoot() {
         return findFoot().orElseGet(() -> {
             NativeTableFooter foot = new NativeTableFooter();
-            add(foot);
+            addComponentAtIndex(getInsertionIndex(RANK_FOOT), foot);
             return foot;
         });
     }
@@ -180,14 +251,7 @@ public class NativeTable extends HtmlContainer
      */
     public NativeTableBody addBody() {
         NativeTableBody body = new NativeTableBody();
-        int index = getBodies().size();
-        if (findCaption().isPresent()) {
-            index++;
-        }
-        if (findHead().isPresent()) {
-            index++;
-        }
-        addComponentAtIndex(index, body);
+        addComponentAtIndex(getInsertionIndex(RANK_BODY), body);
         return body;
     }
 
@@ -217,6 +281,38 @@ public class NativeTable extends HtmlContainer
      */
     public void removeBody() {
         removeBody(0);
+    }
+
+    /**
+     * Returns the index at which a child of the given rank must be inserted to
+     * keep the caption, column groups, head, bodies and foot in the order the
+     * HTML specification requires: right after the last child of the same or a
+     * lower rank.
+     */
+    private int getInsertionIndex(int rank) {
+        List<Component> children = getChildren().toList();
+        for (int i = 0; i < children.size(); i++) {
+            if (getRank(children.get(i)) > rank) {
+                return i;
+            }
+        }
+        return children.size();
+    }
+
+    private static int getRank(Component child) {
+        if (child instanceof NativeTableCaption) {
+            return RANK_CAPTION;
+        }
+        if (child instanceof NativeTableColumnGroup) {
+            return RANK_COLUMN_GROUP;
+        }
+        if (child instanceof NativeTableHeader) {
+            return RANK_HEAD;
+        }
+        if (child instanceof NativeTableFooter) {
+            return RANK_FOOT;
+        }
+        return RANK_BODY;
     }
 
     private Optional<NativeTableCaption> findCaption() {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTable.java
@@ -94,6 +94,31 @@ public class NativeTable extends HtmlContainer
     }
 
     /**
+     * Appends the given components to this table's caption, creating it if none
+     * exists yet. Useful for richer captions containing inline markup.
+     *
+     * @param components
+     *            the components to append.
+     * @return the caption.
+     */
+    public NativeTableCaption addCaption(Component... components) {
+        return addCaption(Arrays.asList(components));
+    }
+
+    /**
+     * List equivalent of {@link #addCaption(Component...)}.
+     *
+     * @param components
+     *            the components to append.
+     * @return the caption.
+     */
+    public NativeTableCaption addCaption(List<? extends Component> components) {
+        NativeTableCaption caption = getCaption();
+        caption.add(components.toArray(Component[]::new));
+        return caption;
+    }
+
+    /**
      * Remove the caption from this table.
      */
     public void removeCaption() {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableBody.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableBody.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -37,12 +36,12 @@ public class NativeTableBody extends HtmlContainer
     }
 
     /**
-     * Creates a new table body with the given children components.
+     * Creates a new table body with the given rows.
      *
-     * @param components
-     *            the children components.
+     * @param rows
+     *            the rows to add.
      */
-    public NativeTableBody(Component... components) {
-        super(components);
+    public NativeTableBody(NativeTableRow... rows) {
+        super(rows);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableCell.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.signals.Signal;
 
@@ -29,11 +28,8 @@ import com.vaadin.flow.signals.Signal;
  * @since 24.5
  */
 @Tag(Tag.TD)
-public class NativeTableCell extends HtmlContainer
+public class NativeTableCell extends AbstractNativeTableCell
         implements ClickNotifier<NativeTableCell> {
-
-    final String ATTRIBUTE_COLSPAN = "colspan";
-    final String ATTRIBUTE_ROWSPAN = "rowspan";
 
     /**
      * Creates a new empty table cell component.
@@ -84,78 +80,5 @@ public class NativeTableCell extends HtmlContainer
     public NativeTableCell(Signal<String> textSignal) {
         Objects.requireNonNull(textSignal, "textSignal must not be null");
         bindText(textSignal);
-    }
-
-    /**
-     * Set the colspan of this cell.
-     *
-     * @param colspan
-     *            a non-negative integer value that indicates how many columns
-     *            the data cell spans or extends.
-     */
-    public void setColspan(int colspan) {
-        if (colspan < 0) {
-            throw new IllegalArgumentException(
-                    "colspan must be a non-negative integer value");
-        }
-        getElement().setAttribute(ATTRIBUTE_COLSPAN, String.valueOf(colspan));
-    }
-
-    /**
-     * Returns the colspan value of this cell.
-     *
-     * @return the current value of the colspan attribute. Default is 1.
-     */
-    public int getColspan() {
-        String colspan = getElement().getAttribute(ATTRIBUTE_COLSPAN);
-        if (colspan == null) {
-            colspan = "1";
-        }
-        return Integer.parseInt(colspan);
-    }
-
-    /**
-     * Reset colspan to its default value of 1.
-     */
-    public void resetColspan() {
-        getElement().removeAttribute(ATTRIBUTE_COLSPAN);
-    }
-
-    /**
-     * Sets the rowspan for this cell.
-     *
-     * @param rowspan
-     *            a non-negative integer value that indicates for how many rows
-     *            the data cell spans or extends. If its value is set to 0, it
-     *            extends until the end of the table grouping section
-     *            ({@code <thead>}, {@code <tbody>}, {@code <tfoot>}, even if
-     *            implicitly defined), that the cell belongs to.
-     */
-    public void setRowspan(int rowspan) {
-        if (rowspan < 0) {
-            throw new IllegalArgumentException(
-                    "rowspan must be a non-negative integer value");
-        }
-        getElement().setAttribute(ATTRIBUTE_ROWSPAN, String.valueOf(rowspan));
-    }
-
-    /**
-     * Returns the rowspan value of this cell.
-     *
-     * @return the current value of the rowspan attribute. Default is 1.
-     */
-    public int getRowspan() {
-        String rowspan = getElement().getAttribute(ATTRIBUTE_ROWSPAN);
-        if (rowspan == null) {
-            rowspan = "1";
-        }
-        return Integer.parseInt(rowspan);
-    }
-
-    /**
-     * Resets the rowspan to its default value of 1.
-     */
-    public void resetRowspan() {
-        getElement().removeAttribute(ATTRIBUTE_ROWSPAN);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumn.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumn.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;col&gt;</code> element — a column (or
+ * range of columns, via {@link #setSpan(int)}) inside a
+ * {@link NativeTableColumnGroup}. Use it to apply column-wide styling without
+ * repeating it on every cell: a class or id on a {@code <col>} can target all
+ * the data cells in that column.
+ * <p>
+ * {@code <col>} is a void element (no children, no end tag) and is only valid
+ * inside a {@code <colgroup>} that does not itself carry a {@code span}
+ * attribute. Only a limited subset of CSS applies to columns:
+ * {@code background}, {@code border} (with {@code border-collapse: collapse}),
+ * {@code visibility: collapse} and {@code width}. Text and font properties do
+ * not inherit into the cells — style those on <code>&lt;td&gt;</code> or
+ * <code>&lt;th&gt;</code> instead.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/col">MDN:
+ *      &lt;col&gt; — The Table Column element</a>
+ */
+@Tag(Tag.COL)
+public class NativeTableColumn extends HtmlComponent {
+
+    private static final String ATTRIBUTE_SPAN = "span";
+
+    /**
+     * Creates a new column component spanning a single column.
+     */
+    public NativeTableColumn() {
+        super();
+    }
+
+    /**
+     * Creates a new column component spanning the given number of columns.
+     *
+     * @param span
+     *            the number of consecutive columns this {@code <col>} element
+     *            applies to. Must be a positive integer.
+     */
+    public NativeTableColumn(int span) {
+        super();
+        setSpan(span);
+    }
+
+    /**
+     * Sets the {@code span} attribute — how many consecutive columns this
+     * {@code <col>} element covers. The default is {@code 1}. Use it to apply
+     * the same styling or attributes across a range of columns without writing
+     * one {@code <col>} per column.
+     *
+     * @param span
+     *            a positive integer.
+     */
+    public void setSpan(int span) {
+        if (span < 1) {
+            throw new IllegalArgumentException(
+                    "span must be a positive integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_SPAN, String.valueOf(span));
+    }
+
+    /**
+     * Returns the value of the {@code span} attribute.
+     *
+     * @return the current span. Default is 1.
+     */
+    public int getSpan() {
+        String span = getElement().getAttribute(ATTRIBUTE_SPAN);
+        if (span == null) {
+            span = "1";
+        }
+        return Integer.parseInt(span);
+    }
+
+    /**
+     * Resets the span to its default value of 1.
+     */
+    public void resetSpan() {
+        getElement().removeAttribute(ATTRIBUTE_SPAN);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumn.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumn.java
@@ -38,9 +38,8 @@ import com.vaadin.flow.component.Tag;
  *      &lt;col&gt; — The Table Column element</a>
  */
 @Tag(Tag.COL)
-public class NativeTableColumn extends HtmlComponent {
-
-    private static final String ATTRIBUTE_SPAN = "span";
+public class NativeTableColumn extends HtmlComponent
+        implements NativeTableColumnSpan {
 
     /**
      * Creates a new column component spanning a single column.
@@ -59,42 +58,5 @@ public class NativeTableColumn extends HtmlComponent {
     public NativeTableColumn(int span) {
         super();
         setSpan(span);
-    }
-
-    /**
-     * Sets the {@code span} attribute — how many consecutive columns this
-     * {@code <col>} element covers. The default is {@code 1}. Use it to apply
-     * the same styling or attributes across a range of columns without writing
-     * one {@code <col>} per column.
-     *
-     * @param span
-     *            a positive integer.
-     */
-    public void setSpan(int span) {
-        if (span < 1) {
-            throw new IllegalArgumentException(
-                    "span must be a positive integer value");
-        }
-        getElement().setAttribute(ATTRIBUTE_SPAN, String.valueOf(span));
-    }
-
-    /**
-     * Returns the value of the {@code span} attribute.
-     *
-     * @return the current span. Default is 1.
-     */
-    public int getSpan() {
-        String span = getElement().getAttribute(ATTRIBUTE_SPAN);
-        if (span == null) {
-            span = "1";
-        }
-        return Integer.parseInt(span);
-    }
-
-    /**
-     * Resets the span to its default value of 1.
-     */
-    public void resetSpan() {
-        getElement().removeAttribute(ATTRIBUTE_SPAN);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumnGroup.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumnGroup.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;colgroup&gt;</code> element — a group of
+ * columns inside a {@link NativeTable}, used to apply attributes (most often a
+ * class for CSS) to several columns at once. Only a limited subset of CSS
+ * applies to column groups: {@code background}, {@code border} (with
+ * {@code border-collapse: collapse}), {@code visibility: collapse} and
+ * {@code width}.
+ * <p>
+ * Per the <a href="https://html.spec.whatwg.org/multipage/tables.html">WHATWG
+ * HTML specification</a>, a {@code <colgroup>} is used in one of two modes:
+ * either it carries a {@code span} attribute and has no children, or it
+ * contains zero or more {@code <col>} children and has no {@code span}
+ * attribute. Manage its {@code <col>} children through the
+ * {@link NativeTableColumn} operations below rather than the generic
+ * {@link HtmlContainer#add(Component...)} inherited from {@link HtmlContainer}.
+ * {@code <colgroup>} elements must be placed after the optional
+ * {@code <caption>} and before any {@code <thead>}, {@code <tbody>},
+ * {@code <tfoot>} or <code>&lt;tr&gt;</code>; the {@link NativeTable} inserts
+ * them at the correct position automatically.
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/colgroup">MDN:
+ *      &lt;colgroup&gt; — The Table Column Group element</a>
+ */
+@Tag(Tag.COLGROUP)
+public class NativeTableColumnGroup extends HtmlContainer {
+
+    private static final String ATTRIBUTE_SPAN = "span";
+
+    /**
+     * Creates a new empty column group.
+     */
+    public NativeTableColumnGroup() {
+        super();
+    }
+
+    /**
+     * Creates a new column group with the given columns appended.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public NativeTableColumnGroup(NativeTableColumn... columns) {
+        super(columns);
+    }
+
+    /**
+     * List equivalent of {@link #NativeTableColumnGroup(NativeTableColumn...)}.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public NativeTableColumnGroup(List<? extends NativeTableColumn> columns) {
+        super(columns.toArray(NativeTableColumn[]::new));
+    }
+
+    /**
+     * Appends a new empty {@code <col>} child to this group.
+     *
+     * @return the new column.
+     */
+    public NativeTableColumn addColumn() {
+        NativeTableColumn column = new NativeTableColumn();
+        add(column);
+        return column;
+    }
+
+    /**
+     * Appends a new {@code <col>} child with the given span to this group.
+     *
+     * @param span
+     *            the number of columns to span.
+     * @return the new column.
+     */
+    public NativeTableColumn addColumn(int span) {
+        NativeTableColumn column = new NativeTableColumn(span);
+        add(column);
+        return column;
+    }
+
+    /**
+     * Appends the given columns to this group.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public void addColumns(NativeTableColumn... columns) {
+        addColumns(Arrays.asList(columns));
+    }
+
+    /**
+     * List equivalent of {@link #addColumns(NativeTableColumn...)}.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public void addColumns(List<? extends NativeTableColumn> columns) {
+        add(columns.toArray(NativeTableColumn[]::new));
+    }
+
+    /**
+     * Returns the columns inside this group.
+     *
+     * @return the list of {@code <col>} children.
+     */
+    public List<NativeTableColumn> getColumns() {
+        return ComponentUtil.getChildrenOfType(this, NativeTableColumn.class)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Removes a column from this group.
+     *
+     * @param column
+     *            the column to remove.
+     */
+    public void removeColumn(NativeTableColumn column) {
+        remove(column);
+    }
+
+    /**
+     * Removes all columns from this group.
+     */
+    public void removeAllColumns() {
+        removeAll();
+    }
+
+    /**
+     * Sets the {@code span} attribute — how many consecutive columns this group
+     * covers when used without {@link NativeTableColumn} children. Per the HTML
+     * specification, {@code span} is only valid on a {@code <colgroup>} that
+     * has no {@code <col>} children. The default is {@code 1}.
+     *
+     * @param span
+     *            a positive integer.
+     */
+    public void setSpan(int span) {
+        if (span < 1) {
+            throw new IllegalArgumentException(
+                    "span must be a positive integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_SPAN, String.valueOf(span));
+    }
+
+    /**
+     * Returns the value of the {@code span} attribute.
+     *
+     * @return the current span. Default is 1.
+     */
+    public int getSpan() {
+        String span = getElement().getAttribute(ATTRIBUTE_SPAN);
+        if (span == null) {
+            span = "1";
+        }
+        return Integer.parseInt(span);
+    }
+
+    /**
+     * Removes the {@code span} attribute, restoring the default value of 1.
+     */
+    public void resetSpan() {
+        getElement().removeAttribute(ATTRIBUTE_SPAN);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumnGroup.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumnGroup.java
@@ -49,9 +49,8 @@ import com.vaadin.flow.component.Tag;
  *      &lt;colgroup&gt; — The Table Column Group element</a>
  */
 @Tag(Tag.COLGROUP)
-public class NativeTableColumnGroup extends HtmlContainer {
-
-    private static final String ATTRIBUTE_SPAN = "span";
+public class NativeTableColumnGroup extends HtmlContainer
+        implements NativeTableColumnSpan {
 
     /**
      * Creates a new empty column group.
@@ -149,42 +148,5 @@ public class NativeTableColumnGroup extends HtmlContainer {
      */
     public void removeAllColumns() {
         removeAll();
-    }
-
-    /**
-     * Sets the {@code span} attribute — how many consecutive columns this group
-     * covers when used without {@link NativeTableColumn} children. Per the HTML
-     * specification, {@code span} is only valid on a {@code <colgroup>} that
-     * has no {@code <col>} children. The default is {@code 1}.
-     *
-     * @param span
-     *            a positive integer.
-     */
-    public void setSpan(int span) {
-        if (span < 1) {
-            throw new IllegalArgumentException(
-                    "span must be a positive integer value");
-        }
-        getElement().setAttribute(ATTRIBUTE_SPAN, String.valueOf(span));
-    }
-
-    /**
-     * Returns the value of the {@code span} attribute.
-     *
-     * @return the current span. Default is 1.
-     */
-    public int getSpan() {
-        String span = getElement().getAttribute(ATTRIBUTE_SPAN);
-        if (span == null) {
-            span = "1";
-        }
-        return Integer.parseInt(span);
-    }
-
-    /**
-     * Removes the {@code span} attribute, restoring the default value of 1.
-     */
-    public void resetSpan() {
-        getElement().removeAttribute(ATTRIBUTE_SPAN);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumnSpan.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableColumnSpan.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * A table column definition carrying a {@code span} attribute, i.e. either a
+ * <code>&lt;col&gt;</code> or a <code>&lt;colgroup&gt;</code>.
+ */
+interface NativeTableColumnSpan extends HasElement {
+
+    String ATTRIBUTE_SPAN = "span";
+
+    /**
+     * Sets the {@code span} attribute — how many consecutive columns this
+     * element covers. The default is {@code 1}. Use it to apply the same
+     * styling or attributes across a range of columns without writing one
+     * element per column.
+     *
+     * @param span
+     *            a positive integer.
+     */
+    default void setSpan(int span) {
+        if (span < 1) {
+            throw new IllegalArgumentException(
+                    "span must be a positive integer value");
+        }
+        getElement().setAttribute(ATTRIBUTE_SPAN, String.valueOf(span));
+    }
+
+    /**
+     * Returns the value of the {@code span} attribute.
+     *
+     * @return the current span. Default is 1.
+     */
+    default int getSpan() {
+        String span = getElement().getAttribute(ATTRIBUTE_SPAN);
+        if (span == null) {
+            span = "1";
+        }
+        return Integer.parseInt(span);
+    }
+
+    /**
+     * Removes the {@code span} attribute, restoring the default value of 1.
+     */
+    default void resetSpan() {
+        getElement().removeAttribute(ATTRIBUTE_SPAN);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableFooter.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableFooter.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -37,12 +36,12 @@ public class NativeTableFooter extends HtmlContainer
     }
 
     /**
-     * Creates a new table footer with the given children components.
+     * Creates a new table footer with the given rows.
      *
-     * @param components
-     *            the children components.
+     * @param rows
+     *            the rows to add.
      */
-    public NativeTableFooter(Component... components) {
-        super(components);
+    public NativeTableFooter(NativeTableRow... rows) {
+        super(rows);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeader.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeader.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -37,12 +36,12 @@ public class NativeTableHeader extends HtmlContainer
     }
 
     /**
-     * Creates a new table header with the given children components.
+     * Creates a new table header with the given rows.
      *
-     * @param components
-     *            the children components.
+     * @param rows
+     *            the rows to add.
      */
-    public NativeTableHeader(Component... components) {
-        super(components);
+    public NativeTableHeader(NativeTableRow... rows) {
+        super(rows);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeaderCell.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.html;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
@@ -24,8 +25,13 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.signals.Signal;
 
 /**
- * Component representing a <code>&lt;th&gt;</code> element.
+ * Component representing a <code>&lt;th&gt;</code> element — a cell that labels
+ * a group of other cells in a {@link NativeTable}. Which cells it labels is
+ * defined by the {@link #setScope(Scope) scope} attribute.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th">MDN:
+ *      &lt;th&gt; — The Table Header element</a>
  * @since 24.5
  */
 @Tag(Tag.TH)
@@ -72,5 +78,106 @@ public class NativeTableHeaderCell extends HtmlContainer
     public NativeTableHeaderCell(Signal<String> textSignal) {
         Objects.requireNonNull(textSignal, "textSignal must not be null");
         bindText(textSignal);
+    }
+
+    /**
+     * Defines the cells that a <code>&lt;th&gt;</code> header relates to —
+     * effectively the answer to "which other cells does this header label?".
+     * Setting it correctly is what lets a screen reader read out the right
+     * column or row header when a user navigates into a data cell.
+     * <p>
+     * If no scope is set (or the value is unrecognized), browsers automatically
+     * infer the scope from the table structure. Per the <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th#scope">HTML
+     * spec</a>, the standard keywords are {@link #ROW row}, {@link #COL col},
+     * {@link #ROWGROUP rowgroup}, and {@link #COLGROUP colgroup}; {@link #AUTO
+     * auto} writes the literal {@code "auto"} attribute value, which browsers
+     * treat the same as omitting the attribute.
+     */
+    public enum Scope {
+        /**
+         * The header relates to all cells of the row it belongs to. Use this
+         * for a leading <code>&lt;th&gt;</code> that labels its row (e.g. the
+         * row's name or category).
+         */
+        ROW("row"),
+        /**
+         * The header relates to all cells of the column it belongs to. Use this
+         * for a header at the top of a column (the most common case in
+         * <code>&lt;thead&gt;</code>).
+         */
+        COL("col"),
+        /**
+         * The header belongs to a row group ({@code <tbody>} or
+         * {@code <thead>}/{@code <tfoot>}) and relates to all cells in that
+         * group.
+         */
+        ROWGROUP("rowgroup"),
+        /**
+         * The header belongs to a column group ({@link NativeTableColumnGroup})
+         * and relates to all cells in that group.
+         */
+        COLGROUP("colgroup"),
+        /**
+         * Writes the literal {@code "auto"} value. Behaves the same as leaving
+         * the attribute unset — the browser infers the scope from the table
+         * structure.
+         */
+        AUTO("auto");
+
+        private final String value;
+
+        Scope(String value) {
+            this.value = value;
+        }
+
+        /**
+         * Returns the attribute value as it appears in the rendered HTML.
+         */
+        public String getValue() {
+            return value;
+        }
+
+        static Scope fromValue(String value) {
+            if (value == null) {
+                return null;
+            }
+            for (Scope s : values()) {
+                if (s.value.equals(value)) {
+                    return s;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Sets the {@code scope} attribute, declaring which cells this header
+     * labels. Critical for accessibility — screen readers use this to announce
+     * the right header when a user navigates into a data cell. Pass
+     * {@code null} to remove the attribute (browsers will then infer scope from
+     * structure).
+     *
+     * @param scope
+     *            the scope, or {@code null} to clear the attribute.
+     * @see Scope
+     */
+    public void setScope(Scope scope) {
+        if (scope == null) {
+            getElement().removeAttribute("scope");
+        } else {
+            getElement().setAttribute("scope", scope.getValue());
+        }
+    }
+
+    /**
+     * Returns the {@code scope} attribute value, if set.
+     *
+     * @return the scope wrapped in an {@link Optional}, or empty if unset (or
+     *         the value is unrecognized).
+     */
+    public Optional<Scope> getScope() {
+        return Optional.ofNullable(
+                Scope.fromValue(getElement().getAttribute("scope")));
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableHeaderCell.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.signals.Signal;
 
@@ -35,7 +34,7 @@ import com.vaadin.flow.signals.Signal;
  * @since 24.5
  */
 @Tag(Tag.TH)
-public class NativeTableHeaderCell extends HtmlContainer
+public class NativeTableHeaderCell extends AbstractNativeTableCell
         implements ClickNotifier<NativeTableHeaderCell> {
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
@@ -66,6 +66,23 @@ public class NativeTableRow extends HtmlContainer
     }
 
     /**
+     * Add a header cell to this row that labels the row itself, with
+     * {@code scope="row"} set on the resulting {@code <th>}. This is a
+     * shortcut for the common pattern of using a leading {@code <th>} as a row
+     * label, which assistive technologies announce as the header for the data
+     * cells in the same row.
+     *
+     * @param text
+     *            the text content.
+     * @return the new {@code <th>} element with {@code scope="row"}.
+     */
+    public NativeTableHeaderCell addRowHeaderCell(String text) {
+        NativeTableHeaderCell cell = addHeaderCell(text);
+        cell.setScope(NativeTableHeaderCell.Scope.ROW);
+        return cell;
+    }
+
+    /**
      * Add a header cell to this row.
      *
      * @return the new {@code <th>} element.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
@@ -43,13 +43,18 @@ public class NativeTableRow extends HtmlContainer
     }
 
     /**
-     * Creates a new table row with the given children components.
+     * Creates a new table row with the given children. A
+     * {@link NativeTableCell} or {@link NativeTableHeaderCell} argument is
+     * added as-is; any other component is wrapped in a new
+     * {@link NativeTableCell}, matching {@link #addCells(Component...)}.
      *
      * @param components
-     *            the children components.
+     *            the cells (used as-is) or other components (wrapped in
+     *            {@code <td>}) to place in this row.
      */
     public NativeTableRow(Component... components) {
-        super(components);
+        super();
+        addCells(components);
     }
 
     /**
@@ -171,114 +176,29 @@ public class NativeTableRow extends HtmlContainer
     }
 
     /**
-     * Returns a list of all cells in this row.
+     * Returns all cells in this row, in document order — both
+     * {@link NativeTableCell} and {@link NativeTableHeaderCell} entries
+     * combined. For kind-specific lists use {@link #getDataCells()} or
+     * {@link #getHeaderCells()}; index into any of these lists with
+     * {@code .get(i)}.
      *
      * @return a list of all cells in this row.
      */
-    public List<Component> getAllCells() {
-        return getChildren()
-                .filter(c -> c instanceof NativeTableCell
-                        || c instanceof NativeTableHeaderCell)
+    public List<AbstractNativeTableCell> getCells() {
+        return getChildren().filter(AbstractNativeTableCell.class::isInstance)
+                .map(AbstractNativeTableCell.class::cast)
                 .collect(Collectors.toList());
     }
 
     /**
-     * Returns the header cell at a given position relative to other header
-     * cells.
+     * Removes a cell from this row.
      *
-     * @param index
-     *            the position of the header cell relative to other header
-     *            cells.
-     * @return the header cell at the given position (relative to other header
-     *         cells).
+     * @param cell
+     *            the cell to remove.
      */
-    public Optional<NativeTableHeaderCell> getHeaderCell(int index) {
-        return getChildren().filter(c -> c instanceof NativeTableHeaderCell)
-                .map(c -> (NativeTableHeaderCell) c).skip(index).findFirst();
+    public void removeCell(AbstractNativeTableCell cell) {
+        remove(cell);
     }
-
-    /**
-     * Returns the data cell at a given position relative to other data cells.
-     *
-     * @param index
-     *            the position of the data cell relative to other data cells.
-     * @return the data cell at the given position (relative to other data
-     *         cells).
-     */
-    public Optional<NativeTableCell> getDataCell(int index) {
-        return getChildren().filter(c -> c instanceof NativeTableCell)
-                .map(c -> (NativeTableCell) c).skip(index).findFirst();
-    }
-
-    /**
-     * Returns the cell at a given position.
-     *
-     * @param index
-     *            the position of the cell.
-     * @return the cell at the given position
-     * @throws IndexOutOfBoundsException
-     *             if index is negative or greater than (or equal to) the number
-     *             of cells in the row
-     */
-    public Optional<Component> getCell(int index) {
-        return getChildren()
-                .filter(c -> c instanceof NativeTableCell
-                        || c instanceof NativeTableHeaderCell)
-                .skip(index).findFirst();
-    }
-
-    /**
-     * Removes the cell at a given position.
-     *
-     * @param index
-     *            the position of the cell to remove
-     */
-    public void removeCell(int index) {
-        getCell(index).ifPresent(this::remove);
-    }
-
-    /**
-     * Removes the header cell at a position relative to other header cells.
-     *
-     * @param index
-     *            the position of the header cell relative to other header
-     *            cells.
-     */
-    public void removeHeaderCell(int index) {
-        getHeaderCell(index).ifPresent(this::remove);
-    }
-
-    /**
-     * Removes a header cell.
-     *
-     * @param headerCell
-     *            the header cell to remove.
-     */
-    public void removeHeaderCell(NativeTableHeaderCell headerCell) {
-        remove(headerCell);
-    }
-
-    /**
-     * Removes the data cell at a given position relative to other data cells.
-     *
-     * @param index
-     *            the position of the data cell to remove relative to other data
-     *            cells.
-     */
-    public void removeDataCell(int index) {
-        getDataCell(index).ifPresent(this::remove);
-    }
-
-    /**
-     * Removes a data cell.
-     *
-     * @param dataCell
-     *            the data cell to remove.
-     */
-    public void removeDataCell(NativeTableCell dataCell) {
-        remove(dataCell);
-    }
-
 
     /**
      * Appends a sequence of data cells ({@code <td>}) with the given text

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRow.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -52,6 +53,19 @@ public class NativeTableRow extends HtmlContainer
     }
 
     /**
+     * Add a header cell to this row with the given text content.
+     *
+     * @param text
+     *            the text content.
+     * @return the new {@code <th>} element.
+     */
+    public NativeTableHeaderCell addHeaderCell(String text) {
+        NativeTableHeaderCell cell = new NativeTableHeaderCell(text);
+        add(cell);
+        return cell;
+    }
+
+    /**
      * Add a header cell to this row.
      *
      * @return the new {@code <th>} element.
@@ -76,6 +90,19 @@ public class NativeTableRow extends HtmlContainer
         NativeTableHeaderCell headerCell = new NativeTableHeaderCell();
         addComponentAtIndex(position, headerCell);
         return headerCell;
+    }
+
+    /**
+     * Add a data cell to this row with the given text content.
+     *
+     * @param text
+     *            the text content.
+     * @return the new {@code <td>} element.
+     */
+    public NativeTableCell addDataCell(String text) {
+        NativeTableCell cell = new NativeTableCell(text);
+        add(cell);
+        return cell;
     }
 
     /**
@@ -235,4 +262,88 @@ public class NativeTableRow extends HtmlContainer
         remove(dataCell);
     }
 
+
+    /**
+     * Appends a sequence of data cells ({@code <td>}) with the given text
+     * contents to this row.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return this row, for fluent chaining.
+     */
+    public NativeTableRow addDataCells(String... cellTexts) {
+        return addDataCells(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addDataCells(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each data cell.
+     * @return this row, for fluent chaining.
+     */
+    public NativeTableRow addDataCells(List<String> cellTexts) {
+        cellTexts.forEach(this::addDataCell);
+        return this;
+    }
+
+    /**
+     * Appends a sequence of header cells ({@code <th>}) with the given text
+     * contents to this row.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return this row, for fluent chaining.
+     */
+    public NativeTableRow addHeaderCells(String... cellTexts) {
+        return addHeaderCells(Arrays.asList(cellTexts));
+    }
+
+    /**
+     * List equivalent of {@link #addHeaderCells(String...)}.
+     *
+     * @param cellTexts
+     *            the text content for each header cell.
+     * @return this row, for fluent chaining.
+     */
+    public NativeTableRow addHeaderCells(List<String> cellTexts) {
+        cellTexts.forEach(this::addHeaderCell);
+        return this;
+    }
+
+    /**
+     * Appends children to this row. A {@link NativeTableCell} or
+     * {@link NativeTableHeaderCell} argument is added as-is; any other
+     * component is wrapped in a new {@link NativeTableCell}, since a
+     * <code>&lt;tr&gt;</code> may only contain {@code <td>} and {@code <th>}
+     * elements.
+     *
+     * @param components
+     *            the cells (used as-is) or other components (wrapped in
+     *            {@code <td>}) to append.
+     * @return this row, for fluent chaining.
+     */
+    public NativeTableRow addCells(Component... components) {
+        return addCells(Arrays.asList(components));
+    }
+
+    /**
+     * List equivalent of {@link #addCells(Component...)}.
+     *
+     * @param components
+     *            the cells or wrap-target components.
+     * @return this row, for fluent chaining.
+     */
+    public NativeTableRow addCells(List<? extends Component> components) {
+        for (Component component : components) {
+            add(isCell(component) ? component
+                    : new NativeTableCell(component));
+        }
+        return this;
+    }
+
+    private static boolean isCell(Component component) {
+        return component instanceof NativeTableCell
+                || component instanceof NativeTableHeaderCell;
+    }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRowContainer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeTableRowContainer.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.html;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
@@ -30,17 +29,6 @@ import com.vaadin.flow.component.HasOrderedComponents;
 interface NativeTableRowContainer extends HasOrderedComponents {
 
     /**
-     * Get the index of a given row.
-     *
-     * @param row
-     *            the row to get the index of.
-     * @return the index of the row.
-     */
-    default int getRowIndex(NativeTableRow row) {
-        return indexOf(row);
-    }
-
-    /**
      * Returns a list of all the rows.
      *
      * @return all the rows in the container.
@@ -48,19 +36,6 @@ interface NativeTableRowContainer extends HasOrderedComponents {
     default List<NativeTableRow> getRows() {
         return getChildren().filter(c -> c instanceof NativeTableRow)
                 .map(c -> (NativeTableRow) c).collect(Collectors.toList());
-    }
-
-    /**
-     * Returns the row at the given index.
-     *
-     * @param index
-     *            the index of the row. Must be greater than 0 and less than the
-     *            size of the container.
-     * @return the row at position {@code index}.
-     */
-    default Optional<NativeTableRow> getRow(int index) {
-        return getChildren().filter(c -> c instanceof NativeTableRow)
-                .map(c -> (NativeTableRow) c).skip(index).findFirst();
     }
 
     /**
@@ -109,17 +84,6 @@ interface NativeTableRowContainer extends HasOrderedComponents {
     }
 
     /**
-     * Remove the row at the given index.
-     *
-     * @param index
-     *            the position of the row to remove.
-     */
-    default void removeRow(int index) {
-        getRow(index).ifPresent(this::remove);
-
-    }
-
-    /**
      * Remove all the rows in the container.
      */
     default void removeAllRows() {
@@ -138,15 +102,6 @@ interface NativeTableRowContainer extends HasOrderedComponents {
     default void replaceRow(int index, NativeTableRow row) {
         Component oldRow = getComponentAt(index);
         replace(oldRow, row);
-    }
-
-    /**
-     * Returns the number of rows in the container.
-     *
-     * @return the row count.
-     */
-    default long getRowCount() {
-        return getChildren().filter(c -> c instanceof NativeTableRow).count();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -78,6 +78,8 @@ class HtmlComponentSmokeTest {
                         IFrame.SandboxType.ALLOW_MODALS });
         testValues.put(Component.class, new Paragraph("Component"));
         testValues.put(HasText.WhiteSpace.class, HasText.WhiteSpace.PRE_LINE);
+        testValues.put(NativeTableHeaderCell.Scope.class,
+                NativeTableHeaderCell.Scope.COL);
     }
 
     private static final Map<Class<?>, Map<Class<?>, Object>> specialTestValues = new HashMap<>();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -78,6 +78,7 @@ class HtmlComponentSmokeTest {
                         IFrame.SandboxType.ALLOW_MODALS });
         testValues.put(Component.class, new Paragraph("Component"));
         testValues.put(HasText.WhiteSpace.class, HasText.WhiteSpace.PRE_LINE);
+        testValues.put(String[].class, new String[] { "a", "b" });
         testValues.put(NativeTableHeaderCell.Scope.class,
                 NativeTableHeaderCell.Scope.COL);
     }
@@ -260,6 +261,17 @@ class HtmlComponentSmokeTest {
         // NativeTable delegates caption text to the nested <caption> element
         if (method.getDeclaringClass() == NativeTable.class
                 && method.getName().startsWith("setCaptionText")) {
+            return true;
+        }
+
+        // setHeaders has three overloads. The String[] one is exercised
+        // normally to cover the bean property; the ones taking header cells
+        // resolve to the same attribute and have no matching getter, and are
+        // covered by focused unit tests.
+        if (method.getDeclaringClass() == AbstractNativeTableCell.class
+                && (method.getName().equals("setHeadersByCells") || (method
+                        .getName().equals("setHeaders")
+                        && method.getParameterTypes()[0] != String[].class))) {
             return true;
         }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -435,8 +435,9 @@ class HtmlComponentSmokeTest {
     }
 
     private static boolean isHtmlComponentSubclass(Class<?> cls) {
-        // Abstract bases such as TableCell cannot be instantiated; they are
-        // covered through their concrete subclasses
+        // Abstract bases such as TableCell and AbstractNativeTableCell
+        // cannot be instantiated; they are covered through their concrete
+        // subclasses
         return HtmlComponent.class.isAssignableFrom(cls)
                 && !Modifier.isAbstract(cls.getModifiers());
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableCellTest.java
@@ -18,8 +18,10 @@ package com.vaadin.flow.component.html;
 import org.junit.jupiter.api.Test;
 
 import static com.vaadin.flow.component.html.AssertUtils.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NativeTableCellTest extends ComponentTest {
     // Actual test methods in super class
@@ -28,6 +30,8 @@ class NativeTableCellTest extends ComponentTest {
     protected void addProperties() {
         addProperty("colspan", int.class, 1, 2, false, false);
         addProperty("rowspan", int.class, 1, 2, false, false);
+        addProperty("headers", String[].class, null, new String[] { "a", "b" },
+                true, true);
     }
 
     @Test
@@ -102,6 +106,63 @@ class NativeTableCellTest extends ComponentTest {
         cell.resetRowspan();
         assertNull(cell.getElement().getAttribute("rowspan"),
                 "Element should not have rowspan attribute");
+    }
+
+    @Test
+    void setHeaders_writesSpaceJoinedAttributeAndReadsBack() {
+        NativeTableCell cell = (NativeTableCell) getComponent();
+        assertTrue(cell.getHeaders().isEmpty());
+
+        cell.setHeaders("name", "age");
+
+        assertEquals("name age", cell.getElement().getAttribute("headers"),
+                "headers should be space-joined");
+        assertArrayEquals(new String[] { "name", "age" },
+                cell.getHeaders().orElseThrow());
+    }
+
+    @Test
+    void setHeaders_empty_clearsTheAttribute() {
+        NativeTableCell cell = (NativeTableCell) getComponent();
+        cell.setHeaders("name");
+
+        cell.setHeaders(new String[0]);
+
+        assertNull(cell.getElement().getAttribute("headers"));
+        assertTrue(cell.getHeaders().isEmpty());
+    }
+
+    @Test
+    void setHeaders_fromHeaderCells_usesTheirIds() {
+        NativeTableCell cell = (NativeTableCell) getComponent();
+        NativeTableHeaderCell name = new NativeTableHeaderCell("Name");
+        NativeTableHeaderCell age = new NativeTableHeaderCell("Age");
+        name.setId("name-h");
+        age.setId("age-h");
+
+        cell.setHeaders(name, age);
+
+        assertEquals("name-h age-h", cell.getElement().getAttribute("headers"),
+                "headers should reference the cells' ids");
+    }
+
+    @Test
+    void setHeaders_fromHeaderCellWithoutId_throws() {
+        NativeTableCell cell = (NativeTableCell) getComponent();
+        NativeTableHeaderCell withoutId = new NativeTableHeaderCell("Name");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cell.setHeaders(withoutId));
+    }
+
+    @Test
+    void resetHeaders_removesTheAttribute() {
+        NativeTableCell cell = (NativeTableCell) getComponent();
+        cell.setHeaders("name");
+
+        cell.resetHeaders();
+
+        assertNull(cell.getElement().getAttribute("headers"));
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableColumnGroupTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableColumnGroupTest.java
@@ -16,12 +16,15 @@
 package com.vaadin.flow.component.html;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NativeTableColumnGroupTest extends ComponentTest {
@@ -60,12 +63,24 @@ class NativeTableColumnGroupTest extends ComponentTest {
         assertEquals(c2, columns.get(1));
     }
 
-    @Test
-    void varargsConstructor() {
+    static Stream<Named<Function<List<NativeTableColumn>, NativeTableColumnGroup>>> groupConstructors() {
+        return Stream.of(
+                Named.of("varargs",
+                        columns -> new NativeTableColumnGroup(
+                                columns.toArray(NativeTableColumn[]::new))),
+                Named.of("list", NativeTableColumnGroup::new));
+    }
+
+    @ParameterizedTest
+    @MethodSource("groupConstructors")
+    void constructor_addsGivenColumns(
+            Function<List<NativeTableColumn>, NativeTableColumnGroup> constructor) {
         NativeTableColumn c1 = new NativeTableColumn();
         NativeTableColumn c2 = new NativeTableColumn(2);
-        NativeTableColumnGroup group = new NativeTableColumnGroup(c1, c2);
-        assertEquals(2, group.getColumns().size());
+
+        NativeTableColumnGroup group = constructor.apply(List.of(c1, c2));
+
+        assertEquals(List.of(c1, c2), group.getColumns());
     }
 
     @Test
@@ -85,27 +100,5 @@ class NativeTableColumnGroupTest extends ComponentTest {
         group.addColumn();
         group.removeAllColumns();
         assertTrue(group.getColumns().isEmpty());
-    }
-
-    @Test
-    void setSpan_writesAttribute() {
-        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
-        group.setSpan(4);
-        assertEquals("4", group.getElement().getAttribute("span"));
-        assertEquals(4, group.getSpan());
-    }
-
-    @Test
-    void setSpan_rejectsNonPositive() {
-        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
-        assertThrows(IllegalArgumentException.class, () -> group.setSpan(0));
-    }
-
-    @Test
-    void resetSpan_removesAttribute() {
-        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
-        group.setSpan(2);
-        group.resetSpan();
-        assertNull(group.getElement().getAttribute("span"));
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableColumnGroupTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableColumnGroupTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NativeTableColumnGroupTest extends ComponentTest {
+    // Property tests in super class
+
+    @Override
+    protected void addProperties() {
+        addProperty("span", int.class, 1, 2, false, false);
+    }
+
+    @Test
+    void addColumn_appendsChild() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        NativeTableColumn col = group.addColumn();
+        assertEquals(1, group.getColumns().size());
+        assertEquals(group, col.getParent().orElseThrow());
+    }
+
+    @Test
+    void addColumnWithSpan_appendsChildWithSpan() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        NativeTableColumn col = group.addColumn(2);
+        assertEquals(2, col.getSpan());
+        assertEquals(1, group.getColumns().size());
+    }
+
+    @Test
+    void addColumns_appendsExistingColumns() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        NativeTableColumn c1 = new NativeTableColumn();
+        NativeTableColumn c2 = new NativeTableColumn(3);
+        group.addColumns(c1, c2);
+        List<NativeTableColumn> columns = group.getColumns();
+        assertEquals(2, columns.size());
+        assertEquals(c1, columns.get(0));
+        assertEquals(c2, columns.get(1));
+    }
+
+    @Test
+    void varargsConstructor() {
+        NativeTableColumn c1 = new NativeTableColumn();
+        NativeTableColumn c2 = new NativeTableColumn(2);
+        NativeTableColumnGroup group = new NativeTableColumnGroup(c1, c2);
+        assertEquals(2, group.getColumns().size());
+    }
+
+    @Test
+    void removeColumn() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        NativeTableColumn c = group.addColumn();
+        group.removeColumn(c);
+        assertTrue(group.getColumns().isEmpty());
+        assertTrue(c.getParent().isEmpty());
+    }
+
+    @Test
+    void removeAllColumns() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        group.addColumn();
+        group.addColumn();
+        group.addColumn();
+        group.removeAllColumns();
+        assertTrue(group.getColumns().isEmpty());
+    }
+
+    @Test
+    void setSpan_writesAttribute() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        group.setSpan(4);
+        assertEquals("4", group.getElement().getAttribute("span"));
+        assertEquals(4, group.getSpan());
+    }
+
+    @Test
+    void setSpan_rejectsNonPositive() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        assertThrows(IllegalArgumentException.class, () -> group.setSpan(0));
+    }
+
+    @Test
+    void resetSpan_removesAttribute() {
+        NativeTableColumnGroup group = (NativeTableColumnGroup) getComponent();
+        group.setSpan(2);
+        group.resetSpan();
+        assertNull(group.getElement().getAttribute("span"));
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableColumnTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableColumnTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NativeTableColumnTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        addProperty("span", int.class, 1, 2, false, false);
+    }
+
+    @Test
+    void defaultSpanIsOne() {
+        NativeTableColumn col = (NativeTableColumn) getComponent();
+        assertEquals(1, col.getSpan());
+    }
+
+    @Test
+    void setSpan_writesAttribute() {
+        NativeTableColumn col = (NativeTableColumn) getComponent();
+        col.setSpan(3);
+        assertEquals("3", col.getElement().getAttribute("span"));
+        assertEquals(3, col.getSpan());
+    }
+
+    @Test
+    void setSpan_rejectsNonPositive() {
+        NativeTableColumn col = (NativeTableColumn) getComponent();
+        assertThrows(IllegalArgumentException.class, () -> col.setSpan(0));
+        assertThrows(IllegalArgumentException.class, () -> col.setSpan(-1));
+    }
+
+    @Test
+    void resetSpan_removesAttribute() {
+        NativeTableColumn col = (NativeTableColumn) getComponent();
+        col.setSpan(4);
+        col.resetSpan();
+        assertNull(col.getElement().getAttribute("span"));
+        assertEquals(1, col.getSpan());
+    }
+
+    @Test
+    void spanConstructor() {
+        NativeTableColumn col = new NativeTableColumn(5);
+        assertEquals(5, col.getSpan());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableHeaderCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableHeaderCellTest.java
@@ -15,6 +15,44 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.html.NativeTableHeaderCell.Scope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class NativeTableHeaderCellTest extends ComponentTest {
     // Actual test methods in super class
+
+    @Test
+    void setScope_writesTheAttributeAndReadsBack() {
+        NativeTableHeaderCell cell = new NativeTableHeaderCell();
+        assertEquals(Optional.empty(), cell.getScope());
+
+        cell.setScope(Scope.ROWGROUP);
+
+        assertEquals("rowgroup", cell.getElement().getAttribute("scope"));
+        assertEquals(Optional.of(Scope.ROWGROUP), cell.getScope());
+    }
+
+    @Test
+    void setScope_null_removesTheAttribute() {
+        NativeTableHeaderCell cell = new NativeTableHeaderCell();
+        cell.setScope(Scope.COL);
+
+        cell.setScope(null);
+
+        assertEquals(null, cell.getElement().getAttribute("scope"));
+        assertEquals(Optional.empty(), cell.getScope());
+    }
+
+    @Test
+    void getScope_unrecognizedAttributeValue_isEmpty() {
+        NativeTableHeaderCell cell = new NativeTableHeaderCell();
+        cell.getElement().setAttribute("scope", "nonsense");
+
+        assertEquals(Optional.empty(), cell.getScope());
+    }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableHeaderCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableHeaderCellTest.java
@@ -26,6 +26,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class NativeTableHeaderCellTest extends ComponentTest {
     // Actual test methods in super class
 
+    @Override
+    protected void addProperties() {
+        addProperty("colspan", int.class, 1, 2, false, false);
+        addProperty("rowspan", int.class, 1, 2, false, false);
+    }
+
     @Test
     void setScope_writesTheAttributeAndReadsBack() {
         NativeTableHeaderCell cell = new NativeTableHeaderCell();
@@ -55,4 +61,5 @@ public class NativeTableHeaderCellTest extends ComponentTest {
 
         assertEquals(Optional.empty(), cell.getScope());
     }
+
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowContainerTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowContainerTest.java
@@ -15,8 +15,15 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
@@ -117,6 +124,24 @@ class NativeTableRowContainerTest {
         assertEquals(3, container.getChildren().count());
         AssertUtils.assertEquals(newRow, container.getRows().get(1),
                 "Row must be replaced with new row");
+    }
+
+    static Stream<Named<Function<NativeTableRow[], NativeTableRowContainer>>> sectionConstructors() {
+        return Stream.of(Named.of("thead", NativeTableHeader::new),
+                Named.of("tbody", NativeTableBody::new),
+                Named.of("tfoot", NativeTableFooter::new));
+    }
+
+    @ParameterizedTest
+    @MethodSource("sectionConstructors")
+    void varargsConstructor_addsGivenRows(
+            Function<NativeTableRow[], NativeTableRowContainer> constructor) {
+        var row0 = new NativeTableRow();
+        var row1 = new NativeTableRow();
+
+        var section = constructor.apply(new NativeTableRow[] { row0, row1 });
+
+        assertEquals(List.of(row0, row1), section.getRows());
     }
 
     @Tag(Tag.TR)

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowContainerTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowContainerTest.java
@@ -66,37 +66,6 @@ class NativeTableRowContainerTest {
     }
 
     @Test
-    void getRow() {
-        var row0 = new NativeTableRow();
-        var row1 = new NativeTableRow();
-        var row2 = new NativeTableRow();
-        container.addRows(row0, row1, row2);
-        AssertUtils.assertEquals(row0, container.getRow(0).orElseThrow(),
-                "Row 0 does not match");
-        AssertUtils.assertEquals(row1, container.getRow(1).orElseThrow(),
-                "Row 1 does not match");
-        AssertUtils.assertEquals(row2, container.getRow(2).orElseThrow(),
-                "Row 2 does not match");
-    }
-
-    @Test
-    void getNonExistentRow() {
-        container.addRow();
-        assertTrue(container.getRow(0).isPresent());
-        assertTrue(container.getRow(1).isEmpty());
-    }
-
-    @Test
-    void getRowIndex() {
-        for (int i = 0; i < 10; i++) {
-            container.addRow();
-            var row = container.getRow(i).orElseThrow();
-            int rowIndex = container.getRowIndex(row);
-            assertEquals(i, rowIndex);
-        }
-    }
-
-    @Test
     void insertRow() {
         var row0 = new NativeTableRow();
         var row1 = new NativeTableRow();
@@ -116,21 +85,6 @@ class NativeTableRowContainerTest {
         container.addRow();
         container.removeAllRows();
         assertEquals(0, container.getChildren().count());
-    }
-
-    @Test
-    void removeRowByIndex() {
-        var row0 = container.addRow();
-        var row1 = container.addRow();
-        var row2 = container.addRow();
-        container.removeRow(1);
-        assertTrue(row1.getParent().isEmpty());
-        var children = container.getChildren().toList();
-        assertEquals(2, children.size());
-        AssertUtils.assertEquals(row0, children.get(0),
-                "row0 must not be removed");
-        AssertUtils.assertEquals(row2, children.get(1),
-                "row2 must not be removed");
     }
 
     @Test
@@ -161,19 +115,8 @@ class NativeTableRowContainerTest {
         var newRow = new NativeTableRow();
         container.replaceRow(1, newRow);
         assertEquals(3, container.getChildren().count());
-        AssertUtils.assertEquals(newRow, container.getRow(1).orElseThrow(),
+        AssertUtils.assertEquals(newRow, container.getRows().get(1),
                 "Row must be replaced with new row");
-    }
-
-    @Test
-    void getRowCount() {
-        assertEquals(0, container.getRowCount());
-        container.addRow();
-        assertEquals(1, container.getRowCount());
-        container.addRow();
-        assertEquals(2, container.getRowCount());
-        container.removeRow(0);
-        assertEquals(1, container.getRowCount());
     }
 
     @Tag(Tag.TR)

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowTest.java
@@ -16,13 +16,19 @@
 package com.vaadin.flow.component.html;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.vaadin.flow.component.Component;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NativeTableRowTest extends ComponentTest {
     // Actual test methods in super class
@@ -54,14 +60,24 @@ public class NativeTableRowTest extends ComponentTest {
         assertEquals(2, row.getChildren().count());
     }
 
-    @Test
-    void addCells_wrapsOnlyNonCellComponents() {
-        NativeTableRow row = new NativeTableRow();
+    static Stream<Named<Function<Component[], NativeTableRow>>> rowBuilders() {
+        return Stream.of(Named.of("constructor", NativeTableRow::new),
+                Named.of("addCells", components -> {
+                    NativeTableRow row = new NativeTableRow();
+                    row.addCells(components);
+                    return row;
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("rowBuilders")
+    void cellsKeptAsIs_otherComponentsWrappedInDataCell(
+            Function<Component[], NativeTableRow> builder) {
         NativeTableHeaderCell th = new NativeTableHeaderCell("header");
         NativeTableCell td = new NativeTableCell("data");
         Span span = new Span("wrapped");
 
-        row.addCells(th, td, span);
+        NativeTableRow row = builder.apply(new Component[] { th, td, span });
 
         List<Component> children = row.getChildren().toList();
         assertEquals(th, children.get(0));
@@ -69,6 +85,52 @@ public class NativeTableRowTest extends ComponentTest {
         NativeTableCell wrapper = assertInstanceOf(NativeTableCell.class,
                 children.get(2));
         assertEquals(span, wrapper.getChildren().findFirst().orElseThrow());
+    }
+
+    @Test
+    void addEmptyCells_appendThemInCallOrder() {
+        NativeTableRow row = new NativeTableRow();
+
+        NativeTableHeaderCell th = row.addHeaderCell();
+        NativeTableCell td = row.addDataCell();
+
+        assertEquals(List.of(th, td), row.getCells());
+        assertEquals("", th.getText());
+        assertEquals("", td.getText());
+    }
+
+    @Test
+    void insertCells_placeThemAtTheGivenPosition() {
+        NativeTableRow row = new NativeTableRow();
+        NativeTableCell first = row.addDataCell("first");
+        NativeTableCell last = row.addDataCell("last");
+
+        NativeTableHeaderCell header = row.insertHeaderCell(1);
+        NativeTableCell middle = row.insertDataCell(2);
+
+        assertEquals(List.of(first, header, middle, last), row.getCells());
+    }
+
+    @Test
+    void getCells_returnsHeaderAndDataCellsInDocumentOrder() {
+        NativeTableRow row = new NativeTableRow();
+        NativeTableHeaderCell th = row.addHeaderCell("header");
+        NativeTableCell td = row.addDataCell("data");
+        row.add(new Span("not a cell"));
+
+        assertEquals(List.of(th, td), row.getCells());
+    }
+
+    @Test
+    void removeCell_detachesCellFromRow() {
+        NativeTableRow row = new NativeTableRow();
+        NativeTableHeaderCell th = row.addHeaderCell("header");
+        NativeTableCell td = row.addDataCell("data");
+
+        row.removeCell(th);
+
+        assertEquals(List.of(td), row.getCells());
+        assertTrue(th.getParent().isEmpty());
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowTest.java
@@ -15,6 +15,15 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
 public class NativeTableRowTest extends ComponentTest {
     // Actual test methods in super class
 
@@ -22,4 +31,44 @@ public class NativeTableRowTest extends ComponentTest {
     protected void addProperties() {
         // Component defines no new properties
     }
+
+    @Test
+    void addDataCells_appendsOneTdPerText() {
+        NativeTableRow row = new NativeTableRow();
+        assertEquals(row, row.addDataCells("a", "b"));
+
+        List<NativeTableCell> cells = row.getDataCells();
+        assertEquals(List.of("a", "b"),
+                cells.stream().map(NativeTableCell::getText).toList());
+        assertEquals(2, row.getChildren().count());
+    }
+
+    @Test
+    void addHeaderCells_appendsOneThPerText() {
+        NativeTableRow row = new NativeTableRow();
+        assertEquals(row, row.addHeaderCells("a", "b"));
+
+        List<NativeTableHeaderCell> cells = row.getHeaderCells();
+        assertEquals(List.of("a", "b"),
+                cells.stream().map(NativeTableHeaderCell::getText).toList());
+        assertEquals(2, row.getChildren().count());
+    }
+
+    @Test
+    void addCells_wrapsOnlyNonCellComponents() {
+        NativeTableRow row = new NativeTableRow();
+        NativeTableHeaderCell th = new NativeTableHeaderCell("header");
+        NativeTableCell td = new NativeTableCell("data");
+        Span span = new Span("wrapped");
+
+        row.addCells(th, td, span);
+
+        List<Component> children = row.getChildren().toList();
+        assertEquals(th, children.get(0));
+        assertEquals(td, children.get(1));
+        NativeTableCell wrapper = assertInstanceOf(NativeTableCell.class,
+                children.get(2));
+        assertEquals(span, wrapper.getChildren().findFirst().orElseThrow());
+    }
+
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowTest.java
@@ -71,4 +71,15 @@ public class NativeTableRowTest extends ComponentTest {
         assertEquals(span, wrapper.getChildren().findFirst().orElseThrow());
     }
 
+    @Test
+    void addRowHeaderCell_setsRowScope() {
+        NativeTableRow row = new NativeTableRow();
+
+        NativeTableHeaderCell cell = row.addRowHeaderCell("Breed");
+
+        assertEquals("Breed", cell.getText());
+        assertEquals(java.util.Optional.of(NativeTableHeaderCell.Scope.ROW),
+                cell.getScope());
+    }
+
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
@@ -249,4 +249,52 @@ class NativeTableTest extends ComponentTest {
         assertTrue(body2.getParent().isPresent());
     }
 
+    @Test
+    void childrenGivenToConstructor_areFoundByAccessors() {
+        var head = new NativeTableHeader();
+        var body = new NativeTableBody();
+        var table = new NativeTable(head, body);
+
+        assertEquals(head, table.getHead(), "Head given to the constructor "
+                + "should be returned instead of a new one being created");
+        assertEquals(List.of(body), table.getBodies());
+        assertEquals(2, table.getChildren().count(),
+                "No extra section should have been created");
+    }
+
+    @Test
+    void sectionAddedWithAdd_isFoundByAccessors() {
+        var component = (NativeTable) getComponent();
+        var body = new NativeTableBody();
+        component.add(body);
+
+        assertEquals(List.of(body), component.getBodies());
+        assertEquals(body, component.getBody());
+        assertEquals(1, component.getChildren().count(),
+                "No extra body should have been created");
+    }
+
+    @Test
+    void removeAll_thenGetHead_returnsAnAttachedHead() {
+        var component = (NativeTable) getComponent();
+        component.getHead();
+        component.removeAll();
+
+        var head = component.getHead();
+        assertTrue(head.getParent().isPresent(),
+                "Head returned after removeAll must be attached to the table");
+        assertEquals(1, component.getChildren().count());
+    }
+
+    @Test
+    void sectionRemovedWithRemove_thenGetFoot_returnsAnAttachedFoot() {
+        var component = (NativeTable) getComponent();
+        component.remove(component.getFoot());
+
+        var foot = component.getFoot();
+        assertTrue(foot.getParent().isPresent(),
+                "Foot returned after remove must be attached to the table");
+        assertEquals(1, component.getChildren().count());
+    }
+
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NativeTableTest extends ComponentTest {
@@ -79,6 +78,14 @@ class NativeTableTest extends ComponentTest {
         var caption = component.getCaption();
         caption.setText(expectedText);
         assertEquals(expectedText, component.getCaptionText());
+    }
+
+    @Test
+    void getCaptionText_withoutCaption_isEmptyAndCreatesNothing() {
+        var component = (NativeTable) getComponent();
+
+        assertEquals("", component.getCaptionText());
+        assertEquals(0, component.getChildren().count());
     }
 
     @Test
@@ -182,24 +189,6 @@ class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    void getBodyByIndex() {
-        var component = (NativeTable) getComponent();
-        var body = component.getBody(0);
-        assertEquals(1, component.getChildren().count());
-        var secondCallBody = component.getBody(0);
-        assertEquals(1, component.getChildren().count());
-        AssertUtils.assertEquals(body, secondCallBody,
-                "No new body should've been created");
-    }
-
-    @Test
-    void getNonExistentBodyByIndex() {
-        var component = (NativeTable) getComponent();
-        assertThrows(IndexOutOfBoundsException.class,
-                () -> component.getBody(1));
-    }
-
-    @Test
     void getBodies() {
         var component = (NativeTable) getComponent();
         for (int i = 0; i < 10; i++) {
@@ -210,31 +199,6 @@ class NativeTableTest extends ComponentTest {
             AssertUtils.assertEquals(component, body.getParent().orElseThrow(),
                     "Body is not a child of table");
         }
-    }
-
-    @Test
-    void removeBody() {
-        var component = (NativeTable) getComponent();
-        for (int i = 0; i < 10; i++) {
-            component.addBody();
-        }
-        var bodies = component.getBodies();
-        for (int i = 0; i < 10; i++) {
-            component.removeBody();
-            assertTrue(bodies.get(i).getParent().isEmpty());
-        }
-    }
-
-    @Test
-    void removeBodyByIndex() {
-        var component = (NativeTable) getComponent();
-        var body0 = component.addBody();
-        var body1 = component.addBody();
-        var body2 = component.addBody();
-        component.removeBody(1);
-        assertTrue(body0.getParent().isPresent());
-        assertTrue(body1.getParent().isEmpty());
-        assertTrue(body2.getParent().isPresent());
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
@@ -297,4 +297,77 @@ class NativeTableTest extends ComponentTest {
         assertEquals(1, component.getChildren().count());
     }
 
+    @Test
+    void addColumnGroup_insertedAfterCaptionBeforeHead() {
+        var table = (NativeTable) getComponent();
+        table.getCaption();
+        table.getHead();
+        var group = table.addColumnGroup();
+        var children = table.getChildren().toList();
+        assertEquals(table.getCaption(), children.get(0));
+        assertEquals(group, children.get(1));
+        assertEquals(table.getHead(), children.get(2));
+    }
+
+    @Test
+    void addColumnGroup_beforeHeadEvenIfHeadAddedLater() {
+        var table = (NativeTable) getComponent();
+        var group = table.addColumnGroup();
+        var head = table.getHead();
+        var children = table.getChildren().toList();
+        assertEquals(group, children.get(0));
+        assertEquals(head, children.get(1));
+    }
+
+    @Test
+    void addColumnGroup_withColumns() {
+        var table = (NativeTable) getComponent();
+        var group = table.addColumnGroup(new NativeTableColumn(),
+                new NativeTableColumn(2));
+        assertEquals(2, group.getColumns().size());
+        assertEquals(List.of(group), table.getColumnGroups());
+    }
+
+    @Test
+    void multipleColumnGroups_appearInInsertionOrder() {
+        var table = (NativeTable) getComponent();
+        var g1 = table.addColumnGroup();
+        var g2 = table.addColumnGroup();
+        var children = table.getChildren().toList();
+        assertEquals(g1, children.get(0));
+        assertEquals(g2, children.get(1));
+    }
+
+    @Test
+    void removeColumnGroup() {
+        var table = (NativeTable) getComponent();
+        var g1 = table.addColumnGroup();
+        var g2 = table.addColumnGroup();
+        table.removeColumnGroup(g1);
+        assertEquals(List.of(g2), table.getColumnGroups());
+        assertTrue(g1.getParent().isEmpty());
+    }
+
+    @Test
+    void addBody_afterCaptionColumnGroupsAndHead() {
+        // caption + 2 colgroups + thead -> tbody must land at index 4
+        var table = (NativeTable) getComponent();
+        table.setCaptionText("x");
+        table.addColumnGroup();
+        table.addColumnGroup();
+        table.getHead();
+        var body = table.addBody();
+        assertEquals(4, table.getChildren().toList().indexOf(body));
+    }
+
+    @Test
+    void addBody_beforeFoot() {
+        var table = (NativeTable) getComponent();
+        var foot = table.getFoot();
+        var body = table.addBody();
+        var children = table.getChildren().toList();
+        assertEquals(body, children.get(0));
+        assertEquals(foot, children.get(1));
+    }
+
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
@@ -370,4 +370,61 @@ class NativeTableTest extends ComponentTest {
         assertEquals(foot, children.get(1));
     }
 
+    @Test
+    void addRow_withTexts_addsDataCellRowToBody() {
+        var table = (NativeTable) getComponent();
+        var row = table.addRow("a", "b");
+
+        assertEquals(List.of(row), table.getBody().getRows());
+        assertEquals(List.of("a", "b"), row.getDataCells().stream()
+                .map(NativeTableCell::getText).toList());
+    }
+
+    @Test
+    void addHeaderRow_withTexts_addsHeaderCellRowToHead() {
+        var table = (NativeTable) getComponent();
+        var row = table.addHeaderRow("a", "b");
+
+        assertEquals(List.of(row), table.getHead().getRows());
+        assertEquals(List.of("a", "b"), row.getHeaderCells().stream()
+                .map(NativeTableHeaderCell::getText).toList());
+    }
+
+    @Test
+    void addFooterRow_withTexts_addsDataCellRowToFoot() {
+        var table = (NativeTable) getComponent();
+        var row = table.addFooterRow("a", "b");
+
+        assertEquals(List.of(row), table.getFoot().getRows());
+        assertEquals(List.of("a", "b"), row.getDataCells().stream()
+                .map(NativeTableCell::getText).toList());
+    }
+
+    @Test
+    void getRows_returnsHeadThenBodiesThenFootRows() {
+        var table = (NativeTable) getComponent();
+        // Added out of document order to show the result follows the table,
+        // not the calls.
+        var footRow = table.addFooterRow();
+        var bodyRow = table.addRow();
+        var headRow = table.addHeaderRow();
+        var secondBodyRow = table.addBody().addRow();
+
+        assertEquals(List.of(headRow, bodyRow, secondBodyRow, footRow),
+                table.getRows());
+    }
+
+    @Test
+    void removeAllRows_keepsTheSections() {
+        var table = (NativeTable) getComponent();
+        table.addHeaderRow();
+        table.addRow();
+        table.addFooterRow();
+
+        table.removeAllRows();
+
+        assertTrue(table.getRows().isEmpty());
+        assertEquals(3, table.getChildren().count());
+    }
+
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
@@ -427,4 +427,16 @@ class NativeTableTest extends ComponentTest {
         assertEquals(3, table.getChildren().count());
     }
 
+    @Test
+    void addCaption_appendsToTheCaptionAndCreatesItIfMissing() {
+        var table = (NativeTable) getComponent();
+        var span = new Span("rich");
+
+        var caption = table.addCaption(span);
+
+        assertEquals(table.getCaption(), caption);
+        assertEquals(span, caption.getChildren().findFirst().orElseThrow());
+        assertEquals(caption, table.getChildren().findFirst().orElseThrow());
+    }
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -812,6 +812,45 @@ public class ComponentUtil {
     }
 
     /**
+     * Gets the child components of the given parent that are instances of the
+     * given type, in child order.
+     * <p>
+     * Useful for components whose children have a known structure, such as the
+     * rows of a table or the items of a list, where the child of interest is
+     * identified by its type rather than by its position.
+     *
+     * @param <T>
+     *            the child component type
+     * @param parent
+     *            the parent component from which to get the child components
+     * @param type
+     *            the type the children must be instances of
+     * @return the children of the given type, in child order
+     */
+    public static <T extends Component> Stream<T> getChildrenOfType(
+            Component parent, Class<T> type) {
+        return parent.getChildren().filter(type::isInstance).map(type::cast);
+    }
+
+    /**
+     * Gets the first child component of the given parent that is an instance of
+     * the given type.
+     *
+     * @param <T>
+     *            the child component type
+     * @param parent
+     *            the parent component from which to get the child component
+     * @param type
+     *            the type the child must be an instance of
+     * @return the first child of the given type, or an empty optional if the
+     *         parent has no such child
+     */
+    public static <T extends Component> Optional<T> getFirstChildOfType(
+            Component parent, Class<T> type) {
+        return getChildrenOfType(parent, type).findFirst();
+    }
+
+    /**
      * Resolves the id of {@code targetComponent} lazily, as described in
      * {@link #resolveOrGenerateIdLater(Element, Component, String, SerializableSupplier, SerializableConsumer)},
      * but without a getter for the current value, so the resolution cannot

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
@@ -146,6 +146,36 @@ class ComponentUtilTest {
     }
 
     @Test
+    void getChildrenOfType_returnsMatchingChildrenInOrder() {
+        // parent
+        // ├── div1 (TestDiv)
+        // ├── span (TestComponent)
+        // └── div2 (TestDiv)
+        TestComponent parent = new TestComponent(ElementFactory.createDiv());
+        TestDiv div1 = new TestDiv();
+        TestComponent span = new TestComponent(ElementFactory.createSpan());
+        TestDiv div2 = new TestDiv();
+        parent.getElement().appendChild(div1.getElement(), span.getElement(),
+                div2.getElement());
+
+        assertEquals(List.of(div1, div2),
+                ComponentUtil.getChildrenOfType(parent, TestDiv.class).toList(),
+                "Only the children of the given type must be returned, in child order");
+        assertEquals(Optional.of(div1),
+                ComponentUtil.getFirstChildOfType(parent, TestDiv.class));
+    }
+
+    @Test
+    void getFirstChildOfType_withNoMatchingChild_returnsEmpty() {
+        TestComponent parent = new TestComponent(ElementFactory.createDiv());
+        parent.getElement().appendChild(
+                new TestComponent(ElementFactory.createSpan()).getElement());
+
+        assertEquals(Optional.empty(),
+                ComponentUtil.getFirstChildOfType(parent, TestDiv.class));
+    }
+
+    @Test
     void getAllChildren_includesVirtualChildren() {
         // parent
         // ├── regular (direct DOM child)

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -19,10 +19,8 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.NativeTable;
-import com.vaadin.flow.component.html.NativeTableCell;
 import com.vaadin.flow.component.html.NativeTableColumn;
 import com.vaadin.flow.component.html.NativeTableColumnGroup;
-import com.vaadin.flow.component.html.NativeTableHeaderCell;
 import com.vaadin.flow.component.html.NativeTableRow;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
@@ -32,8 +30,9 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * Replicates the examples from the MDN "HTML table basics" tutorial:
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
- * Only the {@code <colgroup>}/{@code <col>} example is present so far; the
- * remaining examples need table API that does not exist yet.
+ * The examples are added as the table API they need becomes available; the ones
+ * still missing need {@code scope}, {@code colspan} on <code>&lt;th&gt;</code>
+ * and caption content API.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
 public class HtmlTableTutorialView extends Div {
@@ -74,10 +73,24 @@ public class HtmlTableTutorialView extends Div {
 
         add(new H2("HTML table basics — examples from MDN"));
 
+        add(new H3("1. Basic table with rows and cells"));
+        BasicTable basic = new BasicTable();
+        basic.setId("basic-table");
+        add(basic);
+
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
         timetable.setId("school-timetable");
         add(timetable);
+    }
+
+    /** Example 1: minimal 2-row, 4-column table — no header. */
+    static class BasicTable extends NativeTable {
+        {
+            addRow("Hi, I'm your first cell.", "I'm your second cell.",
+                    "I'm your third cell.", "I'm your fourth cell.");
+            addRow("Second row, first cell.", "Cell 2.", "Cell 3.", "Cell 4.");
+        }
     }
 
     /**
@@ -99,7 +112,7 @@ public class HtmlTableTutorialView extends Div {
 
             NativeTableRow header = addRow();
             header.addDataCell();
-            addHeaderCells(header, "Mon", "Tues", "Wed", "Thurs", "Fri", "Sat",
+            header.addHeaderCells("Mon", "Tues", "Wed", "Thurs", "Fri", "Sat",
                     "Sun");
 
             addPeriodRow("1st period", "English", "", "", "German", "Dutch", "",
@@ -114,42 +127,10 @@ public class HtmlTableTutorialView extends Div {
 
         private void addPeriodRow(String period, String... days) {
             NativeTableRow row = addRow();
-            addHeaderCells(row, period);
-            addDataCells(row, days);
-        }
-
-        /**
-         * Appends a row to the table body.
-         * <p>
-         * Stands in for {@code NativeTable.addRow()}.
-         */
-        private NativeTableRow addRow() {
-            return getBody().addRow();
-        }
-
-        /**
-         * Appends a header cell per text.
-         * <p>
-         * Stands in for {@code NativeTableRow.addHeaderCells(String...)}. The
-         * MDN example also gives these cells a {@code scope}, which needs
-         * {@code NativeTableHeaderCell.setScope}.
-         */
-        private static void addHeaderCells(NativeTableRow row,
-                String... texts) {
-            for (String text : texts) {
-                row.add(new NativeTableHeaderCell(text));
-            }
-        }
-
-        /**
-         * Appends a data cell per text.
-         * <p>
-         * Stands in for {@code NativeTableRow.addDataCells(String...)}.
-         */
-        private static void addDataCells(NativeTableRow row, String... texts) {
-            for (String text : texts) {
-                row.add(new NativeTableCell(text));
-            }
+            // The MDN example also gives this cell scope="row", which needs
+            // NativeTableHeaderCell.setScope.
+            row.addHeaderCell(period);
+            row.addDataCells(days);
         }
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.NativeTable;
 import com.vaadin.flow.component.html.NativeTableColumn;
 import com.vaadin.flow.component.html.NativeTableColumnGroup;
+import com.vaadin.flow.component.html.NativeTableHeaderCell.Scope;
 import com.vaadin.flow.component.html.NativeTableRow;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
@@ -31,7 +32,7 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
  * The examples are added as the table API they need becomes available; the ones
- * still missing need {@code scope}, {@code colspan} on <code>&lt;th&gt;</code>
+ * still missing need {@code colspan}/{@code rowspan} on <code>&lt;th&gt;</code>
  * and caption content API.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
@@ -78,6 +79,11 @@ public class HtmlTableTutorialView extends Div {
         basic.setId("basic-table");
         add(basic);
 
+        add(new H3("2. Adding headers with <th>"));
+        DogsTable dogs = new DogsTable();
+        dogs.setId("dogs-table");
+        add(dogs);
+
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
         timetable.setId("school-timetable");
@@ -90,6 +96,32 @@ public class HtmlTableTutorialView extends Div {
             addRow("Hi, I'm your first cell.", "I'm your second cell.",
                     "I'm your third cell.", "I'm your fourth cell.");
             addRow("Second row, first cell.", "Cell 2.", "Cell 3.", "Cell 4.");
+        }
+    }
+
+    /** Example 2: row-headers and column-headers in the same table. */
+    static class DogsTable extends NativeTable {
+        {
+            NativeTableRow headerRow = addRow();
+            headerRow.addDataCell();
+            for (String name : new String[] { "Knocky", "Flor", "Ella",
+                    "Juan" }) {
+                headerRow.addHeaderCell(name).setScope(Scope.COL);
+            }
+            addRowWithRowHeader("Breed", "Jack Russell", "Poodle", "Streetdog",
+                    "Cocker Spaniel");
+            addRowWithRowHeader("Age", "16", "9", "10", "5");
+            addRowWithRowHeader("Owner", "Mother-in-law", "Me", "Me",
+                    "Sister-in-law");
+            addRowWithRowHeader("Eating habits", "Eats everyone's leftovers",
+                    "Nibbles at food", "Hearty eater",
+                    "Will eat till he explodes");
+        }
+
+        private void addRowWithRowHeader(String header, String... data) {
+            NativeTableRow row = addRow();
+            row.addHeaderCell(header).setScope(Scope.ROW);
+            row.addDataCells(data);
         }
     }
 
@@ -127,9 +159,7 @@ public class HtmlTableTutorialView extends Div {
 
         private void addPeriodRow(String period, String... days) {
             NativeTableRow row = addRow();
-            // The MDN example also gives this cell scope="row", which needs
-            // NativeTableHeaderCell.setScope.
-            row.addHeaderCell(period);
+            row.addHeaderCell(period).setScope(Scope.ROW);
             row.addDataCells(days);
         }
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.NativeTable;
+import com.vaadin.flow.component.html.NativeTableCell;
+import com.vaadin.flow.component.html.NativeTableColumn;
+import com.vaadin.flow.component.html.NativeTableColumnGroup;
+import com.vaadin.flow.component.html.NativeTableHeaderCell;
+import com.vaadin.flow.component.html.NativeTableRow;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Replicates the examples from the MDN "HTML table basics" tutorial:
+ * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
+ * <p>
+ * Only the {@code <colgroup>}/{@code <col>} example is present so far; the
+ * remaining examples need table API that does not exist yet.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
+public class HtmlTableTutorialView extends Div {
+
+    public HtmlTableTutorialView() {
+        Element style = new Element("style");
+        style.setText("""
+                table {
+                  border-collapse: collapse;
+                  border: 2px solid rgb(200 200 200);
+                  letter-spacing: 1px;
+                  font-size: 0.8rem;
+                }
+
+                td,
+                th {
+                  border: 1px solid rgb(190 190 190);
+                  padding: 10px 20px;
+                }
+
+                td {
+                  text-align: center;
+                }
+                .column-background {
+                  background-color: #97db9a;
+                }
+
+                .column-fixed-width {
+                  width: 40px;
+                }
+
+                .column-background-border {
+                  background-color: #dcc48e;
+                  border: 4px solid #c1437a;
+                }
+                """);
+        getElement().appendChild(style);
+
+        add(new H2("HTML table basics — examples from MDN"));
+
+        add(new H3("5. School timetable styled with <colgroup>/<col>"));
+        SchoolTimetable timetable = new SchoolTimetable();
+        timetable.setId("school-timetable");
+        add(timetable);
+    }
+
+    /**
+     * Example 5: school timetable, demonstrating column-level styling via
+     * {@code <colgroup>}/{@code <col>}.
+     */
+    static class SchoolTimetable extends NativeTable {
+        {
+            // Mirrors the MDN colgroup: 2 plain cols, then a sequence of styled
+            // cols, ending with a 2-col fixed-width group on the right.
+            NativeTableColumnGroup group = addColumnGroup();
+            group.addColumn(2);
+            group.addColumn().addClassName("column-background");
+            group.addColumn().addClassName("column-fixed-width");
+            group.addColumn().addClassName("column-background");
+            group.addColumn().addClassName("column-background-border");
+            NativeTableColumn rightPair = group.addColumn(2);
+            rightPair.addClassName("column-fixed-width");
+
+            NativeTableRow header = addRow();
+            header.addDataCell();
+            addHeaderCells(header, "Mon", "Tues", "Wed", "Thurs", "Fri", "Sat",
+                    "Sun");
+
+            addPeriodRow("1st period", "English", "", "", "German", "Dutch", "",
+                    "");
+            addPeriodRow("2nd period", "English", "English", "", "German",
+                    "Dutch", "", "");
+            addPeriodRow("3rd period", "", "German", "German", "", "Dutch", "",
+                    "");
+            addPeriodRow("4th period", "", "English", "English", "", "Dutch",
+                    "", "");
+        }
+
+        private void addPeriodRow(String period, String... days) {
+            NativeTableRow row = addRow();
+            addHeaderCells(row, period);
+            addDataCells(row, days);
+        }
+
+        /**
+         * Appends a row to the table body.
+         * <p>
+         * Stands in for {@code NativeTable.addRow()}.
+         */
+        private NativeTableRow addRow() {
+            return getBody().addRow();
+        }
+
+        /**
+         * Appends a header cell per text.
+         * <p>
+         * Stands in for {@code NativeTableRow.addHeaderCells(String...)}. The
+         * MDN example also gives these cells a {@code scope}, which needs
+         * {@code NativeTableHeaderCell.setScope}.
+         */
+        private static void addHeaderCells(NativeTableRow row,
+                String... texts) {
+            for (String text : texts) {
+                row.add(new NativeTableHeaderCell(text));
+            }
+        }
+
+        /**
+         * Appends a data cell per text.
+         * <p>
+         * Stands in for {@code NativeTableRow.addDataCells(String...)}.
+         */
+        private static void addDataCells(NativeTableRow row, String... texts) {
+            for (String text : texts) {
+                row.add(new NativeTableCell(text));
+            }
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.NativeTable;
 import com.vaadin.flow.component.html.NativeTableColumn;
 import com.vaadin.flow.component.html.NativeTableColumnGroup;
+import com.vaadin.flow.component.html.NativeTableHeaderCell;
 import com.vaadin.flow.component.html.NativeTableHeaderCell.Scope;
 import com.vaadin.flow.component.html.NativeTableRow;
 import com.vaadin.flow.dom.Element;
@@ -31,9 +32,8 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * Replicates the examples from the MDN "HTML table basics" tutorial:
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
- * The examples are added as the table API they need becomes available; the ones
- * still missing need {@code colspan}/{@code rowspan} on <code>&lt;th&gt;</code>
- * and caption content API.
+ * The examples are added as the table API they need becomes available; the one
+ * still missing needs caption content API.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
 public class HtmlTableTutorialView extends Div {
@@ -84,6 +84,11 @@ public class HtmlTableTutorialView extends Div {
         dogs.setId("dogs-table");
         add(dogs);
 
+        add(new H3("3. Allowing cells to span multiple rows and columns"));
+        AnimalsTable animals = new AnimalsTable();
+        animals.setId("animals-table");
+        add(animals);
+
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
         timetable.setId("school-timetable");
@@ -122,6 +127,31 @@ public class HtmlTableTutorialView extends Div {
             NativeTableRow row = addRow();
             row.addHeaderCell(header).setScope(Scope.ROW);
             row.addDataCells(data);
+        }
+    }
+
+    /** Example 3: colspan / rowspan on both {@code <td>} and {@code <th>}. */
+    static class AnimalsTable extends NativeTable {
+        {
+            addRow().addHeaderCell("Animals").setColspan(2);
+            addRow().addHeaderCell("Hippopotamus").setColspan(2);
+
+            NativeTableRow horseRow = addRow();
+            NativeTableHeaderCell horse = horseRow.addHeaderCell("Horse");
+            horse.setScope(Scope.ROW);
+            horse.setRowspan(2);
+            horseRow.addDataCell("Mare");
+            addRow("Stallion");
+
+            addRow().addHeaderCell("Crocodile").setColspan(2);
+
+            NativeTableRow chickenRow = addRow();
+            NativeTableHeaderCell chicken = chickenRow
+                    .addHeaderCell("Chicken");
+            chicken.setScope(Scope.ROW);
+            chicken.setRowspan(2);
+            chickenRow.addDataCell("Hen");
+            addRow("Rooster");
         }
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialView.java
@@ -15,12 +15,14 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.NativeTable;
 import com.vaadin.flow.component.html.NativeTableColumn;
 import com.vaadin.flow.component.html.NativeTableColumnGroup;
+import com.vaadin.flow.component.html.NativeTableHeader;
 import com.vaadin.flow.component.html.NativeTableHeaderCell;
 import com.vaadin.flow.component.html.NativeTableHeaderCell.Scope;
 import com.vaadin.flow.component.html.NativeTableRow;
@@ -32,8 +34,7 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
  * Replicates the examples from the MDN "HTML table basics" tutorial:
  * https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics
  * <p>
- * The examples are added as the table API they need becomes available; the one
- * still missing needs caption content API.
+ * All five examples are present.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.HtmlTableTutorialView", layout = ViewTestLayout.class)
 public class HtmlTableTutorialView extends Div {
@@ -88,6 +89,11 @@ public class HtmlTableTutorialView extends Div {
         AnimalsTable animals = new AnimalsTable();
         animals.setId("animals-table");
         add(animals);
+
+        add(new H3("4. Adding a caption with <caption>, plus <thead>/<tbody>"));
+        PlanetsTable planets = new PlanetsTable();
+        planets.setId("planets-table");
+        add(planets);
 
         add(new H3("5. School timetable styled with <colgroup>/<col>"));
         SchoolTimetable timetable = new SchoolTimetable();
@@ -152,6 +158,113 @@ public class HtmlTableTutorialView extends Div {
             chicken.setRowspan(2);
             chickenRow.addDataCell("Hen");
             addRow("Rooster");
+        }
+    }
+
+    /** Example 4: planet data with caption, thead and rowgroup spans. */
+    static class PlanetsTable extends NativeTable {
+        {
+            addCaption(new Html("<span>Data about the planets of our solar"
+                    + " system (Source: <a href=\"https://nssdc.gsfc.nasa.gov/"
+                    + "planetary/factsheet/\">Nasa's Planetary Fact Sheet -"
+                    + " Metric</a>).</span>"));
+
+            NativeTableHeader head = getHead();
+            NativeTableRow headerRow = head.addRow();
+            headerRow.addDataCell().setColspan(2);
+            addColHeader(headerRow, new Html("<span>Name</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Mass (10<sup>24</sup>kg)</span>"));
+            addColHeader(headerRow, new Html("<span>Diameter (km)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Density (kg/m<sup>3</sup>)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Gravity (m/s<sup>2</sup>)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Length of day (hours)</span>"));
+            addColHeader(headerRow, new Html(
+                    "<span>Distance from Sun (10<sup>6</sup>km)</span>"));
+            addColHeader(headerRow,
+                    new Html("<span>Mean temperature (\u00b0C)</span>"));
+            addColHeader(headerRow, new Html("<span>Number of moons</span>"));
+            addColHeader(headerRow, new Html("<span>Notes</span>"));
+
+            NativeTableRow mercury = addRow();
+            NativeTableHeaderCell terrestrial = mercury
+                    .addHeaderCell("Terrestrial planets");
+            terrestrial.setScope(Scope.ROWGROUP);
+            terrestrial.setColspan(2);
+            terrestrial.setRowspan(4);
+            addRowHeader(mercury, "Mercury");
+            mercury.addDataCells("0.330", "4,879", "5427", "3.7", "4222.6",
+                    "57.9", "167", "0", "Closest to the Sun");
+
+            NativeTableRow venus = addRow();
+            addRowHeader(venus, "Venus");
+            venus.addDataCells("4.87", "12,104", "5243", "8.9", "2802.0",
+                    "108.2", "464", "0", "");
+
+            NativeTableRow earth = addRow();
+            addRowHeader(earth, "Earth");
+            earth.addDataCells("5.97", "12,756", "5514", "9.8", "24.0",
+                    "149.6", "15", "1", "Our world");
+
+            NativeTableRow mars = addRow();
+            addRowHeader(mars, "Mars");
+            mars.addDataCells("0.642", "6,792", "3933", "3.7", "24.7", "227.9",
+                    "-65", "2", "The red planet");
+
+            NativeTableRow jupiter = addRow();
+            NativeTableHeaderCell jovian = jupiter
+                    .addHeaderCell("Jovian planets");
+            jovian.setScope(Scope.ROWGROUP);
+            jovian.setRowspan(4);
+            NativeTableHeaderCell gasGiants = jupiter
+                    .addHeaderCell("Gas giants");
+            gasGiants.setScope(Scope.ROWGROUP);
+            gasGiants.setRowspan(2);
+            addRowHeader(jupiter, "Jupiter");
+            jupiter.addDataCells("1898", "142,984", "1326", "23.1", "9.9",
+                    "778.6", "-110", "67", "The largest planet");
+
+            NativeTableRow saturn = addRow();
+            addRowHeader(saturn, "Saturn");
+            saturn.addDataCells("568", "120,536", "687", "9.0", "10.7",
+                    "1433.5", "-140", "62", "");
+
+            NativeTableRow uranus = addRow();
+            NativeTableHeaderCell iceGiants = uranus
+                    .addHeaderCell("Ice giants");
+            iceGiants.setScope(Scope.ROWGROUP);
+            iceGiants.setRowspan(2);
+            addRowHeader(uranus, "Uranus");
+            uranus.addDataCells("86.8", "51,118", "1271", "8.7", "17.2",
+                    "2872.5", "-195", "27", "");
+
+            NativeTableRow neptune = addRow();
+            addRowHeader(neptune, "Neptune");
+            neptune.addDataCells("102", "49,528", "1638", "11.0", "16.1",
+                    "4495.1", "-200", "14", "");
+
+            NativeTableRow pluto = addRow();
+            NativeTableHeaderCell dwarf = pluto
+                    .addHeaderCell("Dwarf planets");
+            dwarf.setScope(Scope.ROWGROUP);
+            dwarf.setColspan(2);
+            addRowHeader(pluto, "Pluto");
+            pluto.addDataCells("0.0146", "2,370", "2095", "0.7", "153.3",
+                    "5906.4", "-225", "5", "Declassified as a planet in 2006,"
+                            + " but this remains controversial.");
+        }
+
+        private static void addColHeader(NativeTableRow row, Html content) {
+            NativeTableHeaderCell th = row.addHeaderCell();
+            th.setScope(Scope.COL);
+            th.add(content);
+        }
+
+        private static void addRowHeader(NativeTableRow row, String text) {
+            row.addRowHeaderCell(text);
         }
     }
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.html.testbench.NativeTableCellElement;
 import com.vaadin.flow.component.html.testbench.NativeTableColumnElement;
 import com.vaadin.flow.component.html.testbench.NativeTableColumnGroupElement;
 import com.vaadin.flow.component.html.testbench.NativeTableElement;
+import com.vaadin.flow.component.html.testbench.NativeTableHeaderCellElement;
 import com.vaadin.flow.component.html.testbench.NativeTableRowElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -64,6 +65,24 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
                 .id("basic-table");
         Assert.assertEquals("tbody",
                 table.getPropertyElement("firstElementChild").getTagName());
+    }
+
+    @Test
+    public void dogsTableHasColumnAndRowScopedHeaders() {
+        NativeTableElement table = $(NativeTableElement.class).id("dogs-table");
+        List<NativeTableRowElement> rows = table.$(NativeTableRowElement.class)
+                .all();
+
+        List<NativeTableHeaderCellElement> columnHeaders = rows.get(0)
+                .$(NativeTableHeaderCellElement.class).all();
+        Assert.assertEquals(4, columnHeaders.size());
+        columnHeaders.forEach(header -> Assert.assertEquals("col",
+                header.getDomAttribute("scope")));
+
+        NativeTableHeaderCellElement rowHeader = rows.get(1)
+                .$(NativeTableHeaderCellElement.class).first();
+        Assert.assertEquals("row", rowHeader.getDomAttribute("scope"));
+        Assert.assertEquals("Breed", rowHeader.getText());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.NativeTableCellElement;
+import com.vaadin.flow.component.html.testbench.NativeTableColumnElement;
+import com.vaadin.flow.component.html.testbench.NativeTableColumnGroupElement;
+import com.vaadin.flow.component.html.testbench.NativeTableElement;
+import com.vaadin.flow.component.html.testbench.NativeTableRowElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class HtmlTableTutorialIT extends ChromeBrowserTest {
+
+    private static final String BACKGROUND = "rgba(151, 219, 154, 1)";
+    private static final String BACKGROUND_BORDER = "rgba(220, 196, 142, 1)";
+    private static final String TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+    private NativeTableElement timetable;
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        open();
+        timetable = $(NativeTableElement.class).id("school-timetable");
+    }
+
+    @Test
+    public void colgroupRendered_withColumnsInDocumentOrder() {
+        List<NativeTableColumnGroupElement> groups = timetable
+                .$(NativeTableColumnGroupElement.class).all();
+        Assert.assertEquals(1, groups.size());
+
+        List<NativeTableColumnElement> columns = groups.get(0).getColumns();
+        Assert.assertEquals(6, columns.size());
+        Assert.assertEquals(2, columns.get(0).getSpan());
+        Assert.assertEquals(1, columns.get(1).getSpan());
+        Assert.assertEquals(2, columns.get(5).getSpan());
+    }
+
+    @Test
+    public void colgroupIsFirstChildOfTable() {
+        Assert.assertEquals("colgroup",
+                timetable.getPropertyElement("firstElementChild").getTagName());
+    }
+
+    @Test
+    public void columnsCarryTheStylingClasses() {
+        List<NativeTableColumnElement> columns = columns();
+
+        Assert.assertNull(columns.get(0).getDomAttribute("class"));
+        Assert.assertEquals("column-background",
+                columns.get(1).getDomAttribute("class"));
+        Assert.assertEquals("column-fixed-width",
+                columns.get(2).getDomAttribute("class"));
+        Assert.assertEquals("column-background",
+                columns.get(3).getDomAttribute("class"));
+        Assert.assertEquals("column-background-border",
+                columns.get(4).getDomAttribute("class"));
+        Assert.assertEquals("column-fixed-width",
+                columns.get(5).getDomAttribute("class"));
+    }
+
+    @Test
+    public void columnStylesResolveInTheBrowser() {
+        // A <col> paints behind the cells of its column, so the styling has to
+        // be read off the <col> itself rather than off the <td> elements.
+        List<NativeTableColumnElement> columns = columns();
+
+        Assert.assertEquals(TRANSPARENT,
+                columns.get(0).getCssValue("background-color"));
+        Assert.assertEquals(BACKGROUND,
+                columns.get(1).getCssValue("background-color"));
+        Assert.assertEquals(BACKGROUND_BORDER,
+                columns.get(4).getCssValue("background-color"));
+    }
+
+    @Test
+    public void tableBodyHasOneRowPerPeriodPlusTheHeaderRow() {
+        Assert.assertEquals(5,
+                timetable.$(NativeTableRowElement.class).all().size());
+        Assert.assertEquals(7,
+                firstPeriodRow().$(NativeTableCellElement.class).all().size());
+    }
+
+    private List<NativeTableColumnElement> columns() {
+        return timetable.$(NativeTableColumnGroupElement.class).first()
+                .getColumns();
+    }
+
+    private NativeTableRowElement firstPeriodRow() {
+        // Row 0 is the Mon..Sun header row, row 1 is "1st period".
+        return timetable.$(NativeTableRowElement.class).all().get(1);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -86,6 +86,29 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void animalsTableSpansColumnsAndRowsOnHeaderCells() {
+        NativeTableElement table = $(NativeTableElement.class)
+                .id("animals-table");
+        List<NativeTableRowElement> rows = table.$(NativeTableRowElement.class)
+                .all();
+
+        NativeTableHeaderCellElement animals = rows.get(0)
+                .$(NativeTableHeaderCellElement.class).first();
+        Assert.assertEquals("Animals", animals.getText());
+        Assert.assertEquals("2", animals.getDomAttribute("colspan"));
+
+        NativeTableHeaderCellElement horse = rows.get(2)
+                .$(NativeTableHeaderCellElement.class).first();
+        Assert.assertEquals("Horse", horse.getText());
+        Assert.assertEquals("2", horse.getDomAttribute("rowspan"));
+        Assert.assertEquals("row", horse.getDomAttribute("scope"));
+
+        // The <th rowspan=2> means the following row holds only its own cell.
+        Assert.assertEquals(1,
+                rows.get(3).$(NativeTableCellElement.class).all().size());
+    }
+
+    @Test
     public void colgroupRendered_withColumnsInDocumentOrder() {
         List<NativeTableColumnGroupElement> groups = timetable
                 .$(NativeTableColumnGroupElement.class).all();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -20,11 +20,14 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.html.testbench.NativeTableBodyElement;
+import com.vaadin.flow.component.html.testbench.NativeTableCaptionElement;
 import com.vaadin.flow.component.html.testbench.NativeTableCellElement;
 import com.vaadin.flow.component.html.testbench.NativeTableColumnElement;
 import com.vaadin.flow.component.html.testbench.NativeTableColumnGroupElement;
 import com.vaadin.flow.component.html.testbench.NativeTableElement;
 import com.vaadin.flow.component.html.testbench.NativeTableHeaderCellElement;
+import com.vaadin.flow.component.html.testbench.NativeTableHeaderElement;
 import com.vaadin.flow.component.html.testbench.NativeTableRowElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -106,6 +109,35 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
         // The <th rowspan=2> means the following row holds only its own cell.
         Assert.assertEquals(1,
                 rows.get(3).$(NativeTableCellElement.class).all().size());
+    }
+
+    @Test
+    public void planetsTableHasCaptionAndHeadWithRowgroupSpans() {
+        NativeTableElement table = $(NativeTableElement.class)
+                .id("planets-table");
+
+        NativeTableCaptionElement caption = table
+                .$(NativeTableCaptionElement.class).first();
+        Assert.assertEquals("caption",
+                table.getPropertyElement("firstElementChild").getTagName());
+        Assert.assertTrue(caption.getText()
+                .startsWith("Data about the planets of our solar system"));
+        // The caption holds real markup, not just text.
+        Assert.assertEquals("Nasa's Planetary Fact Sheet - Metric",
+                caption.$("a").first().getText());
+
+        NativeTableHeaderElement head = table.$(NativeTableHeaderElement.class)
+                .first();
+        Assert.assertEquals(10,
+                head.$(NativeTableHeaderCellElement.class).all().size());
+
+        NativeTableHeaderCellElement terrestrial = table
+                .$(NativeTableBodyElement.class).first()
+                .$(NativeTableHeaderCellElement.class).first();
+        Assert.assertEquals("Terrestrial planets", terrestrial.getText());
+        Assert.assertEquals("rowgroup", terrestrial.getDomAttribute("scope"));
+        Assert.assertEquals("4", terrestrial.getDomAttribute("rowspan"));
+        Assert.assertEquals("2", terrestrial.getDomAttribute("colspan"));
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HtmlTableTutorialIT.java
@@ -43,6 +43,30 @@ public class HtmlTableTutorialIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void basicTableRendersRowsAndCells() {
+        NativeTableElement table = $(NativeTableElement.class)
+                .id("basic-table");
+        List<NativeTableRowElement> rows = table.$(NativeTableRowElement.class)
+                .all();
+
+        Assert.assertEquals(2, rows.size());
+        Assert.assertEquals(4,
+                rows.get(0).$(NativeTableCellElement.class).all().size());
+        Assert.assertEquals("Hi, I'm your first cell.",
+                rows.get(0).$(NativeTableCellElement.class).first().getText());
+        Assert.assertEquals("Second row, first cell.",
+                rows.get(1).$(NativeTableCellElement.class).first().getText());
+    }
+
+    @Test
+    public void rowsAddedWithAddRowLandInTheImplicitBody() {
+        NativeTableElement table = $(NativeTableElement.class)
+                .id("basic-table");
+        Assert.assertEquals("tbody",
+                table.getPropertyElement("firstElementChild").getTagName());
+    }
+
+    @Test
     public void colgroupRendered_withColumnsInDocumentOrder() {
         List<NativeTableColumnGroupElement> groups = timetable
                 .$(NativeTableColumnGroupElement.class).all();


### PR DESCRIPTION
Every table component is an HtmlContainer, so HasComponents already provides indexOf, getComponentAt, getComponentCount and remove, and the list-returning getters can be indexed with get(i). The hand-written indexed accessors duplicated that, in some cases with different behaviour for the same operation.

Removed: NativeTable.getBody(int), removeBody(int) and removeBody(); NativeTableRow.getCell(int), getDataCell(int), getHeaderCell(int), removeCell(int), removeDataCell and removeHeaderCell in both overloads; NativeTableRowContainer.getRow(int), getRowIndex, getRowCount and removeRow(int).

getAllCells becomes getCells and returns AbstractNativeTableCell rather than Component, and the two kind-specific cell removals collapse into removeCell(AbstractNativeTableCell).

Two behaviour changes come with it. The section constructors take NativeTableRow instead of Component, since anything else is invalid inside <thead>, <tbody> and <tfoot>. NativeTableRow(Component...) now wraps non-cell components in a <td> the way addCells does, instead of adding them straight into the <tr> where they are not allowed.

getCaptionText no longer creates a <caption> as a side effect of being called; it returns an empty string when the table has none.
