### PR TITLE
docs: Clarify Menu javadoc so Hilla is a secondary note #21242

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
@@ -23,12 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines menu information for a route for automatically populated menu.
+ * Defines menu information for a route that should appear in an automatically
+ * populated menu.
  * <p>
- * {@link Menu} is used together with {@link Route} to include it automatically
- * in Hilla application's main menu, but only if server route is accessible and
- * {@code frontend/views/@layout.tsx} is used with {@code createMenuItems()}
- * function to build the menu.
+ * Use {@link Menu} together with {@link Route} so the route is included when
+ * the application builds its main menu, for example with
+ * {@link com.vaadin.flow.server.menu.MenuConfiguration#getMenuEntries()}. The
+ * route is listed only when it is accessible.
+ * <p>
+ * If you also use Hilla, the same annotation is picked up for the Hilla main
+ * menu when {@code frontend/views/@layout.tsx} calls {@code createMenuItems()}.
  *
  * @see Route
  * @since 24.4


### PR DESCRIPTION
## Description

The published `@Menu` javadoc led with Hilla. I rewrote it so the main text is the Flow menu API, and Hilla is only mentioned as a follow-on.

Fixes #21242

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.