### PR TITLE
ci: skip auto-merge when the bot token is unavailable

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -414,16 +414,30 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      # A run triggered by Dependabot is given the Dependabot secret store
+      # instead of the Actions one, so this secret is empty there. The secrets
+      # context cannot be read from an if: condition, but env can, so the token
+      # is bound here and every step that needs it is guarded on it.
+      VAADIN_BOT_TOKEN: ${{ secrets.VAADIN_BOT_TOKEN }}
     steps:
+      - name: Skip auto-merge without a bot token
+        if: ${{ env.VAADIN_BOT_TOKEN == '' }}
+        run: |
+          echo "⏭️ **VAADIN_BOT_TOKEN** is not available to this run, skipping auto-merge" \
+            | tee -a $GITHUB_STEP_SUMMARY
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: ${{ env.VAADIN_BOT_TOKEN != '' }}
         with:
           repository: vaadin/platform-build-script
           ref: main
           token: ${{ secrets.VAADIN_BOT_TOKEN }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: ${{ env.VAADIN_BOT_TOKEN != '' }}
         with:
           node-version: '24.20.0'
       - name: Auto-merge PR
+        if: ${{ env.VAADIN_BOT_TOKEN != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.VAADIN_BOT_TOKEN }}
           GITHUB_REVIEW_TOKEN: ${{ secrets.REVIEW_TOKEN }}


### PR DESCRIPTION
A workflow run triggered by Dependabot is given the Dependabot secret store rather than the Actions one, so VAADIN_BOT_TOKEN expands to an empty string. actions/checkout only falls back to the workflow token when its token input is absent, and an explicitly empty value counts as a missing required input, so the job failed with "Input required and not supplied: token" on every Dependabot pull request.

The secrets context cannot be read from an if: condition, but env can, so the token is bound to a job-level env entry and each step that needs it is guarded on that being non-empty. The same guard also covers forks and any other run without access to the secret.
