### PR TITLE
docs: document ComponentEvent.getSource as the listener component #19850

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEvent.java
@@ -78,6 +78,16 @@ public class ComponentEvent<T extends Component> extends EventObject {
         this.ui = ui;
     }
 
+    /**
+     * Returns the component on which the listener has been attached.
+     * <p>
+     * This is the component the listener was registered with, not a nested
+     * child where a browser event may first have occurred. For example, if a
+     * listener is added to a layout that contains a checkbox,
+     * {@code getSource()} returns the layout, not the checkbox.
+     *
+     * @return the component on which the listener has been attached
+     */
     @SuppressWarnings("unchecked")
     @Override
     public T getSource() {


### PR DESCRIPTION
`ComponentEvent.getSource()` inherited EventObject's javadoc ("the object on which the Event initially occurred"). That reads as if a nested child is the source.

This documents that getSource is the component the listener was registered with. Same idea as the example in #19850.

Fixes #19850