### PR TITLE
chore: pin maven-install-plugin to 3.1.4 (#25226) (CP: 25.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
     <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
     <maven.clean.plugin.version>3.5.0</maven.clean.plugin.version>
     <maven.exec.plugin.version>3.6.3</maven.exec.plugin.version>
+    <!-- Maven 3.8 still binds install:2.4 by default, which corrupts local
+         repository metadata when modules install in parallel (-T). -->
+    <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
     <testbench.version>10.1.3</testbench.version>
     <jetty.version>12.1.5</jetty.version>
     <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
@@ -410,6 +413,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${maven.install.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Maven 3.8.7, which CI pins, binds maven-install-plugin 2.4 through its default lifecycle bindings. That version predates the Resolver-based installer and still writes repository metadata through the legacy ArtifactInstaller API. The group level
com/vaadin/maven-metadata-local.xml
is shared by every maven-plugin packaging module, so flow-maven-plugin and
flow-dev-bundle-plugin both write it during the -T builds CI runs.

Pinning 3.1.4 puts installation on the Resolver API for every module regardless of which Maven version builds the project.
