### PR TITLE
fix: let the Gradle classpath filter be saved in the configuration cache (#25398) (CP: 25.1)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -18,6 +18,8 @@ package com.vaadin.flow.gradle
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
 import kotlin.io.path.div
 import kotlin.io.path.writeText
 import kotlin.test.assertContains
@@ -635,6 +637,45 @@ class VaadinSmokeTest : AbstractGradleTest() {
             false,
             "Expected vaadin-react.tsx not to be created when Hilla is not available"
         ) { vaadinReactTsx.exists() }
+    }
+
+    @Test
+    fun testPrepareFrontend_configurationCache_fileDependency() {
+        // Regression test for the configuration cache failure on a project
+        // that declares a file-based dependency. Such a dependency makes
+        // Gradle keep the classpath artifact view's component filter alive in
+        // the serialized task graph instead of flattening it away, so the
+        // classpath filter predicate has to be storable. Built out of the
+        // Predicate.and()/or()/negate() combinators it was not: those return
+        // lambdas hosted in java.base/java.util.function, and the build failed
+        // with `module java.base does not "opens java.util.function"`.
+
+        // Create frontend folder, that will otherwise be created by the first
+        // execution of vaadinPrepareFrontend, invalidating the cache on the
+        // second run
+        testProject.newFolder("src/main/frontend")
+
+        val localJar = testProject.newFile("libs/local.jar")
+        JarOutputStream(localJar.outputStream()).use { jar ->
+            jar.putNextEntry(JarEntry("marker.txt"))
+            jar.write("placeholder".toByteArray())
+            jar.closeEntry()
+        }
+        testProject.buildFile.writeText(
+            testProject.buildFile.readText().replace(
+                """implementation("org.slf4j:slf4j-simple:$slf4jVersion")""",
+                """implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+                implementation(files("libs/local.jar"))"""
+            )
+        )
+
+        val result = testProject.build("--configuration-cache", "vaadinPrepareFrontend")
+        result.expectTaskSucceded("vaadinPrepareFrontend")
+        assertContains(result.output, "Configuration cache entry stored")
+
+        val result2 = testProject.build("--configuration-cache", "vaadinPrepareFrontend", checkTasksSuccessful = false)
+        result2.expectTaskOutcome("vaadinPrepareFrontend", TaskOutcome.UP_TO_DATE)
+        assertContains(result2.output, "Reusing configuration cache")
     }
 
     private fun enableHilla() {

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/ClasspathFilter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/ClasspathFilter.kt
@@ -16,6 +16,9 @@
 package com.vaadin.flow.gradle
 
 import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.specs.Spec
 import java.io.Serializable
 import java.util.function.Predicate
 
@@ -31,17 +34,71 @@ public data class ClasspathFilter(
         this.exclude.add(exclude)
     }
 
-    public fun toPredicate(): Predicate<ModuleIdentifier> {
-        val includeMatchers = include.map { ModuleIdentifierPredicate.fromGroupNameGlob(it) }
-        val excludeMatchers = exclude.map { ModuleIdentifierPredicate.fromGroupNameGlob(it) }
-        val excludeMatcher: Predicate<ModuleIdentifier> = excludeMatchers.or()
-        val includeMatcher: Predicate<ModuleIdentifier> = if (includeMatchers.isEmpty()) {
-            ModuleIdentifierPredicate.ANY
-        } else {
-            includeMatchers.or()
-        }
-        return includeMatcher.and(excludeMatcher.negate()).or(ModuleIdentifierPredicate.FLOW_SERVER)
+    public fun toPredicate(): Predicate<ModuleIdentifier> =
+        toModuleIdentifierFilter()
+
+    internal fun toModuleIdentifierFilter(): ModuleIdentifierFilter =
+        ModuleIdentifierFilter(include.toList(), exclude.toList())
+}
+
+/**
+ * Accepts the modules selected by a [ClasspathFilter]: a module is accepted
+ * when it matches one of the [include] globs (or when no include is
+ * configured) and matches none of the [exclude] globs. `com.vaadin:flow-server`
+ * is always accepted, as the frontend scanner cannot work without it.
+ *
+ * Deliberately a plain serializable object holding nothing but the configured
+ * globs, instead of a chain built with the `Predicate.and()`/`or()`/`negate()`
+ * combinators. Those combinators return lambdas whose implementation class is
+ * hosted in `java.base/java.util.function`, and Gradle cannot store such a
+ * lambda in a configuration cache entry: a project with a file-based
+ * dependency (`implementation files(...)`) keeps the artifact view's component
+ * filter - and with it this predicate - alive in the serialized task graph
+ * instead of flattening it away, and the build then fails with
+ * `module java.base does not "opens java.util.function"`. The globs are
+ * compiled on demand for the same reason, so that no derived state reaches the
+ * cache entry either.
+ */
+internal data class ModuleIdentifierFilter(
+    private val include: List<String>,
+    private val exclude: List<String>
+) : Predicate<ModuleIdentifier>, Serializable {
+
+    override fun test(t: ModuleIdentifier): Boolean = when {
+        ModuleIdentifierPredicate.FLOW_SERVER.test(t) -> true
+        exclude.any { matches(it, t) } -> false
+        else -> include.isEmpty() || include.any { matches(it, t) }
     }
+
+    private fun matches(glob: String, moduleIdentifier: ModuleIdentifier): Boolean =
+        ModuleIdentifierPredicate.fromGroupNameGlob(glob).test(moduleIdentifier)
+}
+
+/**
+ * Selects the components of a dependency configuration whose module is
+ * accepted by [classpathFilter]. Components that are not
+ * [ModuleComponentIdentifier]s - a local library, or another module of the
+ * same build - are always accepted, as no module coordinates exist to match
+ * them against.
+ *
+ * A named class rather than a lambda so that Gradle serializes it as an
+ * ordinary bean: see [ModuleIdentifierFilter] for why a component filter can
+ * end up in a configuration cache entry.
+ */
+internal class ClasspathComponentFilter(classpathFilter: ClasspathFilter) :
+    Spec<ComponentIdentifier>, Serializable {
+
+    // Snapshots the configured globs at construction time, as the predicate
+    // chain it replaces used to. Typed as the filter implementation rather
+    // than as Predicate, so that nothing unstorable - a lambda, or a chain
+    // built from the Predicate combinators - can reach the configuration
+    // cache entry through this field.
+    private val artifactFilter: ModuleIdentifierFilter =
+        classpathFilter.toModuleIdentifierFilter()
+
+    override fun isSatisfiedBy(element: ComponentIdentifier): Boolean =
+        element !is ModuleComponentIdentifier ||
+                artifactFilter.test(element.moduleIdentifier)
 }
 
 /**
@@ -76,10 +133,6 @@ public data class ModuleIdentifierPredicate(
 
         public val FLOW_SERVER: ModuleIdentifierPredicate = fromGroupNameGlob("com.vaadin:flow-server")
 
-        public val ANY: ModuleIdentifierPredicate = ModuleIdentifierPredicate({ true }, { true })
+        public val ANY: ModuleIdentifierPredicate = fromGroupNameGlob("*:*")
     }
-}
-
-private fun <T> List<Predicate<T>>.or(): Predicate<T> = Predicate { probe ->
-    any { predicate -> predicate.test(probe) }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -127,17 +127,10 @@ internal class GradlePluginAdapter private constructor(
     ): FileCollection {
         val dependencyConfigurationJars: FileCollection =
             if (dependencyConfiguration != null) {
-                val artifactFilter = config.classpathFilter.toPredicate()
                 val artifacts = dependencyConfiguration.incoming.artifactView {
-                    it.componentFilter { componentId ->
-                        // a componentId different ModuleComponentIdentifier
-                        // could be a local library, should not be filtered out
-                        val accepted =
-                            componentId !is ModuleComponentIdentifier || artifactFilter.test(
-                                componentId.moduleIdentifier
-                            )
-                        accepted
-                    }
+                    it.componentFilter(
+                        ClasspathComponentFilter(config.classpathFilter)
+                    )
                 }.files
                 artifacts
             } else project.files()

--- a/flow-plugins/flow-gradle-plugin/src/test/kotlin/com/vaadin/gradle/ClasspathFilterTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/test/kotlin/com/vaadin/gradle/ClasspathFilterTest.kt
@@ -15,7 +15,13 @@
  */
 package com.vaadin.flow.gradle
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.junit.Test
 import kotlin.test.expect
 
@@ -96,5 +102,70 @@ class ClasspathFilterTest {
         expect(false) { m.test(DefaultModuleIdentifier.newId("com.vaadin", "checkbox")) }
         expect(false) { m.test(DefaultModuleIdentifier.newId("org.foo", "bar")) }
         expect(false) { m.test(DefaultModuleIdentifier.newId("com.foo", "bar")) }
+    }
+
+    /**
+     * Regression test for the configuration cache failure that hits any
+     * project with a file-based dependency (`implementation files(...)`).
+     * Such a dependency makes Gradle keep the artifact view's component
+     * filter - and with it this predicate - alive in the serialized task
+     * graph instead of flattening it away. A predicate composed out of the
+     * `Predicate.and()`/`or()`/`negate()` default methods is a lambda hosted
+     * in `java.base/java.util.function`, which Gradle can neither serialize
+     * nor reflect into ("module java.base does not opens java.util.function"),
+     * so the build fails while storing the entry.
+     *
+     * The predicate must therefore be an ordinary serializable object.
+     */
+    @Test
+    fun `default predicate is serializable`() {
+        val m = serializeAndDeserialize(ClasspathFilter().toPredicate())
+        expect(true) { m.test(DefaultModuleIdentifier.newId("com.vaadin", "flow-server")) }
+        expect(true) { m.test(DefaultModuleIdentifier.newId("com.vaadin", "checkbox")) }
+        expect(true) { m.test(DefaultModuleIdentifier.newId("org.foo", "bar")) }
+    }
+
+    @Test
+    fun `configured predicate is serializable`() {
+        val m = serializeAndDeserialize(ClasspathFilter().apply {
+            include("com.vaadin:*")
+            exclude("com.vaadin:checkbox")
+        }.toPredicate())
+        expect(true) { m.test(DefaultModuleIdentifier.newId("com.vaadin", "flow-server")) }
+        expect(false) { m.test(DefaultModuleIdentifier.newId("com.vaadin", "checkbox")) }
+        expect(false) { m.test(DefaultModuleIdentifier.newId("org.foo", "bar")) }
+        expect(false) { m.test(DefaultModuleIdentifier.newId("com.foo", "bar")) }
+    }
+
+    /**
+     * The object Gradle actually stores in the configuration cache entry is
+     * the component filter, not the predicate it delegates to, so it has to
+     * survive a round trip as well.
+     */
+    @Test
+    fun `component filter is serializable`() {
+        val filter = serializeAndDeserialize(ClasspathComponentFilter(
+            ClasspathFilter().apply {
+                include("com.vaadin:*")
+                exclude("com.vaadin:checkbox")
+            }))
+        expect(true) { filter.isSatisfiedBy(moduleComponentId("com.vaadin", "flow-server")) }
+        expect(false) { filter.isSatisfiedBy(moduleComponentId("com.vaadin", "checkbox")) }
+        expect(false) { filter.isSatisfiedBy(moduleComponentId("org.foo", "bar")) }
+        // a component without module coordinates, e.g. a local jar
+        expect(true) { filter.isSatisfiedBy(ComponentIdentifier { "local.jar" }) }
+    }
+
+    private fun moduleComponentId(group: String, name: String): ComponentIdentifier =
+        DefaultModuleComponentIdentifier.newId(
+            DefaultModuleIdentifier.newId(group, name), "1.0"
+        )
+
+    private fun <T> serializeAndDeserialize(value: T): T {
+        val bytes = ByteArrayOutputStream()
+        ObjectOutputStream(bytes).use { it.writeObject(value) }
+        @Suppress("UNCHECKED_CAST")
+        return ObjectInputStream(ByteArrayInputStream(bytes.toByteArray()))
+            .use { it.readObject() } as T
     }
 }


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #25398 to branch 25.1.
---
#### Original PR description
> The filter was built by chaining Predicate.and(), or() and negate(). Those return lambdas that live inside the JDK, and Gradle cannot write them into a configuration cache entry. A project with a file dependency such as `implementation files('libs/some.jar')` keeps the filter in the saved task graph, so the build failed with `module java.base does not "opens java.util.function"`.
>
> Replace the chain with a small class that holds only the configured include and exclude patterns, and pass the component filter to Gradle as a named class instead of a lambda.
>
> Fixes #25396
---
#### Note on the manual pick

`ClasspathFilter.kt`, `GradlePluginAdapter.kt` and `ClasspathFilterTest.kt` are taken over unchanged. The functional test needed one adaptation: upstream it drives `vaadinBuildFrontend` and asserts `UP-TO-DATE` on the second run, which cannot hold on 25.1, where the incremental build feature is not present and that task declares no inputs or outputs. The test therefore covers `vaadinPrepareFrontend`, which keeps the same `GradlePluginAdapter` — and with it the classpath filter — in its configuration cache entry, and is already covered by configuration cache tests on this branch.
