### PR TITLE
fix: keep the Gradle configuration cache entry on a fresh checkout (#25408) (CP: 25.1)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -460,11 +460,21 @@ class VaadinSmokeTest : AbstractGradleTest() {
     }
 
     @Test
-    fun testPrepareFrontend_configurationCache() {
-        // Create frontend folder, that will otherwise be created by the first
-        // execution of vaadinPrepareFrontend, invalidating the cache on the
-        // second run
-        testProject.newFolder("src/main/frontend")
+    fun testPrepareFrontend_configurationCache_freshCheckout() {
+        // Regression test for the configuration-cache entry being discarded on
+        // the second build of a fresh checkout. src/main/frontend is generated
+        // and gitignored, so it does not exist on a clean clone; the first
+        // build creates it, as the parent of vaadinPrepareFrontend's
+        // src/main/frontend/generated output directory. If the plugin probes
+        // that same path while configuring, Gradle records a file-system-entry
+        // input on a path the build itself creates, and the next build reports
+        //   configuration cache cannot be reused because the file system entry
+        //   'src/main/frontend' has been created
+        // although nothing in the project changed. Unlike the other
+        // configuration cache tests here, this one deliberately does NOT
+        // pre-create the folder: that pre-creation is what hides the defect.
+        val frontendFolder = File(testProject.dir, "src/main/frontend")
+        expect(false, "the test must start without $frontendFolder") { frontendFolder.exists() }
 
         val result = testProject.build("--configuration-cache", "vaadinPrepareFrontend")
         result.expectTaskSucceded("vaadinPrepareFrontend")

--- a/flow-server/src/main/java/com/vaadin/flow/internal/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/FrontendUtils.java
@@ -686,12 +686,24 @@ public class FrontendUtils {
      * @return frontend directory to use
      */
     public static File getFrontendFolder(File projectRoot, File frontendDir) {
-        if (!frontendDir.exists() && frontendDir.toPath()
-                .endsWith(DEFAULT_FRONTEND_DIR.substring(2))) {
-            File legacy = new File(projectRoot, LEGACY_FRONTEND_DIR);
-            if (legacy.exists()) {
-                return legacy;
-            }
+        // The legacy folder is probed FIRST on purpose. frontendDir is
+        // src/main/frontend, which build tools create themselves (it is the
+        // parent of an optional task output) and which is gitignored, so it is
+        // absent on a fresh checkout and present after the first build. Under
+        // Gradle's configuration cache a File.exists() call made while
+        // configuring is recorded as an input of the entry, so probing that
+        // path first invalidates the entry on the build right after the one
+        // that created the directory - for a check whose answer never changes,
+        // since with no legacy folder both branches return frontendDir. The
+        // legacy folder is not created by any build, so probing it first is
+        // stable, and && short-circuits away the unstable probe on every
+        // project that has no legacy frontend folder.
+        File legacy = new File(projectRoot, LEGACY_FRONTEND_DIR);
+        if (legacy.exists()
+                && frontendDir.toPath()
+                        .endsWith(DEFAULT_FRONTEND_DIR.substring(2))
+                && !frontendDir.exists()) {
+            return legacy;
         }
         return frontendDir;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FrontendUtilsTest.java
@@ -16,16 +16,20 @@
 package com.vaadin.flow.internal;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.vaadin.flow.internal.FrontendUtils.AnsiColor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FrontendUtilsTest {
 
@@ -82,5 +86,67 @@ class FrontendUtilsTest {
 
         assertEquals(firstIndex, lastIndex);
         assertEquals(output.length() - "[0m".length(), firstIndex);
+    }
+
+    @Test
+    void getFrontendFolder_noLegacyFolder_frontendDirNotProbed(
+            @TempDir File projectRoot) {
+        // Regression test for the Gradle configuration cache: probing
+        // src/main/frontend while configuring records a file-system-entry
+        // input on a path the build itself creates, which discards the entry on
+        // the next build. With no legacy frontend folder the answer is
+        // frontendDir either way, so the probe must not happen at all.
+        AtomicInteger probes = new AtomicInteger();
+        File frontendDir = probeCountingFile(
+                new File(projectRoot, "src/main/frontend").getPath(), probes);
+
+        assertEquals(frontendDir,
+                FrontendUtils.getFrontendFolder(projectRoot, frontendDir));
+        assertEquals(0, probes.get(),
+                "getFrontendFolder must not probe the build-created frontend folder when the project has no legacy frontend folder");
+    }
+
+    @Test
+    void getFrontendFolder_legacyFolderAndNoFrontendDir_legacyReturned(
+            @TempDir File projectRoot) {
+        File legacy = new File(projectRoot, FrontendUtils.LEGACY_FRONTEND_DIR);
+        assertTrue(legacy.mkdirs());
+        File frontendDir = new File(projectRoot, "src/main/frontend");
+
+        assertEquals(legacy,
+                FrontendUtils.getFrontendFolder(projectRoot, frontendDir));
+    }
+
+    @Test
+    void getFrontendFolder_legacyFolderAndExistingFrontendDir_frontendDirReturned(
+            @TempDir File projectRoot) {
+        assertTrue(new File(projectRoot, FrontendUtils.LEGACY_FRONTEND_DIR)
+                .mkdirs());
+        File frontendDir = new File(projectRoot, "src/main/frontend");
+        assertTrue(frontendDir.mkdirs());
+
+        assertEquals(frontendDir,
+                FrontendUtils.getFrontendFolder(projectRoot, frontendDir));
+    }
+
+    @Test
+    void getFrontendFolder_legacyFolderAndCustomFrontendDir_customDirReturned(
+            @TempDir File projectRoot) {
+        assertTrue(new File(projectRoot, FrontendUtils.LEGACY_FRONTEND_DIR)
+                .mkdirs());
+        File customFrontendDir = new File(projectRoot, "my-frontend");
+
+        assertEquals(customFrontendDir, FrontendUtils
+                .getFrontendFolder(projectRoot, customFrontendDir));
+    }
+
+    private static File probeCountingFile(String path, AtomicInteger probes) {
+        return new File(path) {
+            @Override
+            public boolean exists() {
+                probes.incrementAndGet();
+                return super.exists();
+            }
+        };
     }
 }


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #25408 to branch 25.1.
---
#### Original PR description
> `getFrontendFolder` tested the frontend directory for existence before looking for the legacy `frontend/` folder. It feeds scalar task `@Input`s, so it is evaluated while the configuration cache entry is stored, and Gradle records the probe as a file-system-entry input of that entry. The build then creates the probed directory itself: it is the parent of the optional `src/main/frontend/index.html` output, which Gradle materialises even when the task comes from the build cache. The next build therefore reports
>
>     configuration cache cannot be reused because the file system entry
>     'src/main/frontend' has been created
>
> and re-stores the entry, although the project did not change. With no legacy folder present the probe cannot change the result either, so the reconfiguration buys nothing.
>
> Probe the legacy folder first. All three conditions were already ANDed together, so the behaviour is unchanged, and `&&` short-circuits the probe on the build-created path away on every project that has no legacy frontend folder.
>
> The existing configuration cache tests create `src/main/frontend` up front, which is the state a fresh checkout is never in, so the new tests build twice without it.
>
> Fixes #25407
---
