### PR TITLE
test: swap Testbench and Spring Boot boms

### DIFF
--- a/flow-tests/test-default/pom.xml
+++ b/flow-tests/test-default/pom.xml
@@ -26,16 +26,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-testbench-bom</artifactId>
+        <version>${testbench.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.vaadin</groupId>
-        <artifactId>vaadin-testbench-bom</artifactId>
-        <version>${testbench.version}</version>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/flow-tests/test-default/src/test/java/com/vaadin/flow/test/AbstractDefaultIT.java
+++ b/flow-tests/test-default/src/test/java/com/vaadin/flow/test/AbstractDefaultIT.java
@@ -134,7 +134,24 @@ public abstract class AbstractDefaultIT extends BrowserTestBase
      * server to be ready.
      */
     protected void open() {
-        getDriver().get(getTestURL());
+        open(getTestPath());
+    }
+
+    /**
+     * Opens the given path on the test server and waits for the dev server to
+     * be ready.
+     * <p>
+     * Waiting is required because in dev mode requests made while the frontend
+     * bundle is still being built are answered with a placeholder page. That
+     * page carries neither the view contents nor a Flow client, so navigating
+     * without waiting makes element lookups and server side navigation, such as
+     * forwarding, fail.
+     *
+     * @param path
+     *            the path to open, starting with a "/"
+     */
+    protected void open(String path) {
+        getDriver().get(getRootURL() + path);
         waitForDevServer();
     }
 

--- a/flow-tests/test-default/src/test/java/com/vaadin/flow/test/routing/BackNavIT.java
+++ b/flow-tests/test-default/src/test/java/com/vaadin/flow/test/routing/BackNavIT.java
@@ -48,7 +48,7 @@ public class BackNavIT extends AbstractDefaultIT {
 
     private void navigateAndPressBack(
             Supplier<TestBenchElement> navigationElement) {
-        getDriver().get(getRootURL() + BACK_NAV_FIRST_VIEW);
+        open(BACK_NAV_FIRST_VIEW);
 
         try {
             waitUntil(arg -> getDriver().getCurrentUrl()
@@ -84,7 +84,7 @@ public class BackNavIT extends AbstractDefaultIT {
 
     @BrowserTest
     public void backButtonWorksAndContentUpdatesAfterPageRefresh() {
-        getDriver().get(getRootURL() + BACK_NAV_FIRST_VIEW);
+        open(BACK_NAV_FIRST_VIEW);
 
         try {
             waitUntil(arg -> getDriver().getCurrentUrl()
@@ -127,7 +127,7 @@ public class BackNavIT extends AbstractDefaultIT {
 
     @BrowserTest
     public void validateNoAfterNavigationForReplaceState() {
-        getDriver().get(getRootURL() + BACK_NAV_FIRST_VIEW);
+        open(BACK_NAV_FIRST_VIEW);
 
         try {
             waitUntil(arg -> getDriver().getCurrentUrl()

--- a/flow-tests/test-default/src/test/java/com/vaadin/flow/test/routing/ForwardTargetIT.java
+++ b/flow-tests/test-default/src/test/java/com/vaadin/flow/test/routing/ForwardTargetIT.java
@@ -31,7 +31,7 @@ public class ForwardTargetIT extends AbstractDefaultIT {
     // Test for https://github.com/vaadin/flow/issues/19794
     @BrowserTest
     public void testUrlIsCorrectAfterForward() {
-        getDriver().get(getRootURL() + FORWARD_TARGET_VIEW);
+        open(FORWARD_TARGET_VIEW);
 
         try {
             waitUntil(arg -> getDriver().getCurrentUrl()
@@ -41,7 +41,7 @@ public class ForwardTargetIT extends AbstractDefaultIT {
                     + FORWARD_TARGET_VIEW);
         }
 
-        getDriver().get(getRootURL() + "/com.vaadin.flow.ForwardingView");
+        open("/com.vaadin.flow.ForwardingView");
 
         try {
             waitUntil(arg -> getDriver().getCurrentUrl()
@@ -59,8 +59,7 @@ public class ForwardTargetIT extends AbstractDefaultIT {
     // Test for https://github.com/vaadin/flow/issues/19822
     @BrowserTest
     public void testSetParameterCalledOnlyOnceAfterForward() {
-        getDriver().get(
-                getRootURL() + "/com.vaadin.flow.ForwardingToParametersView");
+        open("/com.vaadin.flow.ForwardingToParametersView");
 
         try {
             waitUntil(arg -> getDriver().getCurrentUrl().endsWith(
@@ -78,8 +77,7 @@ public class ForwardTargetIT extends AbstractDefaultIT {
     // Test for https://github.com/vaadin/flow/issues/19822
     @BrowserTest
     public void testRouterLinkSetParameterCalledOnlyOnceAfterForward() {
-        getDriver().get(getRootURL()
-                + "/com.vaadin.flow.RouterLinkForwardingToParametersView");
+        open("/com.vaadin.flow.RouterLinkForwardingToParametersView");
         $("a").id("forwardViewLink").click();
 
         try {


### PR DESCRIPTION
Current Spring Boot BOM manages Selenium to version 4.43, but Testbench uses 4.46. Swapping the BOMs import order allows the project to use Selenium 4.46.
