### PR TITLE
fix: provision devloop HotswapAgent from flow:install-dev-cli

### DIFF
--- a/flow-devloop-daemon/README.md
+++ b/flow-devloop-daemon/README.md
@@ -126,11 +126,17 @@ anything.
 It is provisioned by `mvn flow:install-dev-cli`, not by the first `start`, so a
 machine set up while it had network access can run the loop afterwards with
 none — which is what a container image or a sandboxed agent environment needs.
-The daemon still provisions on demand through the same code and into the same
-cache, so a project that never ran the goal is unaffected and a project that did
-never downloads twice. `-Dvaadin.devcli.skipHotswapAgent=true` installs the CLI
-without it; dropping the release asset into `~/.vaadin/devloop/` by hand works
-too, since what is there is checksum-verified either way.
+The goal runs `HotswapAgentJar` out of the daemon jar the project resolves,
+reflectively, over a class loader of its own: the plugin must not carry the
+daemon into every build it runs in, and the version worth pre-downloading is the
+one the daemon that will actually run has pinned. So a project whose daemon
+predates this only gets a warning, and the goal and the `start` can never
+disagree about the version. The daemon still provisions on demand through the
+same code and into the same cache, so a project that never ran the goal is
+unaffected and one that did never downloads twice.
+`-Dvaadin.devcli.skipHotswapAgent=true` installs the CLI without it; dropping
+the release asset into `~/.vaadin/devloop/` by hand works too, since what is
+there is checksum-verified either way.
 
 ## Outcomes and exit codes
 

--- a/flow-devloop-daemon/README.md
+++ b/flow-devloop-daemon/README.md
@@ -120,6 +120,17 @@ Windows' 32 kB command-line limit). Each in-loop module gets its own
 The HotswapAgent jar is *not* here: it is cached per machine under
 `~/.vaadin/devloop/`, pinned by version and verified against a SHA-256, so one
 download serves every application and a `mvn clean` does not throw it away.
+`HotswapAgentJar` owns all three facts and is the only code that downloads
+anything.
+
+It is provisioned by `mvn flow:install-dev-cli`, not by the first `start`, so a
+machine set up while it had network access can run the loop afterwards with
+none — which is what a container image or a sandboxed agent environment needs.
+The daemon still provisions on demand through the same code and into the same
+cache, so a project that never ran the goal is unaffected and a project that did
+never downloads twice. `-Dvaadin.devcli.skipHotswapAgent=true` installs the CLI
+without it; dropping the release asset into `~/.vaadin/devloop/` by hand works
+too, since what is there is checksum-verified either way.
 
 ## Outcomes and exit codes
 

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/HotswapAgentJar.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/HotswapAgentJar.java
@@ -39,6 +39,14 @@ import java.util.function.Consumer;
  * so there is one pinned version, one checksum and one cache location rather
  * than two that can drift.
  * <p>
+ * The build reaches it by name, through a class loader over this jar: the Maven
+ * and Gradle plugins must not depend on the daemon, and the version that has to
+ * be provisioned is the one in the jar the project resolves and the CLI will
+ * run. So this class name, the {@link #VERSION} field and the signature of
+ * {@link #provision(Consumer)} are a contract with
+ * {@code DevCliInstaller.provisionHotswapAgent} that no compiler checks -
+ * renaming any of them turns the install goal into a no-op that only warns.
+ * <p>
  * This is the only asset the loop downloads. Everything else it needs - the
  * daemon jar, which is also the javaagent - travels in as a project dependency
  * and is resolved from the local Maven repository.

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/HotswapAgentJar.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/HotswapAgentJar.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.devloop.daemon;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.util.function.Consumer;
+
+/**
+ * The HotswapAgent jar the application JVM is launched with: where it is
+ * cached, and how it gets there.
+ * <p>
+ * Separate from {@link Launch} because two very different callers provision it.
+ * The daemon does, at the moment it composes the command line for the
+ * application. The build does too, from {@code flow:install-dev-cli}, so that a
+ * machine prepared while it had network access - a container image, a benchmark
+ * sandbox - can run the loop afterwards without any. Both go through this class
+ * so there is one pinned version, one checksum and one cache location rather
+ * than two that can drift.
+ * <p>
+ * This is the only asset the loop downloads. Everything else it needs - the
+ * daemon jar, which is also the javaagent - travels in as a project dependency
+ * and is resolved from the local Maven repository.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public final class HotswapAgentJar {
+
+    /**
+     * Pinned, never "latest": a changing agent would make applies
+     * irreproducible.
+     * <p>
+     * The checksum is of the {@code hotswap-agent-<version>.jar} release asset
+     * at {@link #URL}, not of the same version on Maven Central - the two are
+     * built separately and there is no promise they are the same bytes. Bumping
+     * the version means downloading that asset and recomputing this.
+     */
+    public static final String VERSION = "2.0.3";
+    public static final String SHA256 = "4ef49724b7d8523536d2e2a7310f827f4db9f4fed3489224e05d7bf87f0594f9";
+    public static final String URL = "https://github.com/HotswapProjects/HotswapAgent/releases/download/RELEASE-"
+            + VERSION + "/hotswap-agent-" + VERSION + ".jar";
+
+    /**
+     * Names a jar that is already on the machine, which is how an air-gapped
+     * setup that never ran the install goal still gets an agent.
+     */
+    public static final String OVERRIDE_PROPERTY = "vaadin.dev.hotswapAgentJar";
+
+    private HotswapAgentJar() {
+    }
+
+    /**
+     * Where machine-level dev-loop assets are cached: the HotswapAgent jar, and
+     * nothing else so far.
+     * <p>
+     * Under the {@code ~/.vaadin} directory Vaadin already owns, so one
+     * download serves every application on the machine and nothing is written
+     * into a project. It also survives a {@code mvn clean}, which a per-project
+     * cache did not.
+     */
+    public static Path cacheDir() {
+        return Path.of(System.getProperty("user.home", "."), ".vaadin",
+                "devloop");
+    }
+
+    /** Where {@link #VERSION} lives once it has been provisioned. */
+    public static Path cachedJar() {
+        return cacheDir().resolve("hotswap-agent-" + VERSION + ".jar");
+    }
+
+    /**
+     * Ensures the HotswapAgent jar is present and matches the pinned checksum,
+     * and answers where it is.
+     * <p>
+     * Downloads only when it has to: an explicit override wins, then an
+     * already-cached copy whose bytes still verify. So a machine provisioned
+     * once needs no network again - not for the next application, and not after
+     * a {@code mvn clean}.
+     *
+     * @param progress
+     *            where to report a download, since it is the one step here that
+     *            takes long enough to need saying out loud
+     * @return the jar to load into the application JVM
+     * @throws IOException
+     *             if the jar cannot be downloaded, or if the bytes in hand are
+     *             not the pinned ones
+     */
+    public static Path provision(Consumer<String> progress) throws IOException {
+        String override = System.getProperty(OVERRIDE_PROPERTY);
+        if (override != null && !override.isBlank()) {
+            Path path = Path.of(override);
+            if (!Files.isRegularFile(path)) {
+                throw new IOException(
+                        OVERRIDE_PROPERTY + " does not exist: " + path);
+            }
+            return path;
+        }
+
+        Path jar = cachedJar();
+        if (Files.isRegularFile(jar)) {
+            String actual = sha256(jar);
+            if (!SHA256.equalsIgnoreCase(actual)) {
+                throw new IOException("cached HotswapAgent checksum mismatch: "
+                        + jar + " (expected " + SHA256 + ", got " + actual
+                        + "). Delete it to re-download.");
+            }
+            return jar;
+        }
+
+        Files.createDirectories(jar.getParent());
+        progress.accept(
+                "provisioning HotswapAgent " + VERSION + " from " + URL);
+        // A unique temp name rather than a fixed sibling: the daemon of one
+        // application, the daemon of another and a build running the install
+        // goal can all reach this at once, and two of them writing one shared
+        // .part file would each verify half of the other download.
+        Path temp = Files.createTempFile(jar.getParent(),
+                "hotswap-agent-" + VERSION + "-", ".part");
+        try {
+            try {
+                HttpClient client = HttpClient.newBuilder()
+                        .followRedirects(HttpClient.Redirect.NORMAL).build();
+                HttpRequest request = HttpRequest.newBuilder(URI.create(URL))
+                        .GET().build();
+                HttpResponse<InputStream> response = client.send(request,
+                        HttpResponse.BodyHandlers.ofInputStream());
+                if (response.statusCode() != 200) {
+                    throw new IOException("download failed with HTTP "
+                            + response.statusCode() + " from " + URL);
+                }
+                try (InputStream in = response.body()) {
+                    Files.copy(in, temp, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("download interrupted", e);
+            }
+
+            String actual = sha256(temp);
+            if (!SHA256.equalsIgnoreCase(actual)) {
+                throw new IOException(
+                        "downloaded HotswapAgent checksum mismatch (expected "
+                                + SHA256 + ", got " + actual + ")");
+            }
+            // Not ATOMIC_MOVE: a file system is free to refuse that, and the
+            // bytes are verified either way, so a concurrent provision can only
+            // move the same content over the same name.
+            Files.move(temp, jar, StandardCopyOption.REPLACE_EXISTING);
+        } finally {
+            Files.deleteIfExists(temp);
+        }
+        progress.accept("provisioned " + jar + " (verified sha256)");
+        return jar;
+    }
+
+    private static String sha256(Path file) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(Files.readAllBytes(file));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IOException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/Launch.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/Launch.java
@@ -18,14 +18,8 @@ package com.vaadin.flow.devloop.daemon;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -39,7 +33,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Composes the app JVM command line, resolves the classpath through Maven, and
- * provisions HotswapAgent so the user never has to.
+ * puts HotswapAgent on it - provisioning one through {@link HotswapAgentJar} if
+ * the build has not already, so the user never has to.
  * <p>
  * Phase 0.5 established that getting the flag set right matters as much as
  * having the jar: without the JPMS opens, HotswapAgent's core helper fails on
@@ -53,20 +48,6 @@ final class Launch {
 
     static final boolean WINDOWS = System.getProperty("os.name", "")
             .toLowerCase(Locale.ROOT).startsWith("windows");
-
-    /**
-     * Pinned, never "latest": a changing agent would make applies
-     * irreproducible.
-     * <p>
-     * The checksum is of the {@code hotswap-agent-<version>.jar} release asset
-     * at {@link #HA_URL}, not of the same version on Maven Central - the two
-     * are built separately and there is no promise they are the same bytes.
-     * Bumping the version means downloading that asset and recomputing this.
-     */
-    static final String HA_VERSION = "2.0.3";
-    static final String HA_SHA256 = "4ef49724b7d8523536d2e2a7310f827f4db9f4fed3489224e05d7bf87f0594f9";
-    static final String HA_URL = "https://github.com/HotswapProjects/HotswapAgent/releases/download/RELEASE-"
-            + HA_VERSION + "/hotswap-agent-" + HA_VERSION + ".jar";
 
     private static final List<String> ADD_OPENS = List.of("java.base/java.lang",
             "java.base/java.lang.reflect", "java.base/java.io",
@@ -218,78 +199,11 @@ final class Launch {
     }
 
     /**
-     * Where machine-level dev-loop assets are cached: the HotswapAgent jar, and
-     * nothing else so far.
-     * <p>
-     * Under the {@code ~/.vaadin} directory Vaadin already owns, so one
-     * download serves every application on the machine and nothing is written
-     * into a project. It also survives a {@code mvn clean}, which a per-project
-     * cache did not.
-     */
-    static Path cacheDir() {
-        return Path.of(System.getProperty("user.home", "."), ".vaadin",
-                "devloop");
-    }
-
-    /**
-     * Ensures the HotswapAgent jar is present and matches the pinned checksum.
-     * Honours an already-present jar and an explicit override so air-gapped
-     * setups still work.
+     * Ensures the HotswapAgent jar is present, downloading it once per machine
+     * if it is not; see {@link HotswapAgentJar}.
      */
     Path ensureHotswapAgent() throws IOException {
-        String override = System.getProperty("vaadin.dev.hotswapAgentJar");
-        if (override != null && !override.isBlank()) {
-            Path path = Path.of(override);
-            if (!Files.isRegularFile(path)) {
-                throw new IOException(
-                        "vaadin.dev.hotswapAgentJar does not exist: " + path);
-            }
-            return path;
-        }
-
-        Path jar = cacheDir().resolve("hotswap-agent-" + HA_VERSION + ".jar");
-        if (Files.isRegularFile(jar)) {
-            String actual = sha256(jar);
-            if (!HA_SHA256.equalsIgnoreCase(actual)) {
-                throw new IOException("cached HotswapAgent checksum mismatch: "
-                        + jar + " (expected " + HA_SHA256 + ", got " + actual
-                        + "). Delete it to re-download.");
-            }
-            return jar;
-        }
-
-        Files.createDirectories(jar.getParent());
-        log.line("provisioning HotswapAgent " + HA_VERSION + " from " + HA_URL);
-        Path temp = jar.resolveSibling(jar.getFileName() + ".part");
-        try {
-            HttpClient client = HttpClient.newBuilder()
-                    .followRedirects(HttpClient.Redirect.NORMAL).build();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(HA_URL))
-                    .GET().build();
-            HttpResponse<InputStream> response = client.send(request,
-                    HttpResponse.BodyHandlers.ofInputStream());
-            if (response.statusCode() != 200) {
-                throw new IOException("download failed with HTTP "
-                        + response.statusCode() + " from " + HA_URL);
-            }
-            try (InputStream in = response.body()) {
-                Files.copy(in, temp, StandardCopyOption.REPLACE_EXISTING);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("download interrupted", e);
-        }
-
-        String actual = sha256(temp);
-        if (!HA_SHA256.equalsIgnoreCase(actual)) {
-            Files.deleteIfExists(temp);
-            throw new IOException(
-                    "downloaded HotswapAgent checksum mismatch (expected "
-                            + HA_SHA256 + ", got " + actual + ")");
-        }
-        Files.move(temp, jar, StandardCopyOption.REPLACE_EXISTING);
-        log.line("provisioned " + jar + " (verified sha256)");
-        return jar;
+        return HotswapAgentJar.provision(log::line);
     }
 
     /**
@@ -1196,20 +1110,6 @@ final class Launch {
     private static final Set<String> LOOP_OWNED = Set.of(
             "spring.devtools.restart.enabled", "vaadin.launch-browser",
             "vaadin.devloop.classes");
-
-    private static String sha256(Path file) throws IOException {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(Files.readAllBytes(file));
-            StringBuilder sb = new StringBuilder(hash.length * 2);
-            for (byte b : hash) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            throw new IOException("SHA-256 unavailable", e);
-        }
-    }
 
     /** Minimal sink so provisioning progress reaches the client that asked. */
     interface Log {

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/HotswapAgentJarTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/HotswapAgentJarTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.devloop.daemon;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Provisioning has to be offline-clean: the build installs the jar once, while
+ * the machine still has network access, and every later {@code start} - of this
+ * application or any other on the machine - has to be satisfied by what is
+ * already there rather than reaching for the network again.
+ */
+class HotswapAgentJarTest {
+
+    private final List<String> progress = new ArrayList<>();
+
+    @AfterEach
+    void clearOverride() {
+        System.clearProperty(HotswapAgentJar.OVERRIDE_PROPERTY);
+    }
+
+    @Test
+    void cacheDir_isMachineLevelRatherThanPerProject() {
+        // One download per machine, and nothing written into a project - which
+        // also means mvn clean does not throw it away.
+        assertEquals(
+                Path.of(System.getProperty("user.home"), ".vaadin", "devloop"),
+                HotswapAgentJar.cacheDir());
+        assertEquals(
+                HotswapAgentJar.cacheDir().resolve(
+                        "hotswap-agent-" + HotswapAgentJar.VERSION + ".jar"),
+                HotswapAgentJar.cachedJar());
+    }
+
+    @Test
+    void provision_honoursAnOverrideWithoutTouchingTheNetwork(@TempDir Path dir)
+            throws IOException {
+        Path own = Files.writeString(dir.resolve("ha.jar"), "not really a jar");
+        System.setProperty(HotswapAgentJar.OVERRIDE_PROPERTY, own.toString());
+
+        // No checksum on an override: the point of it is a jar the developer
+        // vouches for, which is not required to be the pinned release asset.
+        assertEquals(own, HotswapAgentJar.provision(progress::add));
+        assertTrue(progress.isEmpty(),
+                "nothing was downloaded, so nothing should be reported");
+    }
+
+    @Test
+    void provision_failsLoudlyWhenTheOverrideIsMissing(@TempDir Path dir) {
+        Path absent = dir.resolve("absent.jar");
+        System.setProperty(HotswapAgentJar.OVERRIDE_PROPERTY,
+                absent.toString());
+
+        IOException e = assertThrows(IOException.class,
+                () -> HotswapAgentJar.provision(progress::add));
+        assertTrue(e.getMessage().contains(absent.toString()), e.getMessage());
+    }
+}

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/LaunchTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/LaunchTest.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.devloop.daemon;
 
 import java.io.File;
-import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
@@ -49,17 +48,6 @@ class LaunchTest {
     void membership_seesAnAddedEntry() {
         assertNotEquals(Launch.membership(classpath("a.jar")),
                 Launch.membership(classpath("a.jar", "b.jar")));
-    }
-
-    @Test
-    void cacheDir_isMachineLevelRatherThanPerProject() {
-        Path cache = Launch.cacheDir();
-
-        // One HotswapAgent download per machine, and nothing written into a
-        // project - which also means mvn clean does not throw it away.
-        assertEquals(
-                Path.of(System.getProperty("user.home"), ".vaadin", "devloop"),
-                cache);
     }
 
     @Test

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -116,6 +116,10 @@
           <extraArtifacts>
             <artifact>com.vaadin:flow-client:${project.version}</artifact>
             <artifact>com.vaadin:flow-react:${project.version}</artifact>
+            <!-- install-dev-cli provisions HotswapAgent through the daemon the
+                 project resolves, and the plugin deliberately does not depend
+                 on it, so it would not otherwise be in the test repository. -->
+            <artifact>com.vaadin:flow-devloop-daemon:${project.version}</artifact>
           </extraArtifacts>
           <streamLogsOnFailures>true</streamLogsOnFailures>
           <settingsFile>src/it/settings.xml</settingsFile>

--- a/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/invoker.properties
@@ -19,5 +19,11 @@
 # .agents/skills/vaadin-devloop/SKILL.md, which run 1 must replace - that is the
 # only way a fix reaches a project - and run 2 must then be a no-op. Each run
 # logs to its own file so verify.bsh can tell them apart.
+#
+# Run 1 provisions HotswapAgent for real, because "install-dev-cli leaves a
+# machine that can start the loop offline" is the whole point of the goal and a
+# skipped download would not test it. The jar is cached per machine and
+# checksum-verified, so run 2 - and every later build on the same machine -
+# reuses it rather than downloading again.
 invoker.goals.1=--log-file=install-1.log -ntp flow:install-dev-cli
 invoker.goals.2=--log-file=install-2.log -ntp flow:install-dev-cli

--- a/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/pom.xml
@@ -24,6 +24,16 @@
             <artifactId>flow-server</artifactId>
             <version>${flow.version}</version>
         </dependency>
+        <!-- What com.vaadin:vaadin-dev brings a real application, declared
+             directly here so the IT does not drag in the whole dev server.
+             The goal provisions HotswapAgent through this jar, so a project
+             without it is a different case - see verify.bsh. -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-devloop-daemon</artifactId>
+            <version>${flow.version}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/verify.bsh
+++ b/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/verify.bsh
@@ -84,3 +84,37 @@ if (second.indexOf("Installed ") >= 0) {
     throw new RuntimeException(
             "run 2 should have been a no-op, but wrote files: " + second);
 }
+
+// --- HotswapAgent is in the machine-level cache, not in the project ---------
+// The reason the goal downloads it at all: a machine prepared here has to be
+// able to start the loop with no network access afterwards.
+File cache = new File(new File(new File(System.getProperty("user.home")),
+        ".vaadin"), "devloop");
+File[] agents = cache.listFiles();
+boolean agent = false;
+if (agents != null) {
+    for (int i = 0; i < agents.length; i++) {
+        String name = agents[i].getName();
+        if (name.startsWith("hotswap-agent-") && name.endsWith(".jar")) {
+            agent = true;
+        }
+        if (name.endsWith(".part")) {
+            throw new RuntimeException(
+                    "a half-written download was left behind: " + agents[i]);
+        }
+    }
+}
+if (!agent) {
+    throw new RuntimeException(
+            "install-dev-cli should have provisioned HotswapAgent into " + cache);
+}
+// Both runs say where it is, whether they downloaded it or found it cached:
+// the answer to "can this machine start the loop?" should not depend on which.
+if (first.indexOf("HotswapAgent") < 0) {
+    throw new RuntimeException(
+            "run 1 should have reported the provisioned agent: " + first);
+}
+if (second.indexOf("HotswapAgent") < 0) {
+    throw new RuntimeException(
+            "run 2 should have reported the cached agent: " + second);
+}

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/InstallDevCliMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/InstallDevCliMojo.java
@@ -18,12 +18,15 @@ package com.vaadin.flow.plugin.maven;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import com.vaadin.flow.devloop.daemon.HotswapAgentJar;
 import com.vaadin.flow.plugin.base.DevCliInstaller;
 
 /**
@@ -45,6 +48,13 @@ import com.vaadin.flow.plugin.base.DevCliInstaller;
  * the loop needs the network again. Machine-level, so nothing lands in the
  * project and one download serves every application on the machine.
  * <p>
+ * The provisioning runs out of the daemon jar the project itself resolves - the
+ * same one the CLI will run - so the pinned agent version is the version the
+ * running daemon goes on to ask for. Hence the dependency resolution this goal
+ * requires, and hence no scope filter when looking for it: the daemon travels
+ * in as an optional dependency of the dev server, and a project is free to
+ * declare it provided or test instead.
+ * <p>
  * Everything it writes is meant to be committed, like {@code mvnw}: it is
  * project tooling, and the point is that every developer and every agent on the
  * repository gets the same instructions. It is also rewritten whenever it
@@ -57,7 +67,7 @@ import com.vaadin.flow.plugin.base.DevCliInstaller;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  */
-@Mojo(name = "install-dev-cli")
+@Mojo(name = "install-dev-cli", requiresDependencyResolution = ResolutionScope.TEST)
 public class InstallDevCliMojo extends FlowModeAbstractMojo {
 
     /**
@@ -98,19 +108,48 @@ public class InstallDevCliMojo extends FlowModeAbstractMojo {
                     + "download it, and will need network access to do so");
             return;
         }
-        try {
-            DevCliInstaller.provisionHotswapAgent(this);
-        } catch (IOException e) {
-            throw new MojoFailureException("Could not provision HotswapAgent "
-                    + HotswapAgentJar.VERSION + " into "
-                    + HotswapAgentJar.cacheDir()
-                    + ", so the dev loop would have to download it on first "
-                    + "use. Run this goal where " + HotswapAgentJar.URL
-                    + " is reachable, or place that file in the cache "
-                    + "directory by hand - it is verified against a pinned "
-                    + "checksum either way. Pass "
-                    + "-Dvaadin.devcli.skipHotswapAgent=true to install the "
-                    + "CLI without it.", e);
+        Optional<Path> daemon = daemonJar();
+        if (daemon.isEmpty()) {
+            // Not a failure: the scripts are installed and correct, and the
+            // CLI itself reports this with the same remedy the moment it is
+            // run. Saying it now saves finding out then.
+            logWarn("This project does not depend on the dev-loop daemon, so "
+                    + "there was no HotswapAgent to provision - and "
+                    + "`vaadin-dev` cannot run either until it does. Add "
+                    + "com.vaadin:vaadin-dev (optional) to the project.");
+            return;
         }
+        try {
+            DevCliInstaller.provisionHotswapAgent(daemon.get(), this);
+        } catch (IOException e) {
+            throw new MojoFailureException(
+                    "Could not provision HotswapAgent, so the dev loop would "
+                            + "have to download it the first time it runs: "
+                            + e.getMessage()
+                            + ". It is fetched once per machine into "
+                            + "~/.vaadin/devloop from a HotswapAgent GitHub "
+                            + "release, so run this goal somewhere that is "
+                            + "reachable, or put the jar there by hand - it is "
+                            + "verified against a pinned checksum either way. "
+                            + "Pass -Dvaadin.devcli.skipHotswapAgent=true to "
+                            + "install the CLI without it.",
+                    e);
+        }
+    }
+
+    /**
+     * The dev-loop daemon jar among the project dependencies, which is the one
+     * the CLI resolves and runs.
+     * <p>
+     * By coordinates rather than by file name, and with no scope filter, so
+     * that it is found however the project came to declare it.
+     */
+    private Optional<Path> daemonJar() {
+        return project.getArtifacts().stream()
+                .filter(artifact -> "com.vaadin".equals(artifact.getGroupId())
+                        && "flow-devloop-daemon"
+                                .equals(artifact.getArtifactId()))
+                .map(Artifact::getFile).filter(Objects::nonNull)
+                .filter(File::isFile).map(File::toPath).findFirst();
     }
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/InstallDevCliMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/InstallDevCliMojo.java
@@ -23,6 +23,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import com.vaadin.flow.devloop.daemon.HotswapAgentJar;
 import com.vaadin.flow.plugin.base.DevCliInstaller;
 
 /**
@@ -31,9 +32,18 @@ import com.vaadin.flow.plugin.base.DevCliInstaller;
  * Creates {@code .vaadin/vaadin-dev} (plus the {@code .ps1} and {@code .cmd}
  * launchers), the shared instructions under
  * {@code .agents/skills/vaadin-devloop/} and the Claude adapter under
- * {@code .claude/skills/vaadin-devloop/}. Nothing else: no jars are staged, and
- * no agent configuration is touched - the CLI resolves the dev-loop daemon from
- * the project's own dependencies at first use.
+ * {@code .claude/skills/vaadin-devloop/}. No jars are staged into the project
+ * and no agent configuration is touched - the CLI resolves the dev-loop daemon
+ * from the project's own dependencies at first use.
+ * <p>
+ * It also provisions HotswapAgent into {@code ~/.vaadin/devloop}, which is the
+ * only asset the loop downloads rather than resolving from a Maven repository.
+ * That is deliberately the goal's job and not the first {@code vaadin-dev
+ * start}: an image built with network access and developed in without it - a
+ * container, a sandboxed agent environment - would otherwise install fine and
+ * then fail to start the loop at all. Once the goal has succeeded, nothing in
+ * the loop needs the network again. Machine-level, so nothing lands in the
+ * project and one download serves every application on the machine.
  * <p>
  * Everything it writes is meant to be committed, like {@code mvnw}: it is
  * project tooling, and the point is that every developer and every agent on the
@@ -59,6 +69,17 @@ public class InstallDevCliMojo extends FlowModeAbstractMojo {
     @Parameter(property = "vaadin.devcli.targetDirectory", defaultValue = "${project.basedir}")
     private File targetDirectory;
 
+    /**
+     * Installs the project files only, leaving HotswapAgent to be downloaded by
+     * the first {@code vaadin-dev start} that needs it.
+     * <p>
+     * For a run that has no network and does not need one to succeed. Skipping
+     * it gives up the guarantee the provisioning exists for: that the loop
+     * starts afterwards without reaching the network.
+     */
+    @Parameter(property = "vaadin.devcli.skipHotswapAgent", defaultValue = "false")
+    private boolean skipHotswapAgent;
+
     @Override
     protected void executeInternal() throws MojoFailureException {
         Path target = targetDirectory.toPath();
@@ -68,6 +89,28 @@ public class InstallDevCliMojo extends FlowModeAbstractMojo {
         } catch (IOException e) {
             throw new MojoFailureException(
                     "Could not install the vaadin-dev CLI into " + target, e);
+        }
+        // After the files: they are the part of the install that cannot fail
+        // for a reason outside the machine, so an unreachable GitHub still
+        // leaves a project with a working CLI to report the problem from.
+        if (skipHotswapAgent) {
+            logInfo("Skipping HotswapAgent; the first `vaadin-dev start` will "
+                    + "download it, and will need network access to do so");
+            return;
+        }
+        try {
+            DevCliInstaller.provisionHotswapAgent(this);
+        } catch (IOException e) {
+            throw new MojoFailureException("Could not provision HotswapAgent "
+                    + HotswapAgentJar.VERSION + " into "
+                    + HotswapAgentJar.cacheDir()
+                    + ", so the dev loop would have to download it on first "
+                    + "use. Run this goal where " + HotswapAgentJar.URL
+                    + " is reachable, or place that file in the cache "
+                    + "directory by hand - it is verified against a pinned "
+                    + "checksum either way. Pass "
+                    + "-Dvaadin.devcli.skipHotswapAgent=true to install the "
+                    + "CLI without it.", e);
         }
     }
 }

--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -19,15 +19,6 @@
       <artifactId>flow-server</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- The dev-loop daemon owns the pinned HotswapAgent coordinates and the
-         cache layout; install-dev-cli provisions through it rather than
-         restating them. Zero transitive dependencies of its own, by an
-         enforcer rule in that module. -->
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-devloop-daemon</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-build-tools</artifactId>

--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -19,6 +19,15 @@
       <artifactId>flow-server</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- The dev-loop daemon owns the pinned HotswapAgent coordinates and the
+         cache layout; install-dev-cli provisions through it rather than
+         restating them. Zero transitive dependencies of its own, by an
+         enforcer rule in that module. -->
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-devloop-daemon</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-build-tools</artifactId>

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/DevCliInstaller.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/DevCliInstaller.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.devloop.daemon.HotswapAgentJar;
 import com.vaadin.flow.internal.FileIOUtils;
 
 /**
@@ -40,6 +41,12 @@ import com.vaadin.flow.internal.FileIOUtils;
  * Gradle task reads the same bytes from the same jar. Nothing generated and no
  * jars are copied: the CLI resolves the dev-loop daemon from the project's own
  * dependencies at first use.
+ * <p>
+ * {@link #provisionHotswapAgent} is the second half of an install, and the only
+ * part that needs the network: it puts the one asset the loop cannot resolve
+ * from a Maven repository into the machine-level cache, so that a machine
+ * prepared here - a container image built while it had network access, say -
+ * can run the loop later with none.
  * <p>
  * Everything is installed relative to one directory, and the two skill trees
  * are installed as siblings, because the Claude adapter links to the shared
@@ -151,6 +158,36 @@ public final class DevCliInstaller {
             setExecutableIfNeeded(relative, target);
         }
         return new Result(List.copyOf(written), List.copyOf(unchanged));
+    }
+
+    /**
+     * Provisions the HotswapAgent jar into the machine-level dev-loop cache,
+     * which is the one thing the loop would otherwise download the first time
+     * someone runs {@code vaadin-dev start}.
+     * <p>
+     * Doing it here rather than there is what makes the loop usable on a
+     * machine that has no network access by the time anyone develops on it. The
+     * daemon still provisions on demand, through the same code and into the
+     * same cache, so this only ever moves the download earlier - it never
+     * becomes a second copy or a second version.
+     * <p>
+     * Nothing is written into the project: the cache is under
+     * {@code ~/.vaadin/devloop}, so one download serves every application on
+     * the machine and a {@code mvn clean} does not throw it away.
+     *
+     * @param adapter
+     *            the plugin adapter to report through
+     * @return the provisioned jar
+     * @throws IOException
+     *             if the jar can neither be found in the cache nor downloaded
+     */
+    public static Path provisionHotswapAgent(PluginAdapterBase adapter)
+            throws IOException {
+        Path jar = HotswapAgentJar.provision(adapter::logInfo);
+        adapter.logInfo(
+                "HotswapAgent " + HotswapAgentJar.VERSION + " is ready at "
+                        + jar + " - the dev loop needs no network for it");
+        return jar;
     }
 
     /**

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/DevCliInstaller.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/DevCliInstaller.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.plugin.base;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,12 +28,13 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.devloop.daemon.HotswapAgentJar;
 import com.vaadin.flow.internal.FileIOUtils;
 
 /**
@@ -46,7 +50,9 @@ import com.vaadin.flow.internal.FileIOUtils;
  * part that needs the network: it puts the one asset the loop cannot resolve
  * from a Maven repository into the machine-level cache, so that a machine
  * prepared here - a container image built while it had network access, say -
- * can run the loop later with none.
+ * can run the loop later with none. It runs the provisioning code out of the
+ * daemon jar the project resolves, which is deliberately not a dependency of
+ * this module; see there for why.
  * <p>
  * Everything is installed relative to one directory, and the two skill trees
  * are installed as siblings, because the Claude adapter links to the shared
@@ -64,6 +70,12 @@ public final class DevCliInstaller {
             .getLogger(DevCliInstaller.class);
 
     private static final String RESOURCE_ROOT = "vaadin-dev-cli/";
+
+    /**
+     * Loaded out of the daemon jar the project resolves rather than imported;
+     * see {@link #provisionHotswapAgent}.
+     */
+    private static final String PROVISIONER = "com.vaadin.flow.devloop.daemon.HotswapAgentJar";
 
     /**
      * What is installed where, resource path to project-relative path.
@@ -174,20 +186,76 @@ public final class DevCliInstaller {
      * Nothing is written into the project: the cache is under
      * {@code ~/.vaadin/devloop}, so one download serves every application on
      * the machine and a {@code mvn clean} does not throw it away.
+     * <p>
+     * The work is done by {@code HotswapAgentJar} inside {@code daemonJar},
+     * reached through a throwaway class loader rather than by depending on the
+     * daemon from here. Two reasons, and the second is the one that decides it.
+     * A plugin dependency is resolved into the plugin realm before any goal
+     * runs, so every build - {@code -Pproduction} included, and every Gradle
+     * buildscript - would fetch dev-loop tooling nothing in it can call. And
+     * the version that matters is the one the project resolves: the CLI runs
+     * that daemon, so pre-downloading whatever version another copy of the
+     * daemon pins would leave the running daemon asking for a different one and
+     * reaching for the network anyway - in exactly the air-gapped container
+     * this feature exists for. Reading the pin out of the jar that will run
+     * makes the two agree by construction.
+     * <p>
+     * Reflection is safe here because the daemon is dependency-free, by an
+     * enforcer rule in its own module: the platform class loader is a
+     * sufficient parent, and using that rather than this module loader also
+     * means nothing already in the plugin realm can shadow what is loaded.
      *
+     * @param daemonJar
+     *            the {@code flow-devloop-daemon} jar the project resolves
      * @param adapter
      *            the plugin adapter to report through
-     * @return the provisioned jar
+     * @return the provisioned jar, or empty when that daemon is too old to
+     *         carry the provisioning code - in which case a warning has been
+     *         reported and the first {@code start} downloads as before
      * @throws IOException
-     *             if the jar can neither be found in the cache nor downloaded
+     *             if provisioning was attempted and the jar could neither be
+     *             found in the cache nor downloaded
      */
-    public static Path provisionHotswapAgent(PluginAdapterBase adapter)
-            throws IOException {
-        Path jar = HotswapAgentJar.provision(adapter::logInfo);
-        adapter.logInfo(
-                "HotswapAgent " + HotswapAgentJar.VERSION + " is ready at "
-                        + jar + " - the dev loop needs no network for it");
-        return jar;
+    public static Optional<Path> provisionHotswapAgent(Path daemonJar,
+            PluginAdapterBase adapter) throws IOException {
+        try (URLClassLoader loader = new URLClassLoader(
+                new URL[] { daemonJar.toUri().toURL() },
+                ClassLoader.getPlatformClassLoader())) {
+            Class<?> provisioner;
+            try {
+                provisioner = loader.loadClass(PROVISIONER);
+            } catch (ClassNotFoundException e) {
+                LOGGER.debug("No {} in {}", PROVISIONER, daemonJar, e);
+                adapter.logWarn("The dev-loop daemon in " + daemonJar
+                        + " is older than this plugin and cannot provision "
+                        + "HotswapAgent, so the first `vaadin-dev start` will "
+                        + "download it and will need network access to do so");
+                return Optional.empty();
+            }
+            // Parameter and return type both come from java.base, so the two
+            // class loaders agree on them with nothing to adapt between them.
+            Consumer<String> progress = adapter::logInfo;
+            String version = (String) provisioner.getField("VERSION").get(null);
+            Path jar = (Path) provisioner.getMethod("provision", Consumer.class)
+                    .invoke(null, progress);
+            adapter.logInfo("HotswapAgent " + version + " is ready at " + jar
+                    + " - the dev loop needs no network for it");
+            return Optional.of(jar);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException failure) {
+                throw failure;
+            }
+            if (cause instanceof RuntimeException failure) {
+                throw failure;
+            }
+            throw new IOException("provisioning HotswapAgent through "
+                    + daemonJar + " failed: " + cause, cause);
+        } catch (ReflectiveOperationException e) {
+            throw new IOException("the dev-loop daemon in " + daemonJar
+                    + " does not expose the provisioning API this plugin "
+                    + "expects", e);
+        }
     }
 
     /**

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/DevCliInstallerTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/DevCliInstallerTest.java
@@ -15,10 +15,19 @@
  */
 package com.vaadin.flow.plugin.base;
 
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
 import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -29,11 +38,21 @@ import org.junit.rules.TemporaryFolder;
  * The installer writes project tooling, and the promise is that re-running the
  * goal gets you the shipped version - so what it does on a second run matters
  * as much as on the first.
+ * <p>
+ * The provisioning tests build their own daemon jar rather than using the real
+ * one, and that is the point: this module deliberately does not depend on the
+ * daemon, so all that holds the two sides together is the name of a class, a
+ * field and a method signature. A test that imported the real class would not
+ * be checking that at all.
  */
 public class DevCliInstallerTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final List<String> info = new ArrayList<>();
+
+    private final List<String> warnings = new ArrayList<>();
 
     private static final List<String> INSTALLED = List.of(".vaadin/vaadin-dev",
             ".vaadin/vaadin-dev.ps1", ".vaadin/vaadin-dev.cmd",
@@ -148,5 +167,103 @@ public class DevCliInstallerTest {
 
         Assert.assertTrue(
                 Files.isRegularFile(root.resolve(".vaadin/vaadin-dev")));
+    }
+
+    @Test
+    public void provisionHotswapAgent_runsTheProvisionerFromTheGivenJar()
+            throws Exception {
+        Path daemon = daemonJar("""
+                package com.vaadin.flow.devloop.daemon;
+
+                public final class HotswapAgentJar {
+                    public static final String VERSION = "9.9.9";
+
+                    public static java.nio.file.Path provision(
+                            java.util.function.Consumer<String> progress) {
+                        progress.accept("provisioning HotswapAgent 9.9.9");
+                        return java.nio.file.Path.of("cache", "ha-9.9.9.jar");
+                    }
+                }
+                """);
+
+        Optional<Path> provisioned = DevCliInstaller
+                .provisionHotswapAgent(daemon, adapter());
+
+        // The version reported is the one pinned by the jar that was handed
+        // over, not one this plugin knows: the CLI runs the daemon the project
+        // resolves, so that is the only version worth pre-downloading.
+        Assert.assertEquals(Optional.of(Path.of("cache", "ha-9.9.9.jar")),
+                provisioned);
+        Assert.assertTrue("the download progress should reach the build log",
+                info.contains("provisioning HotswapAgent 9.9.9"));
+        Assert.assertTrue("the outcome should name the version and the path",
+                info.stream().anyMatch(line -> line
+                        .startsWith("HotswapAgent 9.9.9 is ready at")));
+        Assert.assertEquals(List.of(), warnings);
+    }
+
+    @Test
+    public void provisionHotswapAgent_daemonTooOldToProvision_warnsAndCarriesOn()
+            throws Exception {
+        // A daemon from before this feature. Not a failure: the CLI is
+        // installed and correct, and the first start downloads as it used to.
+        Path daemon = daemonJar(null);
+
+        Optional<Path> provisioned = DevCliInstaller
+                .provisionHotswapAgent(daemon, adapter());
+
+        Assert.assertEquals(Optional.empty(), provisioned);
+        Assert.assertEquals(1, warnings.size());
+        Assert.assertTrue(warnings.get(0),
+                warnings.get(0).contains("older than this plugin"));
+    }
+
+    /**
+     * A jar holding the given compiled source, or an empty one when it is
+     * {@code null}.
+     */
+    private Path daemonJar(String source) throws Exception {
+        Path work = temporaryFolder.newFolder().toPath();
+        Path jar = work.resolve("flow-devloop-daemon.jar");
+        try (JarOutputStream out = new JarOutputStream(
+                Files.newOutputStream(jar))) {
+            if (source != null) {
+                String name = "com/vaadin/flow/devloop/daemon/HotswapAgentJar.class";
+                out.putNextEntry(new JarEntry(name));
+                Files.copy(compile(work, source).resolve(name),
+                        (OutputStream) out);
+                out.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+    private Path compile(Path work, String source) throws IOException {
+        Path java = work.resolve("HotswapAgentJar.java");
+        Files.writeString(java, source);
+        Path classes = Files.createDirectories(work.resolve("classes"));
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        Assert.assertNotNull("a JDK is required to run this test", compiler);
+        Assert.assertEquals("the stub daemon should compile", 0, compiler.run(
+                null, null, null, "-d", classes.toString(), java.toString()));
+        return classes;
+    }
+
+    /**
+     * A recording adapter. A proxy rather than a mock because only two of the
+     * interface methods are reached, and both only to collect a line.
+     */
+    private PluginAdapterBase adapter() {
+        return (PluginAdapterBase) Proxy.newProxyInstance(
+                PluginAdapterBase.class.getClassLoader(),
+                new Class<?>[] { PluginAdapterBase.class },
+                (proxy, method, args) -> {
+                    if ("logInfo".equals(method.getName())) {
+                        info.add(String.valueOf(args[0]));
+                    } else if ("logWarn".equals(method.getName())) {
+                        warnings.add(String.valueOf(args[0]));
+                    }
+                    return null;
+                });
     }
 }


### PR DESCRIPTION
The jar was downloaded only by the first `vaadin-dev start`, so a machine prepared with network access and developed in without it could not start the dev loop. The goal now provisions it into ~/.vaadin/devloop through the same pinned, checksum-verified code the daemon uses.
