### PR TITLE
feat: List overloads for the table API varargs methods

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -398,6 +398,16 @@ public class Table extends HtmlComponent
     }
 
     /**
+     * List equivalent of {@link #addRows(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addRows(List<? extends TableRow> rows) {
+        getBody().addRows(rows);
+    }
+
+    /**
      * Appends a new empty row to this table's <code>&lt;thead&gt;</code>,
      * creating it if the table has none.
      *
@@ -441,6 +451,16 @@ public class Table extends HtmlComponent
     }
 
     /**
+     * List equivalent of {@link #addHeaderRows(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addHeaderRows(List<? extends TableRow> rows) {
+        getHead().addRows(rows);
+    }
+
+    /**
      * Appends a new empty row to this table's <code>&lt;tfoot&gt;</code>,
      * creating it if the table has none.
      *
@@ -480,6 +500,16 @@ public class Table extends HtmlComponent
      *            the rows to add.
      */
     public void addFooterRows(TableRow... rows) {
+        getFoot().addRows(rows);
+    }
+
+    /**
+     * List equivalent of {@link #addFooterRows(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public void addFooterRows(List<? extends TableRow> rows) {
         getFoot().addRows(rows);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Table.java
@@ -187,6 +187,18 @@ public class Table extends HtmlComponent
     }
 
     /**
+     * List equivalent of {@link #addColumnGroup(TableColumn...)}.
+     *
+     * @param columns
+     *            the columns the new group should hold.
+     * @return the new column group.
+     */
+    public TableColumnGroup addColumnGroup(
+            List<? extends TableColumn> columns) {
+        return addColumnGroup(new TableColumnGroup(columns));
+    }
+
+    /**
      * Returns the column groups of this table, in document order.
      *
      * @return the table's {@code <colgroup>} elements.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableBody.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableBody.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.List;
+
 import org.jspecify.annotations.NullMarked;
 
 import com.vaadin.flow.component.ClickNotifier;
@@ -52,6 +54,17 @@ public class TableBody extends HtmlComponent
      *            the rows to add.
      */
     public TableBody(TableRow... rows) {
+        super();
+        addRows(rows);
+    }
+
+    /**
+     * List equivalent of {@link #TableBody(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public TableBody(List<? extends TableRow> rows) {
         super();
         addRows(rows);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableCell.java
@@ -63,6 +63,16 @@ public abstract class TableCell extends HtmlContainer {
     }
 
     /**
+     * List equivalent of {@link #TableCell(Component...)}.
+     *
+     * @param components
+     *            the children components.
+     */
+    protected TableCell(List<? extends Component> components) {
+        super(components.toArray(Component[]::new));
+    }
+
+    /**
      * Sets the {@code colspan} attribute — how many columns this cell spans.
      * The default is {@code 1}.
      * <p>

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnGroup.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableColumnGroup.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
@@ -68,6 +69,17 @@ public class TableColumnGroup extends HtmlComponent implements TableColumnSpan {
     }
 
     /**
+     * List equivalent of {@link #TableColumnGroup(TableColumn...)}.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public TableColumnGroup(List<? extends TableColumn> columns) {
+        super();
+        addColumns(columns);
+    }
+
+    /**
      * Appends a new empty {@code <col>} child to this group.
      *
      * @return the new column.
@@ -94,9 +106,17 @@ public class TableColumnGroup extends HtmlComponent implements TableColumnSpan {
      *            the columns to add.
      */
     public void addColumns(TableColumn... columns) {
-        for (TableColumn column : columns) {
-            addColumn(column);
-        }
+        addColumns(Arrays.asList(columns));
+    }
+
+    /**
+     * List equivalent of {@link #addColumns(TableColumn...)}.
+     *
+     * @param columns
+     *            the columns to add.
+     */
+    public void addColumns(List<? extends TableColumn> columns) {
+        columns.forEach(this::addColumn);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableDataCell.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.jspecify.annotations.NullMarked;
@@ -52,6 +53,16 @@ public class TableDataCell extends TableCell
      *            the children components.
      */
     public TableDataCell(Component... components) {
+        super(components);
+    }
+
+    /**
+     * List equivalent of {@link #TableDataCell(Component...)}.
+     *
+     * @param components
+     *            the children components.
+     */
+    public TableDataCell(List<? extends Component> components) {
         super(components);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableFoot.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableFoot.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.List;
+
 import org.jspecify.annotations.NullMarked;
 
 import com.vaadin.flow.component.ClickNotifier;
@@ -52,6 +54,17 @@ public class TableFoot extends HtmlComponent
      *            the rows to add.
      */
     public TableFoot(TableRow... rows) {
+        super();
+        addRows(rows);
+    }
+
+    /**
+     * List equivalent of {@link #TableFoot(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public TableFoot(List<? extends TableRow> rows) {
         super();
         addRows(rows);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHead.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHead.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.List;
+
 import org.jspecify.annotations.NullMarked;
 
 import com.vaadin.flow.component.ClickNotifier;
@@ -52,6 +54,17 @@ public class TableHead extends HtmlComponent
      *            the rows to add.
      */
     public TableHead(TableRow... rows) {
+        super();
+        addRows(rows);
+    }
+
+    /**
+     * List equivalent of {@link #TableHead(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to add.
+     */
+    public TableHead(List<? extends TableRow> rows) {
         super();
         addRows(rows);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableHeaderCell.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -54,6 +55,16 @@ public class TableHeaderCell extends TableCell
      *            the children components.
      */
     public TableHeaderCell(Component... components) {
+        super(components);
+    }
+
+    /**
+     * List equivalent of {@link #TableHeaderCell(Component...)}.
+     *
+     * @param components
+     *            the children components.
+     */
+    public TableHeaderCell(List<? extends Component> components) {
         super(components);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRow.java
@@ -63,6 +63,17 @@ public class TableRow extends HtmlComponent implements ClickNotifier<TableRow> {
     }
 
     /**
+     * List equivalent of {@link #TableRow(Component...)}.
+     *
+     * @param components
+     *            the cells, or the content to wrap in cells.
+     */
+    public TableRow(List<? extends Component> components) {
+        super();
+        addCells(components);
+    }
+
+    /**
      * Appends the given components to this row. A {@link TableCell} is added
      * as-is; anything else is wrapped in a new {@link TableDataCell}, since a
      * <code>&lt;tr&gt;</code> may only contain cells.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/TableRowContainer.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.jspecify.annotations.NullMarked;
@@ -66,6 +67,16 @@ interface TableRowContainer extends HasElement {
      *            the rows to append.
      */
     default void addRows(TableRow... rows) {
+        addRows(Arrays.asList(rows));
+    }
+
+    /**
+     * List equivalent of {@link #addRows(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to append.
+     */
+    default void addRows(List<? extends TableRow> rows) {
         for (TableRow row : rows) {
             getElement().appendChild(row.getElement());
         }
@@ -104,6 +115,16 @@ interface TableRowContainer extends HasElement {
      *            the rows to remove.
      */
     default void removeRows(TableRow... rows) {
+        removeRows(Arrays.asList(rows));
+    }
+
+    /**
+     * List equivalent of {@link #removeRows(TableRow...)}.
+     *
+     * @param rows
+     *            the rows to remove.
+     */
+    default void removeRows(List<? extends TableRow> rows) {
         for (TableRow row : rows) {
             getElement().removeChild(row.getElement());
         }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableCellTest.java
@@ -41,19 +41,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TableCellTest extends SignalsUnitTest {
 
-    static Stream<Named<Function<Component[], TableCell>>> childrenConstructors() {
-        return Stream.of(Named.of("td", TableDataCell::new),
-                Named.of("th", TableHeaderCell::new));
+    static Stream<Named<Function<List<Component>, TableCell>>> childrenConstructors() {
+        return Stream.of(
+                Named.of("td varargs",
+                        c -> new TableDataCell(c.toArray(Component[]::new))),
+                Named.of("td list", TableDataCell::new),
+                Named.of("th varargs",
+                        c -> new TableHeaderCell(c.toArray(Component[]::new))),
+                Named.of("th list", TableHeaderCell::new));
     }
 
     @ParameterizedTest
     @MethodSource("childrenConstructors")
     void childrenConstructor_addsGivenChildren(
-            Function<Component[], TableCell> constructor) {
+            Function<List<Component>, TableCell> constructor) {
         Span span = new Span("a");
         Paragraph paragraph = new Paragraph("b");
 
-        TableCell cell = constructor.apply(new Component[] { span, paragraph });
+        TableCell cell = constructor.apply(List.of(span, paragraph));
 
         assertEquals(List.of(span, paragraph), cell.getChildren().toList());
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableColumnGroupTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableColumnGroupTest.java
@@ -16,8 +16,13 @@
 package com.vaadin.flow.component.html;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,14 +51,24 @@ class TableColumnGroupTest extends ComponentTest {
         assertEquals(2, spanning.getSpan());
     }
 
-    @Test
-    void constructorAndAddColumns_attachPreBuiltColumns() {
+    static Stream<Named<Function<List<TableColumn>, TableColumnGroup>>> groupConstructors() {
+        return Stream.of(
+                Named.of("varargs",
+                        c -> new TableColumnGroup(
+                                c.toArray(TableColumn[]::new))),
+                Named.of("list", TableColumnGroup::new));
+    }
+
+    @ParameterizedTest
+    @MethodSource("groupConstructors")
+    void constructorAndAddColumns_attachPreBuiltColumns(
+            Function<List<TableColumn>, TableColumnGroup> constructor) {
         TableColumn first = new TableColumn();
         TableColumn second = new TableColumn(3);
         TableColumn third = new TableColumn();
 
-        TableColumnGroup group = new TableColumnGroup(first, second);
-        group.addColumns(third);
+        TableColumnGroup group = constructor.apply(List.of(first, second));
+        group.addColumns(List.of(third));
 
         assertEquals(List.of(first, second, third), group.getColumns());
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowContainerTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowContainerTest.java
@@ -41,12 +41,15 @@ class TableRowContainerTest {
 
     static Stream<Named<Function<List<TableRow>, TableRowContainer>>> sectionConstructors() {
         return Stream.of(
-                Named.of("thead",
+                Named.of("thead varargs",
                         rows -> new TableHead(rows.toArray(TableRow[]::new))),
-                Named.of("tbody",
+                Named.of("thead list", TableHead::new),
+                Named.of("tbody varargs",
                         rows -> new TableBody(rows.toArray(TableRow[]::new))),
-                Named.of("tfoot",
-                        rows -> new TableFoot(rows.toArray(TableRow[]::new))));
+                Named.of("tbody list", TableBody::new),
+                Named.of("tfoot varargs",
+                        rows -> new TableFoot(rows.toArray(TableRow[]::new))),
+                Named.of("tfoot list", TableFoot::new));
     }
 
     @ParameterizedTest
@@ -127,6 +130,21 @@ class TableRowContainerTest {
         assertEquals(List.of(row1), section.getRows());
         assertTrue(row0.getParent().isEmpty());
         assertTrue(row2.getParent().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("sections")
+    void addAndRemoveRowsWithLists(Supplier<TableRowContainer> factory) {
+        TableRowContainer section = factory.get();
+        TableRow row0 = new TableRow();
+        TableRow row1 = new TableRow();
+        TableRow row2 = new TableRow();
+
+        section.addRows(List.of(row0, row1, row2));
+        assertEquals(List.of(row0, row1, row2), section.getRows());
+
+        section.removeRows(List.of(row0, row2));
+        assertEquals(List.of(row1), section.getRows());
     }
 
     @ParameterizedTest

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowContainerTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowContainerTest.java
@@ -134,21 +134,6 @@ class TableRowContainerTest {
 
     @ParameterizedTest
     @MethodSource("sections")
-    void addAndRemoveRowsWithLists(Supplier<TableRowContainer> factory) {
-        TableRowContainer section = factory.get();
-        TableRow row0 = new TableRow();
-        TableRow row1 = new TableRow();
-        TableRow row2 = new TableRow();
-
-        section.addRows(List.of(row0, row1, row2));
-        assertEquals(List.of(row0, row1, row2), section.getRows());
-
-        section.removeRows(List.of(row0, row2));
-        assertEquals(List.of(row1), section.getRows());
-    }
-
-    @ParameterizedTest
-    @MethodSource("sections")
     void removeAllRows_leavesTheSectionEmpty(
             Supplier<TableRowContainer> factory) {
         TableRowContainer section = factory.get();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableRowTest.java
@@ -16,8 +16,15 @@
 package com.vaadin.flow.component.html;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.vaadin.flow.component.Component;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -57,14 +64,31 @@ class TableRowTest extends ComponentTest {
                 last), row.getCells());
     }
 
-    @Test
-    void constructorAndAddCells_attachPreBuiltCells() {
+    static Stream<Named<Function<List<Component>, TableRow>>> rowBuilders() {
+        return Stream.of(
+                Named.of("varargs constructor",
+                        c -> new TableRow(c.toArray(Component[]::new))),
+                Named.of("list constructor", TableRow::new),
+                Named.of("varargs addCells", c -> {
+                    TableRow row = new TableRow();
+                    row.addCells(c.toArray(Component[]::new));
+                    return row;
+                }), Named.of("list addCells", c -> {
+                    TableRow row = new TableRow();
+                    row.addCells(c);
+                    return row;
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("rowBuilders")
+    void constructorAndAddCells_attachPreBuiltCells(
+            Function<List<Component>, TableRow> builder) {
         TableHeaderCell th = new TableHeaderCell("Name");
         TableDataCell td = new TableDataCell("Mars");
         TableDataCell appended = new TableDataCell(new Span("rich"));
 
-        TableRow row = new TableRow(th, td);
-        row.addCells(appended);
+        TableRow row = builder.apply(List.of(th, td, appended));
 
         assertEquals(List.of(th, td, appended), row.getCells());
         assertEquals("Name", th.getText());

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -178,6 +178,18 @@ class TableTest extends ComponentTest {
     }
 
     @Test
+    void addColumnGroup_listOverloadHoldsTheSameColumns() {
+        Table table = table();
+        var first = new TableColumn(2);
+        var second = new TableColumn();
+
+        var group = table.addColumnGroup(List.of(first, second));
+
+        assertEquals(List.of(group), table.getColumnGroups());
+        assertEquals(List.of(first, second), group.getColumns());
+    }
+
+    @Test
     void removeColumnGroup_detachesOnlyThatGroup() {
         Table table = table();
         var first = table.addColumnGroup();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/TableTest.java
@@ -243,17 +243,24 @@ class TableTest extends ComponentTest {
     }
 
     @Test
-    void addRows_appendPreBuiltRowsToTheMatchingSection() {
+    void addRows_listOverloadsAppendLikeTheVarargsOnes() {
         Table table = table();
         var head = new TableRow();
+        var headFromList = new TableRow();
         var body = new TableRow();
+        var bodyFromList = new TableRow();
         var foot = new TableRow();
+        var footFromList = new TableRow();
 
         table.addHeaderRows(head);
+        table.addHeaderRows(List.of(headFromList));
         table.addRows(body);
+        table.addRows(List.of(bodyFromList));
         table.addFooterRows(foot);
+        table.addFooterRows(List.of(footFromList));
 
-        assertEquals(List.of(head, body, foot), table.getRows());
+        assertEquals(List.of(head, headFromList, body, bodyFromList, foot,
+                footFromList), table.getRows());
     }
 
     @Test


### PR DESCRIPTION
Every varargs method and constructor in the table API now has a List counterpart, so callers holding a collection do not have to convert it to an array at each call site.

NativeTableRowContainer also moves from HasOrderedComponents to HasComponents. The former is deprecated for removal in 26 and its default methods have already moved to the latter, so the interface only needs what HasComponents provides.
