### PR TITLE
Vaadin dev improvements

### DIFF
--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/Jvm.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/Jvm.java
@@ -289,16 +289,23 @@ final class Jvm {
     /**
      * What a JDK home is, read from its {@code release} file and falling back
      * to its directory name.
+     * <p>
+     * The path given may be the root of a macOS bundle rather than the home
+     * itself; the {@code Jdk} always names the home, which is what a launch
+     * needs. The version fallback still comes from the name the caller used,
+     * because that is the one carrying a version - a bundle's home is called
+     * {@code Home}.
      */
     static Jdk describe(Path home) {
-        Path binary = javaIn(home);
-        Map<String, String> release = release(home);
+        Path real = bundleHome(home);
+        Path binary = javaIn(real);
+        Map<String, String> release = release(real);
         String version = release.get("JAVA_VERSION");
         Path name = home.getFileName();
         int feature = featureOf(
                 version != null ? version : name == null ? "" : name.toString())
                 .orElse(0);
-        return new Jdk(home, binary, feature,
+        return new Jdk(real, binary, feature,
                 version != null ? version : "unknown version",
                 isJetBrains(release.get("IMPLEMENTOR"), binary));
     }
@@ -308,6 +315,27 @@ final class Jvm {
         Path win = home.resolve("bin").resolve("java.exe");
         return Files.isRegularFile(win) ? win
                 : home.resolve("bin").resolve("java");
+    }
+
+    /**
+     * The home inside a macOS bundle, or the path itself when it is already a
+     * home.
+     * <p>
+     * A JDK installed on macOS is a bundle whose home is
+     * {@code <root>/Contents/Home}, and that is the layout a JetBrains IDE
+     * leaves in {@code ~/.jdks} - so without this, the runtime a developer
+     * already has is the one never found: the bundle root carries neither the
+     * launcher nor the {@code release} file, and a candidate with no launcher
+     * is dropped without a word. Resolved for anything named as a home,
+     * {@code vaadin.dev.javaHome} included, since a bundle root is what a
+     * Finder window offers.
+     */
+    private static Path bundleHome(Path home) {
+        if (Files.isRegularFile(javaIn(home))) {
+            return home;
+        }
+        Path inside = home.resolve("Contents").resolve("Home");
+        return Files.isRegularFile(javaIn(inside)) ? inside : home;
     }
 
     /**

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/JvmTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/JvmTest.java
@@ -123,6 +123,21 @@ class JvmTest {
         assertEquals(newest, chosen(0).home());
     }
 
+    @Test
+    void aJdkInstalledAsAMacOsBundleIsFoundThroughItsHome() throws IOException {
+        Path home = jdk("jbrsdk-21.0.11.jdk/Contents/Home", "21.0.11",
+                "JetBrains s.r.o.");
+
+        List<Jvm.Jdk> candidates = Jvm.candidates(homes());
+
+        // homes() lists the bundle root, which has neither the launcher nor the
+        // release file - so the JBR a JetBrains IDE downloaded is only a
+        // candidate if the home inside it is resolved.
+        assertEquals(List.of(home),
+                candidates.stream().map(Jvm.Jdk::home).toList());
+        assertTrue(candidates.get(0).jbr());
+    }
+
     /**
      * The chosen JVM for a requirement, or for none when {@code required} is 0,
      * over the temporary JDKs alone.
@@ -139,7 +154,14 @@ class JvmTest {
         }
     }
 
-    /** A JDK home as an installer leaves it: a launcher and a release file. */
+    /**
+     * A JDK home as an installer leaves it: a launcher and a release file.
+     * <p>
+     * Returned canonical, because that is the spelling {@code candidates()}
+     * reports: on macOS the temporary directory is reached through a symlink,
+     * so comparing against the path as built here would compare
+     * {@code /var/folders/...} with {@code /private/var/folders/...}.
+     */
     private Path jdk(String name, String version, String implementor)
             throws IOException {
         Path home = jdks.resolve(name);
@@ -148,6 +170,6 @@ class JvmTest {
         Files.writeString(home.resolve("bin").resolve("java.exe"), "");
         Files.writeString(home.resolve("release"), "JAVA_VERSION=\"" + version
                 + "\"\nIMPLEMENTOR=\"" + implementor + "\"\n");
-        return home;
+        return Reactor.real(home);
     }
 }

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/SKILL.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/SKILL.md
@@ -32,11 +32,16 @@ another application with `--app`, the version that counts is that application's.
    everything after depends on the answer.
 1. If it says `stopped`, `.vaadin/vaadin-dev start` (~30 s cold; it blocks until the app
    serves or fails).
-2. Edit Java, CSS and/or frontend files. Batch the edits — `apply` finds the change-set itself
+2. **Open the app in the browser now, before the first `apply`**, and keep that page open. A
+   CSS or theme push has somewhere to land only if a page is already connected: with none,
+   `apply` says the resource was copied to the classpath and nothing about a push, which is
+   honest but is not the answer you came for. Opening the page afterwards serves the new file
+   from disk, so the change shows up — but that apply's verdict cannot be recovered.
+3. Edit Java, CSS and/or frontend files. Batch the edits — `apply` finds the change-set itself
    by scanning the sources of every module in the loop. Run it once after a batch, not per file.
-3. `.vaadin/vaadin-dev apply` — **the exit code is the verdict**: `0` live, `1` failed,
+4. `.vaadin/vaadin-dev apply` — **the exit code is the verdict**: `0` live, `1` failed,
    `4` superseded.
-4. Verify in the browser. Only then report the change as working.
+5. Verify in the page opened in step 2. Only then report the change as working.
 
 ## Commands
 
@@ -101,6 +106,7 @@ target/devloop/app.log, daemon.log          logs, under the target application
 | Output | Meaning |
 |---|---|
 | `hmr: … pushed 1 stylesheet(s) in place` | CSS is live in the open page, no reload |
+| `hmr: … no browser connected` | the new CSS is on the classpath, but no page was open to push it into — open one and re-apply rather than reporting the change live |
 | `hmr: N theme file(s) pushed in place` | theme CSS is live in the open page, no reload |
 | `hmr: N frontend file(s), applied by Vite (dev server up:…)` | Vite mode: the edit went live when you saved it |
 | `frontend → Failed` with `dev server: [vite] …` | Vite mode: Vite refused to compile the edit — exit `1`. Fix the file it names and re-apply; a restart cannot compile it either |
@@ -116,9 +122,9 @@ target/devloop/app.log, daemon.log          logs, under the target application
 
 `Stable` with an `app log:` line under it is a failure to investigate, not a success.
 
-The app serves on **http://localhost:8080** unless `server.port` says otherwise. Navigate once
-and keep the page open across applies — CSS pushes and Java hot-swaps land in an already-open
-page, and re-navigating hides what you are testing.
+The app serves on **http://localhost:8080** unless `server.port` says otherwise. Navigate once,
+in step 2, and keep the page open across applies — CSS pushes and Java hot-swaps land in an
+already-open page, and re-navigating hides what you are testing.
 
 ## Full reference
 

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/SKILL.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/SKILL.md
@@ -32,7 +32,8 @@ another application with `--app`, the version that counts is that application's.
    everything after depends on the answer.
 1. If it says `stopped`, `.vaadin/vaadin-dev start` (~30 s cold; it blocks until the app
    serves or fails).
-2. **Open the app in the browser now, before the first `apply`**, and keep that page open. A
+2. **Open the app in the browser now, before the first `apply`**, and keep that page open,
+   unless the change ahead has no visual surface at all — step 5 defines which those are. A
    CSS or theme push has somewhere to land only if a page is already connected: with none,
    `apply` says the resource was copied to the classpath and nothing about a push, which is
    honest but is not the answer you came for. Opening the page afterwards serves the new file
@@ -41,7 +42,12 @@ another application with `--app`, the version that counts is that application's.
    by scanning the sources of every module in the loop. Run it once after a batch, not per file.
 4. `.vaadin/vaadin-dev apply` — **the exit code is the verdict**: `0` live, `1` failed,
    `4` superseded.
-5. Verify in the page opened in step 2. Only then report the change as working.
+5. Verify what actually changed, and only then report it as working. A change with a visual
+   surface — a view, component, layout, theme, stylesheet — is verified in the page opened in
+   step 2; nothing else proves the UI renders what you intended. A change with none — a
+   service, a repository, a formatter, a config value — is answered in full by `apply`'s
+   verdict and the project's own tests, so opening a browser to look at nothing buys no
+   evidence and costs the run a browser launch.
 
 ## Commands
 

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
@@ -85,9 +85,10 @@ the app turns up.
 
 ## Verifying in the browser
 
-Use whatever browser automation this agent has — a Playwright/browser MCP server, a
-built-in browser tool, or a headless Playwright/Selenium script. The rules are the same
-whichever it is:
+First, whether to look at all: only a change with a visual surface earns a browser, as the
+shared file's step 5 says. Then use whatever browser automation this agent has — a
+Playwright/browser MCP server, a built-in browser tool, or a headless Playwright/Selenium
+script. The rules are the same whichever it is:
 
 - **Navigate before the first `apply`, then keep the page open across applies.** CSS pushes and
   Java hot-swaps land in an already-open page; re-navigating hides what you are testing. Reload
@@ -149,12 +150,15 @@ VAADIN_DEV_DAEMON_OPTS   JVM options for the daemon, e.g. -Dvaadin.frontend.hotd
 
 ## Also
 
-- The target application's `./mvnw test` for unit + UI tests.
+- The target application's `./mvnw test` for unit + UI tests. Update a test the change
+  actually broke — its assertion is the behaviour you replaced — and say that you did. Leave
+  the rest alone: a test suite rewritten around a one-line edit is scope nobody asked for.
 - If a **Vaadin MCP server** is available (`search_vaadin_docs`, `get_component_java_api`,
   `get_component_styling`, `get_theme_css_properties`), use it instead of recalling API from
   memory; otherwise check the Vaadin version in the application's `pom.xml` and read
   vaadin.com/docs for that version. Prefer theme CSS properties (`--vaadin-*`, `--aura-*`)
-  over hard-coded values.
+  over hard-coded values. This covers a test framework's API too: unpacking jars out of
+  `~/.m2` to find a method name spends minutes on what a docs query answers in seconds.
 - Browser verification needs a browser automation tool. Nothing installs or configures one for
   you: register a Playwright MCP server (or the equivalent for your agent) yourself, and the
   Vaadin docs MCP server alongside it.

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
@@ -89,8 +89,10 @@ Use whatever browser automation this agent has — a Playwright/browser MCP serv
 built-in browser tool, or a headless Playwright/Selenium script. The rules are the same
 whichever it is:
 
-- **Navigate once, keep the page open across applies.** CSS pushes and Java hot-swaps land in
-  an already-open page; re-navigating hides what you are testing. Reload only after a restart.
+- **Navigate before the first `apply`, then keep the page open across applies.** CSS pushes and
+  Java hot-swaps land in an already-open page; re-navigating hides what you are testing. Reload
+  only after a restart. An `apply` run with no page open reports the stylesheet copied rather
+  than pushed — the change is on the classpath, but nothing was told about it.
 - **The first snapshot after navigating is usually empty** — Vaadin renders client-side. Wait
   for a known element or re-snapshot before asserting.
 - **CSS: assert computed style**, not screenshots —

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/claude-skill/vaadin-devloop/SKILL.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/claude-skill/vaadin-devloop/SKILL.md
@@ -25,11 +25,12 @@ application the project's normal way.
 
 The shared file is deliberately tool-agnostic. These are the tools to use for it here.
 
-- Verify with the **Playwright MCP** tools: `browser_navigate` once and before the first
-  `apply` (a CSS push needs a page already connected), then `browser_snapshot` /
-  `browser_evaluate` for the assertions the shared reference describes, and
-  `browser_console_messages` after each change (a `/favicon.ico` 404 is normal noise). The
-  first snapshot after `browser_navigate` is usually empty — Vaadin renders client-side.
+- Verify with the **Playwright MCP** tools, for a change with a visual surface (the shared
+  file's step 5): `browser_navigate` once and before the first `apply` (a CSS push needs a page
+  already connected), then `browser_snapshot` / `browser_evaluate` for the assertions the
+  shared reference describes, and `browser_console_messages` after each change (a
+  `/favicon.ico` 404 is normal noise). The first snapshot after `browser_navigate` is usually
+  empty — Vaadin renders client-side.
 - Use the **Vaadin MCP server** (`search_vaadin_docs`, `get_component_java_api`,
   `get_component_styling`, `get_theme_css_properties`) instead of recalling API from memory;
   check the Vaadin version in the target application's `pom.xml`.

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/claude-skill/vaadin-devloop/SKILL.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/claude-skill/vaadin-devloop/SKILL.md
@@ -25,7 +25,8 @@ application the project's normal way.
 
 The shared file is deliberately tool-agnostic. These are the tools to use for it here.
 
-- Verify with the **Playwright MCP** tools: `browser_navigate` once, then `browser_snapshot` /
+- Verify with the **Playwright MCP** tools: `browser_navigate` once and before the first
+  `apply` (a CSS push needs a page already connected), then `browser_snapshot` /
   `browser_evaluate` for the assertions the shared reference describes, and
   `browser_console_messages` after each change (a `/favicon.ico` 404 is normal noise). The
   first snapshot after `browser_navigate` is usually empty — Vaadin renders client-side.


### PR DESCRIPTION
fa411470d2 fix: find a JDK installed as a macOS bundle — Jvm.java, JvmTest.java

A macOS JDK's home is <root>/Contents/Home, which is what a JetBrains IDE leaves in ~/.jdks. The bundle root has no bin/java, so candidates() dropped it silently: the JBR a developer already has is the one never found, the app runs on a stock JDK, and every structural change escalates to a restart. Resolved in describe(), the single funnel — so candidates(), current() and the vaadin.dev.javaHome override are all covered. Non-macOS paths unchanged.

Also: 5 of 8 JvmTest cases failed on any Mac before this — @TempDir gives /var/..., candidates() canonicalises to /private/var/.... The fixture now returns the canonical path. Suite: 120/120 (was 115 + 5 failures).

a228b302ec docs: open the browser before the first apply — skill resources

A CSS push lands only in an already-connected page. With none, apply reports the resource copied and nothing about a push. Observed live: mixed change-set with no page → resources: copied 1 to the classpath; same CSS edit with a page open → hmr: 1 resource(s) copied, pushed 1 stylesheet(s) in place in 0.01s. The cycle now opens the page between start and the first edit, and the outcome table carries hmr: … no browser connected.

1d861e8de0 docs: verify in the browser only what has something to show — skill resources

Timed on a real agent run (43 turns, 166s): browser leg 24s; hunting a test framework's API through ~/.m2 jars 19s; retrying a denied ./mvnw test 29s. So the browser is not what to cut — but a change with no visual surface has nothing to look at. Step 5 is now proportional: views/components/themes/stylesheets are verified in the page, services/repositories/config by apply's verdict plus the project's tests.