### PR TITLE
fix!: Do not override the minimum frontend package age configured for the package manager (#25173) (CP: 25.2)

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -582,7 +583,7 @@ public class FrontendTools {
 
     /**
      * Reads the registry URLs npm resolves for the given directory by running
-     * {@code npm config ls --json}. The returned map contains the global
+     * {@code npm config list --json}. The returned map contains the global
      * {@code registry} entry and every scoped {@code @scope:registry} entry, as
      * resolved by npm across all its configuration sources.
      *
@@ -592,26 +593,85 @@ public class FrontendTools {
      *         map if the configuration cannot be read
      */
     Map<String, String> getConfiguredRegistries(File workingDirectory) {
-        List<String> command = new ArrayList<>(getNpmExecutable(false));
-        command.add("config");
-        command.add("ls");
-        command.add("--json");
+        JsonNode config = getResolvedConfiguration(getNpmExecutable(false),
+                workingDirectory);
         Map<String, String> registries = new HashMap<>();
+        for (String key : config.propertyNames()) {
+            if ((key.equals("registry") || key.endsWith(":registry"))
+                    && config.get(key).isString()) {
+                registries.put(key, config.get(key).asString());
+            }
+        }
+        return registries;
+    }
+
+    /**
+     * Reads the value the given npm or pnpm command resolves for a
+     * configuration key.
+     * <p>
+     * Several keys can be given for a setting that the tool spells differently
+     * depending on its version; the first one that has a value is returned.
+     *
+     * @param toolCommand
+     *            the npm or pnpm command to run
+     * @param workingDirectory
+     *            the directory the configuration is resolved from, so that a
+     *            project {@code .npmrc} is taken into account
+     * @param keys
+     *            the configuration keys to look for, in order of preference
+     * @return the configured value, or an empty optional if none of the keys
+     *         has a scalar value or the configuration cannot be read
+     */
+    Optional<String> getConfiguredSetting(List<String> toolCommand,
+            File workingDirectory, String... keys) {
+        JsonNode config = getResolvedConfiguration(toolCommand,
+                workingDirectory);
+        for (String key : keys) {
+            JsonNode value = config.get(key);
+            // npm lists every key it knows, using null for the ones that are
+            // not configured; pnpm lists only the configured ones. Settings
+            // that npm lists as an array, such as omit or noproxy, are not
+            // values this can return.
+            if (value != null && value.isValueNode() && !value.isNull()) {
+                return Optional.of(value.asString());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Reads the configuration the given npm or pnpm command resolves for a
+     * directory by running {@code config list --json}.
+     * <p>
+     * The configuration is read from the tool itself, so it accounts for every
+     * configuration source and precedence rule the tool applies (command line,
+     * environment variables, project/user/global/builtin {@code .npmrc} and,
+     * for pnpm, {@code pnpm-workspace.yaml}). The subcommand has to be spelled
+     * {@code list}, as pnpm does not know the {@code ls} alias npm accepts.
+     *
+     * @param toolCommand
+     *            the npm or pnpm command to run
+     * @param workingDirectory
+     *            the directory the configuration is resolved from, so that a
+     *            project {@code .npmrc} is taken into account
+     * @return the resolved configuration, or an empty object if it cannot be
+     *         read
+     */
+    JsonNode getResolvedConfiguration(List<String> toolCommand,
+            File workingDirectory) {
+        List<String> command = new ArrayList<>(toolCommand);
+        command.add("config");
+        command.add("list");
+        command.add("--json");
         try {
             String output = FrontendUtils.executeCommand(command,
                     builder -> builder.directory(workingDirectory));
-            JsonNode config = JacksonUtils.readTree(output);
-            for (String key : config.propertyNames()) {
-                if ((key.equals("registry") || key.endsWith(":registry"))
-                        && config.get(key).isString()) {
-                    registries.put(key, config.get(key).asString());
-                }
-            }
+            return JacksonUtils.readTree(output);
         } catch (CommandExecutionException | RuntimeException e) {
-            getLogger().debug("Could not read the npm registry configuration; "
-                    + "assuming the default registry.", e);
+            getLogger().debug("Could not read the configuration using '{}'",
+                    String.join(" ", command), e);
+            return JacksonUtils.createObjectNode();
         }
-        return registries;
     }
 
     /**
@@ -657,9 +717,9 @@ public class FrontendTools {
      * the {@code --min-release-age} install flag (see
      * {@link #MIN_NPM_VERSION_FOR_RELEASE_AGE}). Used when building the
      * {@code npm install} command for the minimum-package-age check (see
-     * {@link Options#withMinimumFrontendPackageAgeDays(int)}) to decide between
-     * {@code --min-release-age} and the {@code --before=<date>} fallback
-     * supported by older npm versions.
+     * {@link Options#withMinimumFrontendPackageAgeDays(Integer)}) to decide
+     * between {@code --min-release-age} and the {@code --before=<date>}
+     * fallback supported by older npm versions.
      *
      * @param npmCommand
      *            the npm command to invoke for {@code --version}

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 
@@ -175,11 +176,12 @@ public class Options implements Serializable {
 
     /**
      * Minimum age, in days, that an npm/pnpm/bun frontend package version must
-     * have before it is allowed to be installed. Defaults to {@code 1} day as a
-     * mitigation against malicious packages published to the registry; set to
-     * {@code 0} to disable.
+     * have before it is allowed to be installed, or {@code null} when nothing
+     * has been configured on the Vaadin side. In the latter case the value is
+     * resolved from the package manager configuration, falling back to
+     * {@link TaskRunNpmInstall#DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS}.
      */
-    private int minimumFrontendPackageAgeDays = 1;
+    private @Nullable Integer minimumFrontendPackageAgeDays;
 
     private ApplicationConfiguration applicationConfiguration;
 
@@ -1179,21 +1181,35 @@ public class Options implements Serializable {
      * to avoid pulling in brand-new versions that may have been compromised by
      * a supply-chain attack but not yet detected and removed from the registry.
      * <p>
-     * For npm this is translated to a {@code --before=<date>} argument; for
-     * pnpm it becomes {@code --config.minimum-release-age=<minutes>} (requires
-     * pnpm &ge; 10.16.0); for bun it becomes
-     * {@code --minimum-release-age=<seconds>} (requires bun &ge; 1.3.0).
+     * For npm this is translated to a {@code --min-release-age=<days>}
+     * argument, or {@code --before=<date>} for npm older than 11.10.0; for pnpm
+     * it becomes {@code --config.minimum-release-age=<minutes>} (requires pnpm
+     * &ge; 10.16.0); for bun it becomes {@code --minimum-release-age=<seconds>}
+     * (requires bun &ge; 1.3.0). Since these are command line arguments, they
+     * take precedence over anything the package manager reads from its own
+     * configuration.
+     * <p>
+     * When set to {@code null}, no such argument is passed if npm or pnpm
+     * already resolves a minimum release age from its own configuration
+     * ({@code .npmrc} or {@code pnpm-workspace.yaml}), so that a manually run
+     * {@code npm install} behaves the same way. Only if nothing is configured
+     * there,
+     * {@link TaskRunNpmInstall#DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS} is
+     * used. The configuration of bun cannot be read, so the default always
+     * applies for it.
      *
      * @param minimumFrontendPackageAgeDays
-     *            minimum allowed age in days, or {@code 0} to disable the check
+     *            minimum allowed age in days, {@code 0} to disable the check,
+     *            or {@code null} to use the package manager configuration
      * @return this builder
      * @throws IllegalArgumentException
      *             if {@code minimumFrontendPackageAgeDays} is negative
      * @since 25.1.6
      */
     public Options withMinimumFrontendPackageAgeDays(
-            int minimumFrontendPackageAgeDays) {
-        if (minimumFrontendPackageAgeDays < 0) {
+            @Nullable Integer minimumFrontendPackageAgeDays) {
+        if (minimumFrontendPackageAgeDays != null
+                && minimumFrontendPackageAgeDays < 0) {
             throw new IllegalArgumentException(
                     "minimumFrontendPackageAgeDays must be >= 0");
         }
@@ -1204,12 +1220,15 @@ public class Options implements Serializable {
     /**
      * Gets the minimum age (in days) a frontend package version must have
      * before npm, pnpm or bun is allowed to install it. {@code 0} means the
-     * check is disabled.
+     * check is disabled and {@code null} means that nothing has been configured
+     * on the Vaadin side, in which case the package manager configuration
+     * decides. See {@link #withMinimumFrontendPackageAgeDays(Integer)}.
      *
-     * @return the minimum allowed age in days
+     * @return the minimum allowed age in days, or {@code null} if not
+     *         configured
      * @since 25.1.6
      */
-    public int getMinimumFrontendPackageAgeDays() {
+    public @Nullable Integer getMinimumFrontendPackageAgeDays() {
         return minimumFrontendPackageAgeDays;
     }
 

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.util.SharedUtil;
 
 import static com.vaadin.flow.internal.FrontendUtils.commandToString;
@@ -61,6 +62,14 @@ import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_VERSION;
  * @since 2.0
  */
 public class TaskRunNpmInstall implements FallibleCommand {
+
+    /**
+     * The minimum age, in days, a frontend package version must have before it
+     * is installed, used when neither Vaadin nor the package manager itself has
+     * been configured with a value. Mitigates supply-chain attacks where a
+     * compromised version is briefly available on the registry.
+     */
+    static final int DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS = 1;
 
     private static final String MODULES_YAML = ".modules.yaml";
 
@@ -292,12 +301,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             }
         }
 
-        boolean npmSupportsMinReleaseAge = options
-                .getMinimumFrontendPackageAgeDays() > 0
-                && !options.isEnableBun() && !options.isEnablePnpm()
-                && tools.npmSupportsMinReleaseAge(npmExecutable);
-        getMinimumFrontendPackageAgeArgument(options, npmSupportsMinReleaseAge)
-                .ifPresent(npmInstallCommand::add);
+        resolveMinimumFrontendPackageAgeArgument(options, tools, npmExecutable,
+                logger).ifPresent(npmInstallCommand::add);
 
         postinstallCommand.add("run");
         postinstallCommand.add("postinstall");
@@ -437,44 +442,128 @@ public class TaskRunNpmInstall implements FallibleCommand {
     }
 
     /**
-     * Builds the install argument that prevents npm, pnpm or bun from
-     * installing frontend package versions newer than
-     * {@link Options#getMinimumFrontendPackageAgeDays()} days. Returns an empty
-     * optional when the check is disabled.
+     * Resolves the install argument that stops the active package manager from
+     * installing frontend package versions that are too new, or nothing if the
+     * age should not be restricted from here.
+     * <p>
+     * A value configured through Vaadin is always used as is, {@code 0}
+     * disabling the check. When nothing is configured, the package manager is
+     * asked what it resolves for its own minimum release age setting; if it
+     * already has one, no argument is passed so that the package manager
+     * applies its own configuration. Only when neither is configured does
+     * {@link #DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS} apply.
      *
      * @param options
      *            current build options
+     * @param tools
+     *            the frontend tools used to read the package manager
+     *            configuration
+     * @param toolCommand
+     *            the npm, pnpm or bun command used for the install
+     * @param logger
+     *            the logger to report the resolved source of the value to
+     * @return the install argument, or an empty optional if none should be
+     *         passed
+     */
+    static Optional<String> resolveMinimumFrontendPackageAgeArgument(
+            Options options, FrontendTools tools, List<String> toolCommand,
+            Logger logger) {
+        Integer configuredDays = options.getMinimumFrontendPackageAgeDays();
+        if (configuredDays != null && configuredDays == 0) {
+            return Optional.empty();
+        }
+        boolean npmSupportsMinReleaseAge = !options.isEnableBun()
+                && !options.isEnablePnpm()
+                && tools.npmSupportsMinReleaseAge(toolCommand);
+        int days;
+        if (configuredDays != null) {
+            days = configuredDays;
+        } else {
+            Optional<String> packageManagerValue = getPackageManagerConfiguredMinimumReleaseAge(
+                    options, tools, toolCommand, npmSupportsMinReleaseAge);
+            if (packageManagerValue.isPresent()) {
+                logger.info(
+                        "Keeping the minimum frontend package age configured for {} "
+                                + "({}) instead of applying the Vaadin default. Set the "
+                                + "'{}' parameter to override it.",
+                        getToolName(options), packageManagerValue.get(),
+                        InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS);
+                return Optional.empty();
+            }
+            days = DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS;
+        }
+        return Optional.of(getMinimumFrontendPackageAgeArgument(options, days,
+                npmSupportsMinReleaseAge));
+    }
+
+    /**
+     * Reads the minimum release age the active package manager resolves from
+     * its own configuration, so that Vaadin does not override it with a command
+     * line argument.
+     * <p>
+     * Only npm and pnpm are asked, as bun has no command for printing its
+     * resolved configuration (see <a href=
+     * "https://github.com/oven-sh/bun/issues/7140">oven-sh/bun#7140</a>). The
+     * {@code minimumReleaseAge} setting a {@code bunfig.toml} may define is
+     * therefore not taken into account.
+     */
+    private static Optional<String> getPackageManagerConfiguredMinimumReleaseAge(
+            Options options, FrontendTools tools, List<String> toolCommand,
+            boolean npmSupportsMinReleaseAge) {
+        File npmFolder = options.getNpmFolder();
+        if (options.isEnableBun()) {
+            return Optional.empty();
+        }
+        if (options.isEnablePnpm()) {
+            // pnpm reads the setting from pnpm-workspace.yaml and, up to pnpm
+            // 10, from .npmrc as well, reporting it camel-cased since pnpm 11
+            return tools.getConfiguredSetting(toolCommand, npmFolder,
+                    "minimumReleaseAge", "minimum-release-age");
+        }
+        if (npmSupportsMinReleaseAge) {
+            return tools.getConfiguredSetting(toolCommand, npmFolder,
+                    "min-release-age");
+        }
+        // Older npm has no min-release-age setting, but the --before argument
+        // used as a fallback does have a configuration counterpart
+        return tools.getConfiguredSetting(toolCommand, npmFolder, "before");
+    }
+
+    /**
+     * Builds the install argument that prevents npm, pnpm or bun from
+     * installing frontend package versions newer than the given number of days.
+     *
+     * @param options
+     *            current build options
+     * @param days
+     *            the minimum age in days, always positive
      * @param npmSupportsMinReleaseAge
      *            {@code true} if the active npm understands
      *            {@code --min-release-age} (npm 11.10+); when {@code false} the
      *            legacy {@code --before=<date>} flag is used instead. Ignored
      *            when bun or pnpm is enabled.
      */
-    static Optional<String> getMinimumFrontendPackageAgeArgument(
-            Options options, boolean npmSupportsMinReleaseAge) {
-        int days = options.getMinimumFrontendPackageAgeDays();
-        if (days <= 0) {
-            return Optional.empty();
-        }
+    static String getMinimumFrontendPackageAgeArgument(Options options,
+            int days, boolean npmSupportsMinReleaseAge) {
         if (options.isEnableBun()) {
             // bun: --minimum-release-age takes a value in seconds
             long seconds = (long) days * 24 * 60 * 60;
-            return Optional.of("--minimum-release-age=" + seconds);
+            return "--minimum-release-age=" + seconds;
         }
         if (options.isEnablePnpm()) {
             // pnpm: minimumReleaseAge is a setting (in minutes), so it has
             // to be passed via the --config.<name> CLI form, not as a
             // top-level option
             long minutes = (long) days * 24 * 60;
-            return Optional.of("--config.minimum-release-age=" + minutes);
+            return "--config.minimum-release-age=" + minutes;
         }
         if (npmSupportsMinReleaseAge) {
             // npm 11.10+: --min-release-age takes a value in days
-            return Optional.of("--min-release-age=" + days);
+            return "--min-release-age=" + days;
         }
         // Older npm: --before takes any Date.parse-able string
         String before = Instant.now().minus(days, ChronoUnit.DAYS).toString();
-        return Optional.of("--before=" + before);
+        return "--before=" + before;
     }
 
     private void consumeProcessOutput(Process process,

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -45,10 +45,13 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.internal.FrontendUtils;
+import com.vaadin.flow.internal.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.internal.FrontendVersion;
 import com.vaadin.flow.internal.Platform;
 import com.vaadin.flow.internal.ReflectTools;
@@ -947,4 +950,91 @@ class FrontendToolsTest {
                 "only the non-default scoped registry should be returned");
     }
 
+    @Test
+    void getConfiguredSetting_pnpm_readsTheConfigurationWithConfigList()
+            throws CommandExecutionException {
+        try (MockedStatic<FrontendUtils> frontendUtils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            frontendUtils
+                    .when(() -> FrontendUtils.executeCommand(Mockito.anyList(),
+                            Mockito.any()))
+                    .thenReturn("{\"minimumReleaseAge\": 4320}");
+
+            assertEquals(Optional.of("4320"),
+                    tools.getConfiguredSetting(List.of("node", "pnpm.cjs"),
+                            new File(baseDir), "minimumReleaseAge",
+                            "minimum-release-age"));
+
+            // the subcommand has to be 'list', as pnpm does not know the 'ls'
+            // alias npm accepts
+            frontendUtils.verify(() -> FrontendUtils.executeCommand(Mockito.eq(
+                    List.of("node", "pnpm.cjs", "config", "list", "--json")),
+                    Mockito.any()));
+        }
+    }
+
+    @Test
+    void getConfiguredSetting_firstKeyMissing_fallsBackToTheNextOne()
+            throws CommandExecutionException {
+        try (MockedStatic<FrontendUtils> frontendUtils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            // pnpm 10 reports the setting kebab-cased, pnpm 11 camel-cased
+            frontendUtils
+                    .when(() -> FrontendUtils.executeCommand(Mockito.anyList(),
+                            Mockito.any()))
+                    .thenReturn("{\"minimum-release-age\": 4320}");
+
+            assertEquals(Optional.of("4320"),
+                    tools.getConfiguredSetting(List.of("node", "pnpm.cjs"),
+                            new File(baseDir), "minimumReleaseAge",
+                            "minimum-release-age"));
+        }
+    }
+
+    @Test
+    void getConfiguredSetting_keyWithoutScalarValue_isEmpty()
+            throws CommandExecutionException {
+        try (MockedStatic<FrontendUtils> frontendUtils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            // npm lists every key it knows, using null for the unconfigured
+            // ones and an array for some of the others, while pnpm lists only
+            // the configured ones
+            frontendUtils
+                    .when(() -> FrontendUtils.executeCommand(Mockito.anyList(),
+                            Mockito.any()))
+                    .thenReturn("{\"min-release-age\": null, \"omit\": []}");
+
+            assertEquals(Optional.empty(), tools.getConfiguredSetting(
+                    List.of("npm"), new File(baseDir), "min-release-age"));
+            assertEquals(Optional.empty(), tools.getConfiguredSetting(
+                    List.of("npm"), new File(baseDir), "before"));
+            assertEquals(Optional.empty(), tools.getConfiguredSetting(
+                    List.of("npm"), new File(baseDir), "omit"));
+        }
+    }
+
+    @Test
+    void getConfiguredSetting_configurationCannotBeRead_isEmpty()
+            throws CommandExecutionException {
+        try (MockedStatic<FrontendUtils> frontendUtils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            frontendUtils
+                    .when(() -> FrontendUtils.executeCommand(Mockito.anyList(),
+                            Mockito.any()))
+                    .thenThrow(new CommandExecutionException(1, "",
+                            "unknown subcommand"))
+                    .thenReturn("minimum-release-age=4320\n");
+
+            assertEquals(Optional.empty(),
+                    tools.getConfiguredSetting(List.of("node", "pnpm.cjs"),
+                            new File(baseDir), "minimumReleaseAge"),
+                    "a tool that fails should be ignored rather than failing the build");
+            // the key the output would yield if it were read as key=value
+            // pairs, so that only JSON is accepted
+            assertEquals(Optional.empty(),
+                    tools.getConfiguredSetting(List.of("node", "pnpm.cjs"),
+                            new File(baseDir), "minimum-release-age"),
+                    "a tool answering in some other format should be ignored rather than failing the build");
+        }
+    }
 }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -767,93 +767,143 @@ class TaskRunNpmInstallTest {
     }
 
     @Test
-    void minimumFrontendPackageAge_defaultIsOneDay_addsArgument() {
-        // Default is 1 day → 1440 minutes for pnpm, 86400 seconds for bun,
-        // --min-release-age=1 for npm 11.10+, and --before=<iso-instant> for
-        // older npm
-        assertEquals("--min-release-age=1",
-                TaskRunNpmInstall
-                        .getMinimumFrontendPackageAgeArgument(
-                                new MockOptions(npmFolder), true)
-                        .orElseThrow());
-        assertTrue(TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(
-                        new MockOptions(npmFolder), false)
-                .orElseThrow().startsWith("--before="));
-        assertEquals("--config.minimum-release-age=1440",
-                TaskRunNpmInstall.getMinimumFrontendPackageAgeArgument(
-                        new MockOptions(npmFolder).withEnablePnpm(true), false)
-                        .orElseThrow());
-        assertEquals("--minimum-release-age=86400",
-                TaskRunNpmInstall.getMinimumFrontendPackageAgeArgument(
-                        new MockOptions(npmFolder).withEnableBun(true), false)
-                        .orElseThrow());
-    }
-
-    @Test
-    void minimumFrontendPackageAge_zeroDisablesCheck_returnsEmpty() {
-        Options npmOptions = new MockOptions(npmFolder)
-                .withMinimumFrontendPackageAgeDays(0);
-        assertFalse(TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(npmOptions, true)
-                .isPresent());
-        assertFalse(TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(npmOptions, false)
-                .isPresent());
-        assertFalse(TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(
-                        new MockOptions(npmFolder).withEnablePnpm(true)
-                                .withMinimumFrontendPackageAgeDays(0),
-                        false)
-                .isPresent());
-        assertFalse(TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(
-                        new MockOptions(npmFolder).withEnableBun(true)
-                                .withMinimumFrontendPackageAgeDays(0),
-                        false)
-                .isPresent());
-    }
-
-    @Test
-    void minimumFrontendPackageAge_npmNewEnough_addsMinReleaseAgeArgument() {
-        Options npmOptions = new MockOptions(npmFolder)
-                .withMinimumFrontendPackageAgeDays(2);
-        Optional<String> arg = TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(npmOptions, true);
-        // npm 11.10+: --min-release-age takes a value in days
-        assertEquals("--min-release-age=2", arg.orElseThrow());
-    }
-
-    @Test
-    void minimumFrontendPackageAge_npmTooOld_fallsBackToBeforeArgument() {
-        Options npmOptions = new MockOptions(npmFolder)
-                .withMinimumFrontendPackageAgeDays(2);
-        Optional<String> arg = TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(npmOptions, false);
-        assertTrue(arg.isPresent());
-        assertTrue(arg.get().startsWith("--before="),
-                "Older npm should fall back to --before, was: " + arg.get());
-    }
-
-    @Test
-    void minimumFrontendPackageAge_pnpm_addsMinimumReleaseAgeArgument() {
-        Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true)
-                .withMinimumFrontendPackageAgeDays(2);
-        Optional<String> arg = TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(pnpmOptions, false);
+    void minimumFrontendPackageAge_pnpm_usesMinimumReleaseAgeInMinutes() {
         // 2 days = 2880 minutes; pnpm setting form
-        assertEquals("--config.minimum-release-age=2880", arg.orElseThrow());
+        assertEquals("--config.minimum-release-age=2880",
+                TaskRunNpmInstall.getMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder).withEnablePnpm(true), 2,
+                        false));
     }
 
     @Test
-    void minimumFrontendPackageAge_bun_addsMinimumReleaseAgeInSeconds() {
-        Options bunOptions = new MockOptions(npmFolder).withEnableBun(true)
-                .withMinimumFrontendPackageAgeDays(2);
+    void minimumFrontendPackageAge_bun_usesMinimumReleaseAgeInSeconds() {
         // 2 days = 172800 seconds
         assertEquals("--minimum-release-age=172800",
-                TaskRunNpmInstall
-                        .getMinimumFrontendPackageAgeArgument(bunOptions, false)
+                TaskRunNpmInstall.getMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder).withEnableBun(true), 2,
+                        false));
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_nothingConfigured_usesDefault() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+
+        assertEquals("--min-release-age="
+                + TaskRunNpmInstall.DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS,
+                resolveMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder), tools).orElseThrow());
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_zeroConfigured_noArgument() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+
+        assertFalse(resolveMinimumFrontendPackageAgeArgument(
+                new MockOptions(npmFolder).withMinimumFrontendPackageAgeDays(0),
+                tools).isPresent());
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_npmrcValue_doesNotOverrideIt() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+        Mockito.when(tools.getConfiguredSetting(Mockito.anyList(),
+                Mockito.eq(npmFolder), Mockito.eq("min-release-age")))
+                .thenReturn(Optional.of("7"));
+
+        // No argument is passed, so npm applies its own configuration
+        assertFalse(resolveMinimumFrontendPackageAgeArgument(
+                new MockOptions(npmFolder), tools).isPresent());
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_configuredInVaadin_overridesNpmrcValue() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+        Mockito.when(tools.getConfiguredSetting(Mockito.anyList(),
+                Mockito.eq(npmFolder), Mockito.eq("min-release-age")))
+                .thenReturn(Optional.of("7"));
+
+        assertEquals("--min-release-age=3",
+                resolveMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder)
+                                .withMinimumFrontendPackageAgeDays(3),
+                        tools).orElseThrow());
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_npmTooOldWithBeforeConfigured_doesNotOverrideIt() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+        Mockito.when(tools.npmSupportsMinReleaseAge(Mockito.anyList()))
+                .thenReturn(false);
+        // npm older than 11.10 has no min-release-age setting, so the
+        // counterpart of the --before fallback is what it is asked for
+        Mockito.when(tools.getConfiguredSetting(Mockito.anyList(),
+                Mockito.eq(npmFolder), Mockito.eq("before")))
+                .thenReturn(Optional.of("2026-01-01"));
+
+        assertFalse(resolveMinimumFrontendPackageAgeArgument(
+                new MockOptions(npmFolder), tools).isPresent());
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_npmTooOldWithNothingConfigured_usesBeforeDefault() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+        Mockito.when(tools.npmSupportsMinReleaseAge(Mockito.anyList()))
+                .thenReturn(false);
+
+        assertTrue(resolveMinimumFrontendPackageAgeArgument(
+                new MockOptions(npmFolder), tools).orElseThrow()
+                .startsWith("--before="));
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_pnpmConfiguredValue_doesNotOverrideIt() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+        // pnpm names the setting minimumReleaseAge, unlike npm
+        Mockito.when(tools.getConfiguredSetting(Mockito.anyList(),
+                Mockito.eq(npmFolder), Mockito.eq("minimumReleaseAge"),
+                Mockito.eq("minimum-release-age")))
+                .thenReturn(Optional.of("4320"));
+
+        // No argument is passed, so pnpm applies its own configuration
+        assertFalse(resolveMinimumFrontendPackageAgeArgument(
+                new MockOptions(npmFolder).withEnablePnpm(true), tools)
+                .isPresent());
+    }
+
+    @Test
+    void resolveMinimumFrontendPackageAge_bun_configurationIsNotRead() {
+        FrontendTools tools = mockToolsWithoutMinimumReleaseAge();
+        // whatever bun might resolve is ignored, as bun cannot report it
+        Mockito.when(tools.getConfiguredSetting(Mockito.anyList(),
+                Mockito.any(), Mockito.any(String[].class)))
+                .thenReturn(Optional.of("4320"));
+
+        // bunfig.toml is not looked at, so the default is applied
+        assertEquals("--minimum-release-age="
+                + TaskRunNpmInstall.DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS
+                        * 24 * 60 * 60,
+                resolveMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder).withEnableBun(true), tools)
                         .orElseThrow());
+        Mockito.verify(tools, Mockito.never()).getConfiguredSetting(
+                Mockito.anyList(), Mockito.any(), Mockito.any(String[].class));
+    }
+
+    private FrontendTools mockToolsWithoutMinimumReleaseAge() {
+        FrontendTools tools = Mockito.mock(FrontendTools.class);
+        Mockito.when(tools.npmSupportsMinReleaseAge(Mockito.anyList()))
+                .thenReturn(true);
+        Mockito.when(tools.getConfiguredSetting(Mockito.anyList(),
+                Mockito.any(), Mockito.any(String[].class)))
+                .thenReturn(Optional.empty());
+        return tools;
+    }
+
+    private Optional<String> resolveMinimumFrontendPackageAgeArgument(
+            Options options, FrontendTools tools) {
+        return TaskRunNpmInstall.resolveMinimumFrontendPackageAgeArgument(
+                options, tools, List.of("npm"),
+                LoggerFactory.getLogger(TaskRunNpmInstallTest.class));
     }
 
 }

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -214,13 +214,19 @@ public class BuildDevBundleMojo extends AbstractMojo
     /**
      * Minimum age (in days) a frontend (npm) package version must have before
      * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
-     * where a compromised version is briefly available on the registry.
-     * Defaults to {@code 1} day; set to {@code 0} to disable. Requires pnpm
-     * &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     * where a compromised version is briefly available on the registry. Set to
+     * {@code 0} to disable. Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when
+     * those tools are used.
+     * <p>
+     * When not set, the value configured for npm or pnpm itself ({@code .npmrc}
+     * or {@code pnpm-workspace.yaml}) is used, so that a manually run
+     * {@code npm install} behaves the same way. Only when there is no such
+     * value does the check default to {@code 1} day. The configuration of bun
+     * cannot be read, so the default always applies for it.
      */
     @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "1")
-    private int minimumFrontendPackageAgeDays;
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS)
+    private Integer minimumFrontendPackageAgeDays;
 
     /**
      * The folder where the META-INF/resources files are copied. Used for
@@ -591,7 +597,7 @@ public class BuildDevBundleMojo extends AbstractMojo
     }
 
     @Override
-    public int minimumFrontendPackageAgeDays() {
+    public Integer minimumFrontendPackageAgeDays() {
         return minimumFrontendPackageAgeDays;
     }
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -373,7 +373,9 @@ internal class GradlePluginAdapter private constructor(
         return config.commercialWithBanner.get()
     }
 
-    override fun minimumFrontendPackageAgeDays(): Int =
-        config.minimumFrontendPackageAgeDays.get()
+    // Null when not configured, so that the value configured for the package
+    // manager itself is used instead of being overridden
+    override fun minimumFrontendPackageAgeDays(): Int? =
+        config.minimumFrontendPackageAgeDays.orNull
 
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -360,8 +360,14 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
      * Minimum age (in days) a frontend (npm) package version must have before
      * npm, pnpm or bun is allowed to install it. Mitigates supply-chain
      * attacks where a compromised version is briefly available on the
-     * registry. Defaults to {@code 1} day; set to {@code 0} to disable.
-     * Requires pnpm >= 10.16.0 or bun >= 1.3.0 when those tools are used.
+     * registry. Set to {@code 0} to disable. Requires pnpm >= 10.16.0 or bun
+     * >= 1.3.0 when those tools are used.
+     *
+     * When not set, the value configured for npm or pnpm itself
+     * ({@code .npmrc} or {@code pnpm-workspace.yaml}) is used, so that a
+     * manually run {@code npm install} behaves the same way. Only when there is
+     * no such value does the check default to {@code 1} day. The configuration
+     * of bun cannot be read, so the default always applies for it.
      */
     public abstract val minimumFrontendPackageAgeDays: Property<Int>
 
@@ -677,7 +683,7 @@ public class PluginEffectiveConfiguration(
         project.getStringProperty(
             "vaadin.${InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS}"
         ).map(String::toInt)
-            .orElse(extension.minimumFrontendPackageAgeDays.convention(1))
+            .orElse(extension.minimumFrontendPackageAgeDays)
 
     public val npmExcludeWebComponents: Provider<Boolean> = extension
         .npmExcludeWebComponents.convention(false)

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -161,13 +161,19 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     /**
      * Minimum age (in days) a frontend (npm) package version must have before
      * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
-     * where a compromised version is briefly available on the registry.
-     * Defaults to {@code 1} day; set to {@code 0} to disable. Requires pnpm
-     * &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     * where a compromised version is briefly available on the registry. Set to
+     * {@code 0} to disable. Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when
+     * those tools are used.
+     * <p>
+     * When not set, the value configured for npm or pnpm itself ({@code .npmrc}
+     * or {@code pnpm-workspace.yaml}) is used, so that a manually run
+     * {@code npm install} behaves the same way. Only when there is no such
+     * value does the check default to {@code 1} day. The configuration of bun
+     * cannot be read, so the default always applies for it.
      */
     @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "1")
-    private int minimumFrontendPackageAgeDays;
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS)
+    private Integer minimumFrontendPackageAgeDays;
 
     @Override
     protected void executeInternal()
@@ -328,7 +334,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     }
 
     @Override
-    public int minimumFrontendPackageAgeDays() {
+    public Integer minimumFrontendPackageAgeDays() {
         return minimumFrontendPackageAgeDays;
     }
 

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -129,13 +129,18 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
 
     /**
      * Minimum age (in days) a frontend package version must have before npm,
-     * pnpm or bun is allowed to install it. Defaults to {@code 1} day as a
-     * mitigation against malicious packages briefly published to the registry;
-     * set to {@code 0} to disable.
+     * pnpm or bun is allowed to install it, as a mitigation against malicious
+     * packages briefly published to the registry. {@code 0} disables the check.
+     * <p>
+     * When {@code null}, the value configured for npm or pnpm itself
+     * ({@code .npmrc} or {@code pnpm-workspace.yaml}) is used, defaulting to
+     * one day if there is none. The configuration of bun cannot be read, so the
+     * default always applies for it.
      *
-     * @return the minimum allowed age in days, or {@code 0} when disabled
+     * @return the minimum allowed age in days, {@code 0} when disabled, or
+     *         {@code null} when not configured
      */
-    default int minimumFrontendPackageAgeDays() {
-        return 1;
+    default Integer minimumFrontendPackageAgeDays() {
+        return null;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -409,9 +409,14 @@ public class InitParameters implements Serializable {
 
     /**
      * Configuration name for the minimum age (in days) a frontend (npm) package
-     * version must have before npm, pnpm or bun is allowed to install it.
-     * Defaults to {@code 1} day; set to {@code 0} to disable.
-     * 
+     * version must have before npm, pnpm or bun is allowed to install it. Set
+     * to {@code 0} to disable.
+     * <p>
+     * When not set, the value configured for npm or pnpm itself ({@code .npmrc}
+     * or {@code pnpm-workspace.yaml}) is used, defaulting to {@code 1} day if
+     * there is none. The configuration of bun cannot be read, so the default
+     * always applies for it.
+     *
      * @since 25.1.6
      */
     public static final String MINIMUM_FRONTEND_PACKAGE_AGE_DAYS = "npm.minimumFrontendPackageAgeDays";

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -293,8 +293,13 @@ public class DevModeInitializer implements Serializable {
         boolean npmExcludeWebComponents = config
                 .getBooleanProperty(NPM_EXCLUDE_WEB_COMPONENTS, false);
 
-        int minimumFrontendPackageAgeDays = Integer.parseInt(config
-                .getStringProperty(MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, "1"));
+        // Left as null when not configured, so that the value configured for
+        // the package manager itself is used instead of being overridden
+        String minimumFrontendPackageAge = config
+                .getStringProperty(MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, null);
+        Integer minimumFrontendPackageAgeDays = minimumFrontendPackageAge == null
+                ? null
+                : Integer.valueOf(minimumFrontendPackageAge);
 
         options.enablePackagesUpdate(true)
                 .useByteCodeScanner(useByteCodeScanner)

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
@@ -260,10 +260,19 @@ class DevModeInitializerTest extends DevModeInitializerTestBase {
     void minimumFrontendPackageAgeDays_readFromConfig_passedToOptions()
             throws Exception {
         Mockito.when(appConfig.getStringProperty(
-                InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, "1"))
+                InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, null))
                 .thenReturn("7");
 
         assertEquals(7,
+                captureNodeTasksOptions().getMinimumFrontendPackageAgeDays());
+    }
+
+    @Test
+    void minimumFrontendPackageAgeDays_notInConfig_leftUnsetInOptions()
+            throws Exception {
+        // Null lets the package manager configuration decide instead of
+        // overriding it with a command line argument
+        assertNull(
                 captureNodeTasksOptions().getMinimumFrontendPackageAgeDays());
     }
 


### PR DESCRIPTION
The `minimumFrontendPackageAgeDays` parameter defaulted to `1` and was **always** passed as a command line argument to the package manager. A command line argument takes precedence over every configuration source of npm, pnpm and bun, so a project that had configured `min-release-age` in its `.npmrc` (or `minimumReleaseAge` in `pnpm-workspace.yaml`) silently got the Vaadin default instead — `mvn vaadin:build-frontend` and a manually run `npm install` disagreed on which package versions were allowed to be installed.

The parameter is now **unset by default** (`Integer`/`null` rather than `int`/`1`):

- A value configured on the Vaadin side is used as is, `0` still disables the check.
- When nothing is configured, the package manager is asked what it resolves for its own minimum release age setting. If it already has one, **no argument is passed** and the package manager applies its own configuration; this is logged at info level along with the parameter to set in order to override it.
- Only when neither is configured does the one-day default (`TaskRunNpmInstall.DEFAULT_MINIMUM_FRONTEND_PACKAGE_AGE_DAYS`) apply.

The resolved configuration is read from the tool itself with `config list --json`, so it accounts for every configuration source and precedence rule the tool applies (command line, environment variables, project/user/global/builtin `.npmrc`, and for pnpm `pnpm-workspace.yaml`). The subcommand has to be spelled `list` — pnpm does not know the `ls` alias npm accepts, which is what made an earlier attempt at this fail on pnpm.

The npm registry lookup already ran the same command, so both now share `FrontendTools.getResolvedConfiguration` and there is a single way to ask npm or pnpm what it resolves for a directory. Details handled along the way:

- **Key spelling varies by version**: pnpm 11 reports the setting camel-cased as `minimumReleaseAge` while pnpm 10 reports it kebab-cased, so `getConfiguredSetting` takes the keys to look for in order of preference.
- **Only scalars are read**: npm lists some of its settings (`omit`, `noproxy`) as arrays, which `JsonNode.asString` does not accept. The guard against that previously lived only in the registry lookup; reading a setting now skips anything that is not a scalar, and `null` (which npm uses for keys it knows but that are not configured) counts as unset.
- **Old npm**: where `--min-release-age` is unsupported and the `--before=<date>` fallback is used, the `before` setting is read as the configuration counterpart.
- **A tool answering in a non-JSON format** is ignored rather than failing the build.
- **bun is not asked.** Detecting a value configured for bun meant parsing `bunfig.toml` by hand, as bun has no command for printing its resolved configuration
([oven-sh/bun#7140](https://github.com/oven-sh/bun/issues/7140)). That hand-written parser recognized only a subset of what TOML allows, so it could just as easily miss a configured value as pick up something that was not one. It has been removed — for bun the Vaadin default applies as before, and the documentation says so.

`resolveMinimumFrontendPackageAgeArgument` now returns the install argument to add, or nothing. Previously the day-count resolution returned `0` both for a check that is explicitly disabled and for one the package manager already handles itself, and the caller had to repeat the same check to know whether it needed to ask npm for its version at all. The remaining argument-formatting method only converts a positive number of days into the flag for the package manager in use.

- Covers the old-npm path (where the `before` counterpart is read instead of `min-release-age`), which had no coverage at all.
- The bun test previously relied on a mock that reports nothing for any key, so it passed even if bun were asked for its configuration; it now stubs a value and asserts that it is neither read nor used.
- Argument-formatting assertions that duplicated the resolution tests were dropped; the pnpm and bun ones remain, where the day count is converted to minutes and seconds and a wrong conversion would otherwise pass unnoticed.

Also restores the `flow-client` lockfile that a local build had rewritten.

```java
// Changed
- public Options withMinimumFrontendPackageAgeDays(int minimumFrontendPackageAgeDays)
+ public Options withMinimumFrontendPackageAgeDays(@Nullable Integer minimumFrontendPackageAgeDays) // null means "use the package manager configuration"
- public int getMinimumFrontendPackageAgeDays()
+ public @Nullable Integer getMinimumFrontendPackageAgeDays() // null when nothing is configured on the Vaadin side
```

```java
// Changed
- default int minimumFrontendPackageAgeDays() // returned 1
+ default Integer minimumFrontendPackageAgeDays() // returns null
```

```java
// Changed
- public int minimumFrontendPackageAgeDays()
+ public Integer minimumFrontendPackageAgeDays() // the vaadin.npm.minimumFrontendPackageAgeDays parameter no longer has a default value
```

```java
// Changed
- public int minimumFrontendPackageAgeDays()
+ public Integer minimumFrontendPackageAgeDays() // the vaadin.npm.minimumFrontendPackageAgeDays parameter no longer has a default value
```

---------
