### PR TITLE
fix: stop passing --scripts-prepend-node-path to npm (#25333) (CP: 24.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -901,7 +901,6 @@ public class FrontendTools {
                 getNpmCliToolExecutable(BuildTool.NPM));
         returnCommand.add("--no-update-notifier");
         returnCommand.add("--no-audit");
-        returnCommand.add("--scripts-prepend-node-path=true");
 
         if (removePnpmLock) {
             // remove pnpm-lock.yaml which contains pnpm as a dependency.

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -413,7 +413,7 @@ public class FrontendToolsTest {
                 not(containsString(vaadinHomeDir)));
         assertThat(tools.getNodeExecutable(), not(containsString(baseDir)));
 
-        assertEquals(4, tools.getNpmExecutable().size());
+        assertEquals(3, tools.getNpmExecutable().size());
         assertThat(tools.getNpmExecutable().get(0), containsString("npm"));
         assertThat(tools.getNpmExecutable().get(1),
                 containsString("--no-update-notifier"));


### PR DESCRIPTION
What

Removes the `--scripts-prepend-node-path=true` flag that `FrontendTools#getNpmExecutable` appended to every generated npm command line, and updates `FrontendToolsTest` accordingly (the default npm command is now 4 elements instead of 5).

Why

npm 12 removed the long-deprecated `--scripts-prepend-node-path` config and now **rejects unknown CLI flags**. As a result every `npm install` executed by `build-frontend` fails with:

```
Unknown cli flag
```

whenever a global npm 12 is used.

The flag dates back to when Flow ran npm 6, where it made lifecycle scripts run with the same node binary that executes `npm-cli.js`. Since npm 7, script execution moved to `@npmcli/run-script`, which builds `PATH` from the `node_modules/.bin` folders, the node-gyp bin folder and the inherited `PATH` — it never looks at this config.

Flow requires npm 11.3 or newer, so **no supported npm version honours the flag**. Dropping it changes nothing except that npm 12 no longer fails.
