### PR TITLE
test: compare file timestamps instead of the wall clock in JarContentsManagerTest

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/JarContentsManagerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/JarContentsManagerTest.java
@@ -453,14 +453,13 @@ public class JarContentsManagerTest {
         File jsonFile = copyFilesFromJar(outputDirectory, jarDirectory,
                 testJar);
 
-        long timestamp = System.currentTimeMillis();
-        Assert.assertTrue(FileUtils.isFileOlder(jsonFile, timestamp));
+        long timestamp = jsonFile.lastModified();
 
         jarContentsManager.copyFilesFromJarTrimmingBasePath(testJar,
                 jarDirectory, outputDirectory);
 
-        // The file is still older
-        Assert.assertTrue(FileUtils.isFileOlder(jsonFile, timestamp));
+        // The file is unmodified
+        Assert.assertEquals(timestamp, jsonFile.lastModified());
     }
 
     @Test


### PR DESCRIPTION
copyFilesFromJar_doNotUpdateFileIfContentIsTheSame asserted that the copied file was older than System.currentTimeMillis() read right after the copy. That comparison truncates the reference time to whole milliseconds while the file modification time carries sub-millisecond precision, so it only holds when a millisecond boundary happens to fall between writing the file and reading the clock. On fast machines it usually does not, and the test fails.

Record the file's own modification time before the second copy and assert it is unchanged afterwards, which is what the test is actually about.

Backport of ce57f79c798d44520740b4bec0ed254d70914699, already on 24.8 and later.
