### PR TITLE
ci: run the Gradle plugin tests in GitHub Actions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -433,10 +433,6 @@ jobs:
         with:
           junit_files: '**/target/*-reports/TEST*.xml'
           check_run_annotations: all tests, skipped tests
-      - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
-        with:
-          name: |
-            saved-workspace
       - name: Compute Stats
         run: |
           ./scripts/computeMatrix.js test-results >> $GITHUB_STEP_SUMMARY
@@ -445,6 +441,20 @@ jobs:
         run: |
           echo "🚫 THERE ARE TEST MODULES WITH FAILURES or BEEN CANCELLED" | tee -a $GITHUB_STEP_SUMMARY
           exit 1
+  cleanup-artifacts:
+    permissions:
+      actions: write
+    # The saved-workspace artifact can only be deleted once every job that
+    # restores it has run: deleting it in test-results raced with the Gradle
+    # tests, which restore it as soon as the build job finishes.
+    if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+    needs: [test-results, gradle-tests]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
+        with:
+          name: |
+            saved-workspace
   auto-merge:
     needs: api-diff-labeling
     if: github.event_name == 'pull_request'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,6 +23,7 @@ env:
   _HEAD_REF: ${{ github.head_ref }}
   _REF_NAME: ${{ github.ref_name }}
   _MERGE_GROUP_SHA: ${{ github.event.merge_group.head_sha }}
+  _MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
   _BASE_REF: ${{ github.event.pull_request.base.ref }}
   _HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   _PR_NUMBER: ${{ github.event.number }}
@@ -250,6 +251,156 @@ jobs:
         with:
           name: tests-output-it-${{ matrix.current }}
           path: tests-report-*.tgz
+  gradle-tests:
+    name: Gradle Tests
+    # Ports the TeamCity 'Gradle Tests' build. Always runs so it can be marked
+    # as a required check, but the expensive steps are gated on whether
+    # anything the Gradle plugin builds on actually changed, so unrelated PRs
+    # pass immediately. Unlike the other test jobs this one needs no secrets,
+    # so it runs for pull requests from forks too.
+    needs: build
+    timeout-minutes: 120
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{env._HEAD_SHA}}
+          fetch-depth: 0  # Full history required to diff against the merge base
+      - name: Decide whether to run
+        # An ignore list rather than an allow list. The job runs `gradlew
+        # build`, and check dependsOn functionalTest, so it also builds the
+        # sample applications under src/functionalTest - and those declare
+        # com.vaadin:flow, the aggregate that pulls in flow-client,
+        # flow-html-components, flow-data, flow-dnd and flow-push, plus
+        # vaadin-spring. Enumerating everything that can break the job is
+        # error prone and goes stale as modules are added, so anything that is
+        # not known to be irrelevant runs it: what is left out is the
+        # integration tests, documentation and the unrelated workflows.
+        # Merge groups carry a base_sha, so they are filtered the same way; a
+        # push or a manual run has nothing to compare against and always
+        # builds. run stays true whenever the comparison cannot be made: a gate
+        # that does not know what changed has to run the job, not report green.
+        id: decide
+        run: |
+          set -euo pipefail
+          run=true
+          DIFF_BASE=
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              # The checkout is by sha, which leaves no remote-tracking branch
+              # for the base, so fetch one explicitly rather than relying on
+              # whatever refs happen to be present.
+              if git fetch --no-tags origin \
+                  "+refs/heads/$_BASE_REF:refs/remotes/origin/$_BASE_REF"; then
+                DIFF_BASE=$(git merge-base HEAD "refs/remotes/origin/$_BASE_REF" || true)
+              fi
+              ;;
+            merge_group)
+              # The merge group branch is built on top of base_sha, so it is
+              # already in the history checked out here.
+              DIFF_BASE=$_MERGE_GROUP_BASE_SHA
+              ;;
+          esac
+          if [ -z "$DIFF_BASE" ]; then
+            echo "No base to compare against, running the job."
+          elif ! CHANGED=$(git diff --name-only "$DIFF_BASE" HEAD); then
+            echo "Could not diff against $DIFF_BASE, running the job."
+          else
+            RELEVANT=$(printf '%s\n' "$CHANGED" | awk '
+              $0 == ".github/workflows/validation.yml" { print; next }
+              /^flow-tests\// { next }
+              /^\.github\// { next }
+              /\.md$/ { next }
+              { print }')
+            if [ -z "$RELEVANT" ]; then
+              echo "No changes affecting the Gradle plugin, skipping."
+              run=false
+            else
+              echo "Changes affecting the Gradle plugin:"
+              printf '%s\n' "$RELEVANT"
+            fi
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        with:
+          node-version: '24.9.0'
+      - name: Set up JDK
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: "${{ env.JAVA_VERSION }}"
+          distribution: 'temurin'
+      - name: Set flow version to 999.99-SNAPSHOT
+        # The Gradle build takes its version from the root pom, so the poms have
+        # to match the saved workspace for the plugin to resolve
+        # flow-plugin-base from the local repository.
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        run: |
+          ./scripts/computeMatrix.js set-version --version=999.99-SNAPSHOT
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('flow-plugins/flow-gradle-plugin/**/*.gradle', 'flow-plugins/flow-gradle-plugin/gradle.properties', 'flow-plugins/flow-gradle-plugin/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: ${{ steps.decide.outputs.run == 'true' && github.run_attempt == 1 }}
+        with:
+          name: saved-workspace
+      - name: Restore Workspace
+        # Reuse the Flow artifacts installed by the build job instead of
+        # building Flow a second time.
+        if: ${{ steps.decide.outputs.run == 'true' && github.run_attempt == 1 }}
+        run: |
+          tar xf workspace.tar
+          tar cf - .m2 | (cd ~ && tar xf -)
+      - name: Compile and Install Flow
+        # On re-runs the saved-workspace artifact has already been deleted,
+        # so compile from scratch like the test jobs do.
+        if: ${{ steps.decide.outputs.run == 'true' && github.run_attempt > 1 }}
+        run: |
+          cmd="mvn install -B -ntp -DskipTests  -pl \!flow-plugins/flow-gradle-plugin"
+          eval $cmd -T 2C -q || eval $cmd
+      - name: Run Gradle build and functionalTests
+        if: ${{ steps.decide.outputs.run == 'true' }}
+        working-directory: flow-plugins/flow-gradle-plugin
+        # The sample applications the functional tests build resolve
+        # com.vaadin:flow from the version of the Gradle build, which the poms
+        # set to 999.99-SNAPSHOT above, so they exercise the workspace restored
+        # here rather than a published snapshot. The functionalTest task passes
+        # it on; AbstractGradleTest fails the build if it ever stops arriving.
+        run: |
+          ./gradlew build --stacktrace
+      - name: Package test-report files
+        if: ${{ always() && steps.decide.outputs.run == 'true' }}
+        run: |
+          # -type f, so the matching directories are not listed alongside the
+          # files they contain and archived a second time.
+          find flow-plugins/flow-gradle-plugin -type f \
+            \( -path '*/build/reports/tests/*' -o -path '*/build/test-results/*' \) \
+            > gradle-reports.txt
+          # tar refuses to create an empty archive, so only pack a report if the
+          # Gradle build got far enough to write one.
+          if [ -s gradle-reports.txt ]; then
+            tar -czf gradle-tests-report.tgz -T gradle-reports.txt
+          fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() && steps.decide.outputs.run == 'true' }}
+        with:
+          # Deliberately not named tests-output-*: the test-results job merges
+          # that pattern and only understands surefire/failsafe reports.
+          name: gradle-tests-report
+          path: gradle-tests-report.tgz
+          if-no-files-found: ignore
   test-results:
     permissions:
       actions: write

--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -128,6 +128,14 @@ task functionalTest(type: Test) {
     classpath = sourceSets.functionalTest.runtimeClasspath
     maxParallelForks = 1
     jvmArgs('-Xms512M', '-Xmx1024M')
+    // The applications the tests generate resolve com.vaadin:flow from this
+    // variable, see AbstractGradleTest. Default it to the version being built
+    // so the tests exercise the working copy instead of a published snapshot.
+    // It has to be set here: Gradle drops environment variables whose names
+    // are not valid identifiers, so `vaadin.version` cannot be passed in from
+    // the command line. Override with -Pvaadin.version, which also sets the
+    // project version.
+    environment('vaadin.version', version.toString())
     testLogging {
         exceptionFormat = 'full'
         showStandardStreams = true

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
@@ -27,7 +27,7 @@ import java.io.File
  */
 abstract class AbstractGradleTest {
 
-    val flowVersion = System.getenv("vaadin.version").takeUnless { it.isNullOrEmpty() } ?: "25.1-SNAPSHOT"
+    val flowVersion = resolveFlowVersion()
     val slf4jVersion = "2.0.3"
 
     /**
@@ -51,5 +51,34 @@ abstract class AbstractGradleTest {
     @Before
     fun dumpEnvironment() {
         println("Test project directory: ${testProject.dir}")
+        println("Building the test projects against Flow $flowVersion")
+    }
+
+    private companion object {
+        const val VERSION_ENV = "vaadin.version"
+        const val FALLBACK_VERSION = "25.1-SNAPSHOT"
+
+        /**
+         * The version the generated test projects build against, taken from the
+         * `vaadin.version` environment variable that the `functionalTest` task
+         * sets to the version being built.
+         *
+         * The fallback to a published snapshot only exists for running the
+         * tests outside that task. On CI it would be silent and harmful: the
+         * tests would pass against a released version instead of the one just
+         * built, so the build would report green without ever exercising the
+         * changes under test. Fail there instead.
+         */
+        fun resolveFlowVersion(): String {
+            val version = System.getenv(VERSION_ENV).takeUnless { it.isNullOrEmpty() }
+            check(version != null || System.getenv("CI").isNullOrEmpty()) {
+                "The $VERSION_ENV environment variable is not set, so the test " +
+                        "projects would be built against the published " +
+                        "$FALLBACK_VERSION rather than against the version under " +
+                        "test. The functionalTest task in build.gradle sets it; " +
+                        "run the tests through that task."
+            }
+            return version ?: FALLBACK_VERSION
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Ports the `gradle-tests` job from main (#24714) into this branch's `validation.yml`, keeping the branch's own Node version.
- Adds `_MERGE_GROUP_BASE_SHA` and `_BASE_REF` to the workflow env, which the job's change detection reads.
- `functionalTest` now sets `vaadin.version` to the version being built, so the generated sample applications resolve `com.vaadin:flow` from the restored workspace instead of a published snapshot.
- `AbstractGradleTest` fails instead of falling back to the published version when `CI` is set and the variable is missing.

## Context

The TeamCity `Gradle Tests` build has no VCS trigger any more, so the `Gradle Tests (Flow Pull Requests Validation set)` context it publishes never reports, and every pull request against this branch stays blocked on a required check that cannot arrive. Once this is merged, branch protection can require the `Gradle Tests` job instead and the TeamCity context can be dropped.
