### PR TITLE
fix(devloop): ask the dev server whether a frontend change compiles

### DIFF
--- a/flow-devloop-daemon/README.md
+++ b/flow-devloop-daemon/README.md
@@ -284,20 +284,43 @@ load-bearing rather than tidiness: a bundled edit escalates to a restart, the re
 re-registers, and without the re-seed the same file would be offered again after the restart
 that already folded it into the bundle — restarting the app for ever.
 
-**A Vite compile error is found through the log, not the protocol.** Flow pipes every line
-Vite writes through `DevServerOutputTracker` at `INFO`, so a TypeScript syntax error arrives
-looking like progress: the level says `INFO` and the word "error" is lower case, and even the
-detail line does not help because `[PARSE_ERROR]` has no word boundary before `ERROR`. `AppLog`
-matches those openers separately (`DEV_SERVER_ERROR`), on the first line of a report rather
-than on anything containing "error" - the report runs to a source excerpt, a caret diagram and
-a JavaScript stack, and counting each line would turn one broken file into a dozen errors.
+**A Vite compile error is found by asking the dev server, with the log as the fallback.**
+Vite compiles a module when something *requests* it - not when the file is saved, and not when
+`apply` runs. So the log alone cannot answer whether the frontend half of a change is live: it
+holds a report only if a browser happened to re-fetch the module while the daemon was watching,
+and a page already showing the error overlay does not re-fetch at all. Every other signal then
+says the change went fine, and the apply reports a clean `Stable` over a file the page cannot
+load.
 
-Two things follow from Vite compiling on **save** rather than on apply. The error is already in
-the log when `apply` starts, so `Watch.mark()` would drop it as somebody else's; only
-dev-server errors, and only when a frontend file actually changed, are carried across that
-boundary (`Transaction.carriedLogErrors`, merged in `finish`). And when the browser fetches the
-module during the apply instead, the error lands asynchronously, so the frontend leg settles in
-Vite mode exactly as the redefine leg does.
+So the frontend leg asks. `FRONTEND_CHECK <paths>` has the connector fetch each changed file
+through `DevModeHandler.prepareConnection`, exactly as the browser would and on the base Vite
+was actually launched with (`ViteHandler.getPathToVaadin()`, so an app on a context path works
+too). A `500` is a refusal and carries Vite's own message in the error page it serves for its
+overlay; a `200` means the module compiles. Only `500` counts - a `404` means the dev server
+does not serve that path at all, and failing an apply over one would be a worse answer than the
+truth.
+
+The answer is authoritative **in both directions**, which is the point. A refusal fails the
+apply (`Transaction.devServerRefusal`) and leaves the file unmarked, so the next apply asks
+again rather than reporting `no changes` over a module that never compiled. And a clean answer
+*overrules the log* (`Transaction.devServerAsked`): once the file is fixed, the report still in
+the log describes the version before the fix - and the daemon's own request for the broken one
+is among the things that put it there - so trusting the log would fail the very apply that
+repaired the problem.
+
+The log is still read, for the dev server that cannot be asked: an app too old to know the
+command, or one whose dev server has gone away. Flow pipes every line Vite writes through
+`DevServerOutputTracker` at `INFO`, so a TypeScript syntax error arrives looking like progress:
+the level says `INFO` and the word "error" is lower case, and even the detail line does not
+help because `[PARSE_ERROR]` has no word boundary before `ERROR`. `AppLog` matches those
+openers separately (`DEV_SERVER_ERROR`), on the first line of a report rather than on anything
+containing "error" - the report runs to a source excerpt, a caret diagram and a JavaScript
+stack, and counting each line would turn one broken file into a dozen errors. Because Vite
+compiles on save, that error is already in the log when `apply` starts and `Watch.mark()` would
+drop it as somebody else's; only dev-server errors, and only when a frontend file actually
+changed, are carried across that boundary (`Transaction.carriedLogErrors`, merged in `finish`).
+And when the browser fetches the module during the apply instead, the error lands
+asynchronously, so the frontend leg settles in Vite mode exactly as the redefine leg does.
 
 The quoted line is wrapped, not truncated, and its layout prefix is stripped first. Spring
 Boot spends about a hundred characters on a timestamp, a level, a pid, a thread and an
@@ -331,6 +354,15 @@ VAADIN_DEV_DAEMON_OPTS="-Dvaadin.frontend.hotdeploy=true" .vaadin/vaadin-dev sta
 #   edit src/main/frontend/<something>.ts
 .vaadin/vaadin-dev apply
 #   expect: hmr: N frontend file(s), applied by Vite (dev server up:<port>)
+
+#   then break the same file - a missing brace is enough - and, with nothing
+#   open in a browser, so the log stays silent about it:
+.vaadin/vaadin-dev apply
+#   expect: exit 1, "dev server: <file>: Transform failed ...", and the same
+#   answer again on a repeat apply and after re-saving the file still broken
+#   fix the file
+.vaadin/vaadin-dev apply
+#   expect: exit 0, Stable - the report left in the log must not fail this one
 ```
 
 ## Known limits

--- a/flow-devloop-daemon/README.md
+++ b/flow-devloop-daemon/README.md
@@ -284,61 +284,57 @@ load-bearing rather than tidiness: a bundled edit escalates to a restart, the re
 re-registers, and without the re-seed the same file would be offered again after the restart
 that already folded it into the bundle — restarting the app for ever.
 
-**A Vite compile error is found by asking the dev server, with the log as the fallback.**
-Vite compiles a module when something *requests* it - not when the file is saved, and not when
-`apply` runs. So the log alone cannot answer whether the frontend half of a change is live: it
-holds a report only if a browser happened to re-fetch the module while the daemon was watching,
-and a page already showing the error overlay does not re-fetch at all. Every other signal then
-says the change went fine, and the apply reports a clean `Stable` over a file the page cannot
-load.
+**A Vite compile error is found by asking the dev server, not by overhearing it.** Vite compiles
+a module when something *requests* it - not on save, and not when `apply` runs. So the log holds a
+report only if a browser happened to re-fetch while the daemon was watching, and a page already
+showing the error overlay does not re-fetch at all; every other signal then says the change went
+fine, and the apply reports a clean `Stable` over a file the page cannot load. So the frontend leg
+asks. `FRONTEND_CHECK <paths>` has the connector fetch each changed file through
+`DevModeHandler.prepareConnection`, on the base Vite was actually launched with
+(`ViteHandler.getPathToVaadin()`, so an app on a context path works too). A `500` is a refusal and
+carries Vite's own message; a `200` means the module compiles. Only `500` counts - a `404` means
+the dev server does not serve that path at all.
 
-So the frontend leg asks. `FRONTEND_CHECK <paths>` has the connector fetch each changed file
-through `DevModeHandler.prepareConnection`, exactly as the browser would and on the base Vite
-was actually launched with (`ViteHandler.getPathToVaadin()`, so an app on a context path works
-too). A `500` is a refusal and carries Vite's own message in the error page it serves for its
-overlay; a `200` means the module compiles. Only `500` counts - a `404` means the dev server
-does not serve that path at all, and failing an apply over one would be a worse answer than the
-truth.
+A `200` is not the whole story, though, because it answers only the question it was asked: can
+this module be *served*. Types are stripped without being checked, so a type error - and a
+stray `>` in JSX, which oxc tolerates and `tsc` does not - comes back `200`, runs, and is still
+wrong. That failure exists only in the log, where `vite-plugin-checker` writes it
+(`CHECKER_ERROR`, told apart from `DEV_SERVER_ERROR` for exactly this reason). It type-checks
+within about a hundred milliseconds of the *save*, so its report is already there by the time
+anyone runs `apply` - which is why the checker's errors are carried across `Watch.mark()` like
+the dev server's, and why not carrying them let a broken `.tsx` through as `Stable`. Fatal only
+when the change-set touched a frontend file, so a Java-only edit is never failed by a type
+error somebody else left behind.
 
-The answer is authoritative **in both directions**, which is the point. A refusal fails the
-apply (`Transaction.devServerRefusal`) and leaves the file unmarked, so the next apply asks
-again rather than reporting `no changes` over a module that never compiled. And a clean answer
-*overrules the log* (`Transaction.devServerAsked`): once the file is fixed, the report still in
-the log describes the version before the fix - and the daemon's own request for the broken one
-is among the things that put it there - so trusting the log would fail the very apply that
-repaired the problem.
+The answer is authoritative **in both directions**, which is the point. A refusal fails the apply
+(`Transaction.devServerRefusal`) and leaves the file unmarked, so the next apply asks again rather
+than reporting `no changes` over a module that never compiled. And a clean answer *overrules the
+log* (`Transaction.devServerAsked`): once the file is fixed, the report still in the log describes
+the version before the fix - the daemon's own request for the broken one is among the things that
+put it there - so trusting the log would fail the very apply that repaired the problem. That
+overruling is scoped to transform errors, the only ones the fetch answers for; the checker's
+verdict is read from the log either way. The log stays the whole fallback for a dev server that
+cannot be asked: an app too old for the command, or one
+whose dev server has gone away. It takes finding, because Flow pipes Vite's output through
+`DevServerOutputTracker` at `INFO` - the level says `INFO`, "error" is lower case, and
+`[PARSE_ERROR]` has no word boundary before `ERROR` - so `AppLog` matches those openers separately
+(`DEV_SERVER_ERROR`). An error Vite logged on save is already there when `apply` starts, so
+dev-server errors are carried across `Watch.mark()` when a frontend file actually changed
+(`Transaction.carriedLogErrors`); one logged mid-apply is caught by settling, as in the redefine
+leg.
 
-The log is still read, for the dev server that cannot be asked: an app too old to know the
-command, or one whose dev server has gone away. Flow pipes every line Vite writes through
-`DevServerOutputTracker` at `INFO`, so a TypeScript syntax error arrives looking like progress:
-the level says `INFO` and the word "error" is lower case, and even the detail line does not
-help because `[PARSE_ERROR]` has no word boundary before `ERROR`. `AppLog` matches those
-openers separately (`DEV_SERVER_ERROR`), on the first line of a report rather than on anything
-containing "error" - the report runs to a source excerpt, a caret diagram and a JavaScript
-stack, and counting each line would turn one broken file into a dozen errors. Because Vite
-compiles on save, that error is already in the log when `apply` starts and `Watch.mark()` would
-drop it as somebody else's; only dev-server errors, and only when a frontend file actually
-changed, are carried across that boundary (`Transaction.carriedLogErrors`, merged in `finish`).
-And when the browser fetches the module during the apply instead, the error lands
-asynchronously, so the frontend leg settles in Vite mode exactly as the redefine leg does.
-
-The quoted line is wrapped, not truncated, and its layout prefix is stripped first. Spring
-Boot spends about a hundred characters on a timestamp, a level, a pid, a thread and an
-abbreviated logger; truncating with that still attached spent the whole budget saying nothing
-and cut off the diagnosis. A compiler message is the one output whose tail matters as much as
-its head, so `TransactionEngine.quote` gives each segment its own row and wraps at 100 columns
-- letting a token longer than that overflow rather than splitting a path the reader wants to
-copy. `AppLog` carries two things out of the report, because "Transform failed with 1 error:"
-is neither: what went wrong, and where (minus the `?t=` cache-buster Vite hangs off every
-hot-updated module). The source excerpt, the caret row and the JavaScript stack are skipped
-(`REPORT_DECORATION`): the excerpt is the developer's own code, a caret diagram cannot line up
-inside an indented, wrapped summary, and the position above it is what they actually need.
-
-The parts of one error are joined with a unit separator rather than a `|`, because a report is
-full of pipes - when the renderer falls back to ASCII, a source excerpt is drawn as
-`1 | export function ...`, and splitting on that turned one line of the developer's code into
-two rows with the gutter missing. The separator never leaves the daemon: `--json` and the
-one-line reason both put ` | ` back.
+Either way the report is compacted to three parts and **wrapped, not truncated**. The opening
+line, the line naming the error and the source position are kept; the excerpt, caret diagram and
+JavaScript stack are dropped (`REPORT_DECORATION`), because the excerpt is the developer's own
+code and a caret diagram cannot line up inside an indented summary. `AppLog.report` does this for
+a report that arrives whole from the connector and `Watch` line by line for one read out of the
+log, which is why the connector joins its lines with the separator rather than flattening them to
+spaces. The parts are joined with a unit separator rather than a `|`, because an ASCII excerpt is
+drawn as `1 | export function ...` and splitting on that lost the gutter; it never leaves the
+daemon, as `--json` and the one-line reason both put ` | ` back. `quote` and `reasonRows` then wrap
+at 100 columns, letting a long path overflow a row rather than be cut in half - a compiler message
+is the one output whose tail matters as much as its head, and truncating a refusal at 160
+characters cut off "Unterminated string constant" on a message whose head is an absolute path.
 
 **Vite mode is verified by hand**, because `hotdeploy` is baked into the app JVM from the
 daemon's own system properties and `flow-tests/test-devloop` deliberately shares one

--- a/flow-devloop-daemon/README.md
+++ b/flow-devloop-daemon/README.md
@@ -293,7 +293,13 @@ asks. `FRONTEND_CHECK <paths>` has the connector fetch each changed file through
 `DevModeHandler.prepareConnection`, on the base Vite was actually launched with
 (`ViteHandler.getPathToVaadin()`, so an app on a context path works too). A `500` is a refusal and
 carries Vite's own message; a `200` means the module compiles. Only `500` counts - a `404` means
-the dev server does not serve that path at all.
+the dev server does not serve that path at all. The paths are joined with the unit separator
+(`U+001F`) rather than a comma, which is a legal character in a Unix path. The check is bounded:
+each probe makes Vite compile on demand, and a cold or restarting dev server is slow, so the
+connector answers well inside the daemon's 30s wait and reports a timeout, a reset, or a
+request that could not be answered as *inconclusive* rather than as "served" - an unanswered
+request is not proof the module compiles, so the verdict falls back to the log instead of
+letting a swallowed error read as a `200`.
 
 A `200` is not the whole story, though, because it answers only the question it was asked: can
 this module be *served*. Types are stripped without being checked, so a type error - and a

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/AppLog.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/AppLog.java
@@ -114,6 +114,41 @@ final class AppLog {
                     + "|Failed to resolve import ");
 
     /**
+     * A failure from the dev server's checker, which type-checks in the
+     * background rather than on the way to the browser.
+     * <p>
+     * A separate question from {@link #DEV_SERVER_ERROR}, and the distinction
+     * is load-bearing: a transform error means the module cannot be served, and
+     * fetching it answers that definitively. A type error does not - oxc strips
+     * the types without checking them, so the module is served, runs, and is
+     * still wrong. Fetching it comes back {@code 200}, so the log is the only
+     * place this failure exists and a clean fetch must not be taken to overrule
+     * it.
+     * <p>
+     * Matched on {@code vite-plugin-checker}'s own opener, not on
+     * {@code [TypeScript] Found N error(s)}: that line comes after the report,
+     * so counting it too would make one broken file two errors, and it is
+     * printed for a clean run as {@code Found 0 error(s)}.
+     */
+    private static final Pattern CHECKER_ERROR = Pattern
+            .compile("\\bERROR\\((?:TypeScript|ESLint|Stylelint|vue-tsc)\\)");
+
+    /**
+     * The checker saying the project is clean, which is what makes its verdict
+     * answerable at all.
+     * <p>
+     * It announces both outcomes on every pass, so the pair of patterns is a
+     * state the daemon can track rather than a stream of events whose currency
+     * it has to guess. Without the clean half an error stayed true for the rest
+     * of the run: fixing the file and applying reported the failure that had
+     * just been repaired, because the report was still in the window and
+     * nothing said it had been superseded.
+     */
+    private static final Pattern CHECKER_CLEAN = Pattern
+            .compile("\\[(?:TypeScript|ESLint|Stylelint|vue-tsc)\\]\\s+"
+                    + "(?:No errors|Found 0 error)");
+
+    /**
      * The line that opens a stack trace - the exception's own type and message.
      * A logger prints its message first and the throwable on the line below, so
      * this is where the type is, and the type is what says whether a redefine
@@ -209,7 +244,7 @@ final class AppLog {
      * position above it are what they actually need. The log keeps the rest.
      */
     private static final Pattern REPORT_DECORATION = Pattern
-            .compile("^\\s*\\d+\\s*[|│]" + "|^[\\s|│─┬╭╰"
+            .compile("^\\s*>?\\s*\\d+\\s*[|│]" + "|^[\\s|│─┬╭╰"
                     + "╯├┤┌┐└┘^~'`,.:*-]*$" + "|^at\\s");
 
     /** Errors kept per window; a reply quoting more than this helps nobody. */
@@ -237,6 +272,79 @@ final class AppLog {
      */
     static boolean devServerError(String line) {
         return DEV_SERVER_ERROR.matcher(line).find();
+    }
+
+    /**
+     * Whether one log line is a failure the dev server's checker reported.
+     *
+     * @param line
+     *            a log line
+     * @return {@code true} if the checker reported a failure on it
+     */
+    static boolean checkerError(String line) {
+        return CHECKER_ERROR.matcher(line).find();
+    }
+
+    /**
+     * Whether one log line is a frontend failure of either kind - a module the
+     * dev server could not transform, or one its checker rejected. What both
+     * have in common is that they are attributable to a frontend change, which
+     * is what earns them a carry across {@link Watch#mark()}.
+     *
+     * @param line
+     *            a log line
+     * @return {@code true} if the frontend toolchain reported a failure on it
+     */
+    static boolean frontendError(String line) {
+        return devServerError(line) || checkerError(line);
+    }
+
+    /**
+     * A dev-server report compacted to the parts that diagnose it: the opening
+     * line, the line naming the error, and the source position.
+     * <p>
+     * The same rule {@link Watch} applies to a report it reads line by line out
+     * of the log, for one that arrives whole instead - the connector asks the
+     * dev server directly and gets the entire message back in one piece.
+     * Without it the source excerpt, the caret diagram and the JavaScript stack
+     * all come along, and a verdict line that is mostly box-drawing says less
+     * than the three parts that matter.
+     *
+     * @param lines
+     *            the report, one entry per line
+     * @return the parts worth reporting, joined with {@link #SEGMENT}
+     */
+    static String report(List<String> lines) {
+        List<String> parts = new ArrayList<>();
+        boolean detailTaken = false;
+        boolean locationTaken = false;
+        for (String raw : lines) {
+            String line = message(raw);
+            if (line.isEmpty() || (!parts.isEmpty()
+                    && REPORT_DECORATION.matcher(line).find())) {
+                // Layout and the developer's own source, not the diagnosis.
+                // Read past it: what is wanted may still be below.
+                continue;
+            }
+            if (parts.isEmpty()) {
+                parts.add(line);
+                continue;
+            }
+            java.util.regex.Matcher location = SOURCE_LOCATION.matcher(line);
+            if (location.find()) {
+                if (!locationTaken) {
+                    parts.add(location.group(1) + ":" + location.group(2));
+                    locationTaken = true;
+                }
+            } else if (!detailTaken) {
+                parts.add(line);
+                detailTaken = true;
+            }
+            if (detailTaken && locationTaken) {
+                break;
+            }
+        }
+        return String.join(SEGMENT, parts);
     }
 
     /**
@@ -333,6 +441,22 @@ final class AppLog {
         private int count;
         private String failure;
         private boolean continuing;
+
+        /**
+         * The checker's latest verdict: its report while the project does not
+         * type-check, or {@code null} once it says the project is clean.
+         * <p>
+         * Deliberately outlives {@link #mark()}, unlike everything else here. A
+         * logged error is an event belonging to a window; a type-check result
+         * is the current state of the project, and the checker only
+         * re-announces it when something changes. Clearing it per window would
+         * mean an apply saw the verdict only if the developer happened to save
+         * during it.
+         */
+        private String checkerFailure;
+
+        /** Whether the parts now being appended belong to that verdict. */
+        private boolean checkerBuilding;
         /**
          * Whether the last error was a dev-server one still missing its detail.
          * <p>
@@ -391,6 +515,11 @@ final class AppLog {
          * apply} can only report as an internal failure.
          */
         private void append(String text) {
+            if (checkerBuilding && checkerFailure != null) {
+                // Kept in step with the entry below so the verdict carries the
+                // position too - it outlives the window that entry lives in.
+                checkerFailure = checkerFailure + SEGMENT + text;
+            }
             int last = errors.size() - 1;
             if (last < 0) {
                 return;
@@ -402,16 +531,28 @@ final class AppLog {
         synchronized List<String> drain() {
             List<String> lines = cursor.drain();
             for (String line : lines) {
+                if (CHECKER_CLEAN.matcher(line).find()) {
+                    // Supersedes whatever it last said: the project
+                    // type-checks now.
+                    checkerFailure = null;
+                    checkerBuilding = false;
+                }
                 boolean header = THROWN_HEADER.matcher(line).find();
                 boolean logged = ERROR_LINE.matcher(line).find()
                         || DEV_SERVER_ERROR.matcher(line).find();
                 if (logged) {
+                    if (checkerError(line)) {
+                        checkerFailure = line;
+                        checkerBuilding = true;
+                    } else {
+                        checkerBuilding = false;
+                    }
                     count++;
                     continuing = errors.size() < MAX_ERRORS;
                     if (continuing) {
                         errors.add(line);
                     }
-                    detailScan = continuing && devServerError(line)
+                    detailScan = continuing && frontendError(line)
                             ? DETAIL_SCAN_LINES
                             : 0;
                     detailTaken = false;
@@ -477,6 +618,9 @@ final class AppLog {
             detailScan = 0;
             detailTaken = false;
             locationTaken = false;
+            // The verdict itself stays - see the field. Only the half-built
+            // detail is dropped, exactly as it is for the errors above.
+            checkerBuilding = false;
         }
 
         /**
@@ -512,6 +656,17 @@ final class AppLog {
                 }
             }
             return errors();
+        }
+
+        /**
+         * The checker's verdict as it stands, drained up to now: its report
+         * while the project does not type-check, empty once it is clean.
+         *
+         * @return the report, or empty when the project type-checks
+         */
+        synchronized Optional<String> checkerFailure() {
+            drain();
+            return Optional.ofNullable(checkerFailure);
         }
 
         /** The errors in this window, without waiting for more. */

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
@@ -135,6 +135,21 @@ final class TransactionEngine {
          * the previous apply instead, and this is that carry-over.
          */
         volatile List<String> carriedLogErrors = List.of();
+
+        /**
+         * What the dev server said when asked to serve this change's frontend
+         * files, if it refused one. Null when it served them all, when there
+         * was nothing to ask about, or when the app could not be asked.
+         */
+        volatile String devServerRefusal;
+
+        /**
+         * Whether the dev server actually answered about this change. Told
+         * apart from {@link #devServerRefusal} being null because "it served
+         * every file" and "nobody could be asked" are opposite answers: the
+         * first one overrules the log, the second one has to trust it.
+         */
+        volatile boolean devServerAsked;
         long detectMs;
         long compileMs;
         long runtimeMs;
@@ -493,6 +508,10 @@ final class TransactionEngine {
             tx.frontendMode = plan.hasWork()
                     ? (plan.vite() ? "vite" : "dev-bundle")
                     : "";
+            // Asked before the plan is described, not after: the line
+            // below says what became of these files, and "Vite applied them on
+            // save" is not true of one Vite refused to compile.
+            askDevServer(plan, tx, log);
             if (plan.hasWork()) {
                 describeFrontend(plan, tx, log);
             }
@@ -862,7 +881,9 @@ final class TransactionEngine {
             Launch.Log log) {
         String where = plan.vite() ? "Vite " + tx.frontend : "dev bundle";
         String consequence;
-        if (plan.vite()) {
+        if (plan.vite() && tx.devServerRefusal != null) {
+            consequence = "the dev server refused one of them";
+        } else if (plan.vite()) {
             consequence = "Vite applied them on save";
         } else if (!plan.escalation().isEmpty()) {
             consequence = "a restart rebuilds the bundle";
@@ -955,8 +976,11 @@ final class TransactionEngine {
         if (!plan.hasWork() || plan.vite() || active == null
                 || !active.isOpen()) {
             // Nothing to do, but the bytes are accounted for either way: Vite
-            // already applied them, so offering them again would be a lie.
-            markFrontendApplied(plan);
+            // already applied them, so offering them again would be a lie -
+            // unless it would, because Vite refused to compile them.
+            if (mayMarkApplied(tx)) {
+                markFrontendApplied(plan);
+            }
             return true;
         }
         if (!plan.themeCss().isEmpty()) {
@@ -992,8 +1016,83 @@ final class TransactionEngine {
             // that did not happen.
             tx.servedLive = plan.servedLive().size();
         }
-        markFrontendApplied(plan);
+        if (mayMarkApplied(tx)) {
+            markFrontendApplied(plan);
+        }
         return true;
+    }
+
+    /**
+     * Whether these frontend bytes may be written off as live.
+     * <p>
+     * A file the dev server refused is not, however the leg above went: the
+     * page is still loading the last version that compiled. Marking it anyway
+     * is what made the apply after a refused one report {@code no changes} -
+     * the file was accounted for, so nothing was left to notice - which is the
+     * same green answer over a broken module, one apply later.
+     */
+    private boolean mayMarkApplied(Transaction tx) {
+        return tx.devServerRefusal == null;
+    }
+
+    /**
+     * Asks the dev server to serve every frontend file in this change, and
+     * remembers what it said if it refused one.
+     * <p>
+     * Vite compiles a module when something requests it, not when {@code apply}
+     * runs. So whether its complaint lands in the log while the daemon is
+     * watching depends on whether a browser happened to re-fetch the module
+     * during those few hundred milliseconds - and a page already showing the
+     * error overlay does not re-fetch at all. The report then sits in the log
+     * from an earlier window, this window is silent, and the apply reports a
+     * clean {@code Stable} over a file the page cannot load. Asking turns that
+     * race into a question with an answer, and one that is right in both
+     * directions: the dev server refuses the module while it is broken and
+     * serves it once it is fixed, so nothing has to remember a stale verdict.
+     * <p>
+     * Only in Vite mode. A dev bundle was built before the app started, so
+     * there is no dev server to ask - and no on-demand compile to be wrong
+     * about.
+     * <p>
+     * Silence is not a refusal. An app too old to know the command, one whose
+     * connector cannot answer, or a dev server that is unreachable all leave
+     * this unset, and the verdict falls back to what the log says - which is
+     * what it was before.
+     */
+    private void askDevServer(Frontend.Plan plan, Transaction tx,
+            Launch.Log log) {
+        Connector active = this.connector;
+        if (!plan.vite() || active == null || !active.isOpen()) {
+            return;
+        }
+        List<Path> modules = new ArrayList<>();
+        modules.addAll(plan.themeCss());
+        modules.addAll(plan.servedLive());
+        modules.addAll(plan.bundled());
+        if (modules.isEmpty()) {
+            return;
+        }
+        Optional<String> reply = active
+                .command("FRONTEND_CHECK " + join(modules), 30);
+        if (reply.isEmpty() || !reply.get().startsWith("OK")) {
+            return;
+        }
+        Map<String, String> fields = Connector.fields(reply.get());
+        // Recorded even when nothing was refused, and that is the load-bearing
+        // half: it is what lets a clean answer overrule a log that still holds
+        // the report from before the file was fixed.
+        tx.devServerAsked = true;
+        if (parseInt(fields.get("refused")) == 0) {
+            return;
+        }
+        String file = fields.getOrDefault("file", "a frontend file");
+        tx.devServerRefusal = file + ": " + fields.getOrDefault("message",
+                "the dev server would not compile it");
+        // Said plainly rather than left to the verdict line: a restart is the
+        // usual answer to "not live", and it is the wrong one here - nothing
+        // but an edit to the file can make this compile.
+        log.line("dev server refused " + file
+                + "; only fixing the file can apply that");
     }
 
     private void markFrontendApplied(Frontend.Plan plan) {
@@ -1180,8 +1279,16 @@ final class TransactionEngine {
      * hands an agent a green answer for a file the browser cannot load, which
      * is the one answer this daemon must never give.
      * <p>
-     * Both windows are read. An error Vite logged when the file was saved sits
-     * in {@code carriedLogErrors} - it happened before this apply started,
+     * The dev server's own answer settles it whenever there is one, in both
+     * directions, because it was asked about this change and answers for the
+     * files as they are on disk now. A clean answer therefore overrules the
+     * log: an error in it describes the file as it was before this edit fixed
+     * it, and the daemon's own request is one of the things that put it there.
+     * The log is the fallback for what cannot be asked - an app too old for the
+     * command, or a dev server that has gone away.
+     * <p>
+     * Both log windows are read. An error Vite logged when the file was saved
+     * sits in {@code carriedLogErrors} - it happened before this apply started,
      * which is precisely why it was carried across - and one logged while the
      * apply ran is in what settling collected.
      * <p>
@@ -1194,6 +1301,12 @@ final class TransactionEngine {
             // server is complaining about. Anything else in the log belongs to
             // an edit this apply was not asked about, and failing over it would
             // be a worse answer than the truth.
+            return Optional.empty();
+        }
+        if (tx.devServerRefusal != null) {
+            return Optional.of(tx.devServerRefusal);
+        }
+        if (tx.devServerAsked) {
             return Optional.empty();
         }
         return java.util.stream.Stream
@@ -1446,6 +1559,17 @@ final class TransactionEngine {
                 tx.logErrors.stream().filter(line -> !merged.contains(line))
                         .forEach(merged::add);
                 tx.logErrors = List.copyOf(merged);
+            }
+            // The dev server was asked about these very files and served them
+            // all, so its reports in the log describe the version this edit
+            // replaced - the daemon's own request for the broken one among
+            // them. Quoting a parse error under a Stable verdict reads as a
+            // green answer over a broken page, which is the confusion this
+            // whole leg exists to prevent. What the app logged itself stays:
+            // that is still about the run.
+            if (tx.devServerAsked && tx.devServerRefusal == null) {
+                tx.logErrors = tx.logErrors.stream()
+                        .filter(line -> !AppLog.devServerError(line)).toList();
             }
             // A superseded transaction is not the answer to "what is the
             // state?".

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
@@ -150,6 +150,15 @@ final class TransactionEngine {
          * first one overrules the log, the second one has to trust it.
          */
         volatile boolean devServerAsked;
+
+        /**
+         * The checker's verdict on the project as this apply read it: its
+         * report, or null when it says the project type-checks. Read from the
+         * log rather than asked for, because nothing serves it - but a verdict,
+         * not a sighting, so an error the developer has since fixed cannot fail
+         * this apply.
+         */
+        volatile String checkerFailure;
         long detectMs;
         long compileMs;
         long runtimeMs;
@@ -449,12 +458,13 @@ final class TransactionEngine {
             // With one exception, taken before the window closes: a dev server
             // compiles on save, so its complaint about a file in this very
             // change-set is already in the log and would be dropped as
-            // somebody else's. Only dev-server errors, and only when a frontend
+            // somebody else's - and its checker type-checks on save too, a
+            // moment later. Only frontend errors, and only when a frontend
             // file actually changed, so nothing else is carried across.
             if (!frontendChanges.isEmpty()) {
                 tx.carriedLogErrors = app.watch().map(AppLog.Watch::errors)
                         .orElse(List.of()).stream()
-                        .filter(AppLog::devServerError).toList();
+                        .filter(AppLog::frontendError).toList();
             }
             app.watch().ifPresent(AppLog.Watch::mark);
 
@@ -695,7 +705,7 @@ final class TransactionEngine {
                             Optional<String> broken = devServerFailure(tx);
                             if (broken.isPresent()) {
                                 return finish(tx, Outcome.FAILED,
-                                        "dev server: " + brief(broken.get()),
+                                        "dev server: " + detail(broken.get()),
                                         "hmr", DEV_SERVER_NEXT_ACTION, started);
                             }
                             tx.hotswapDetail = "redefineClasses("
@@ -946,14 +956,15 @@ final class TransactionEngine {
         // the instant the probe answers reads an empty log and calls a broken
         // file Stable, which is the same mistake the redefine leg settles to
         // avoid.
-        app.watch()
-                .ifPresent(watching -> tx.logErrors = plan.vite()
-                        ? watching.settle(ERROR_SETTLE_MILLIS)
-                        : watching.errors());
+        app.watch().ifPresent(watching -> {
+            tx.logErrors = plan.vite() ? watching.settle(ERROR_SETTLE_MILLIS)
+                    : watching.errors();
+            tx.checkerFailure = watching.checkerFailure().orElse(null);
+        });
         Optional<String> broken = devServerFailure(tx);
         if (broken.isPresent()) {
             return finish(tx, Outcome.FAILED,
-                    "dev server: " + brief(broken.get()), "hmr",
+                    "dev server: " + detail(broken.get()), "hmr",
                     DEV_SERVER_NEXT_ACTION, started);
         }
         return finish(tx, Outcome.STABLE, "", "hmr", "", started);
@@ -1086,8 +1097,14 @@ final class TransactionEngine {
             return;
         }
         String file = fields.getOrDefault("file", "a frontend file");
-        tx.devServerRefusal = file + ": " + fields.getOrDefault("message",
-                "the dev server would not compile it");
+        // Compacted by the same rule a report read out of the log gets: the
+        // whole message came back, and most of a Vite report is a source
+        // excerpt and a caret diagram the reader already has in the editor.
+        String report = AppLog.report(List.of(
+                fields.getOrDefault("message", "").split(AppLog.SEGMENT, -1)));
+        tx.devServerRefusal = report.isEmpty()
+                ? file + AppLog.SEGMENT + "the dev server would not compile it"
+                : file + AppLog.SEGMENT + report;
         // Said plainly rather than left to the verdict line: a restart is the
         // usual answer to "not live", and it is the wrong one here - nothing
         // but an edit to the file can make this compile.
@@ -1257,6 +1274,7 @@ final class TransactionEngine {
         }
         List<String> errors = watching.settle(ERROR_SETTLE_MILLIS);
         tx.logErrors = errors;
+        tx.checkerFailure = watching.checkerFailure().orElse(null);
         if (!errors.isEmpty()) {
             log.line("app log: " + errors.size()
                     + " error(s) since the redefine");
@@ -1279,13 +1297,25 @@ final class TransactionEngine {
      * hands an agent a green answer for a file the browser cannot load, which
      * is the one answer this daemon must never give.
      * <p>
-     * The dev server's own answer settles it whenever there is one, in both
-     * directions, because it was asked about this change and answers for the
-     * files as they are on disk now. A clean answer therefore overrules the
-     * log: an error in it describes the file as it was before this edit fixed
-     * it, and the daemon's own request is one of the things that put it there.
-     * The log is the fallback for what cannot be asked - an app too old for the
-     * command, or a dev server that has gone away.
+     * The dev server's own answer settles the question it was asked - can this
+     * module be served - in both directions, because it answers for the files
+     * as they are on disk now. A clean answer therefore overrules a
+     * <em>transform</em> error in the log: that describes the file as it was
+     * before this edit fixed it, and the daemon's own request is one of the
+     * things that put it there.
+     * <p>
+     * It does not overrule the checker. Types are stripped without being
+     * checked, so a module with a type error is served with a {@code 200} and
+     * the fetch has no opinion on it at all - the log is the only place that
+     * failure exists.
+     * <p>
+     * The checker is therefore read as a verdict rather than as errors seen in
+     * the window, because it announces a clean project as well as a broken one.
+     * Both halves are load-bearing: it type-checks within a moment of the
+     * <em>save</em>, so a report is in the log before anyone runs {@code apply}
+     * - which is what let a broken {@code .tsx} through as {@code Stable} - and
+     * equally, an error the developer has since fixed is still sitting there,
+     * which would otherwise fail the very apply that repaired it.
      * <p>
      * Both log windows are read. An error Vite logged when the file was saved
      * sits in {@code carriedLogErrors} - it happened before this apply started,
@@ -1306,24 +1336,44 @@ final class TransactionEngine {
         if (tx.devServerRefusal != null) {
             return Optional.of(tx.devServerRefusal);
         }
+        // The checker's own verdict, not a sighting of one of its errors in
+        // the window: it announces a clean project too, so an error the
+        // developer has since fixed is superseded rather than reported back at
+        // the apply that repaired it.
+        if (tx.checkerFailure != null) {
+            return Optional.of(tx.checkerFailure);
+        }
         if (tx.devServerAsked) {
             return Optional.empty();
         }
         return java.util.stream.Stream
                 .concat(tx.carriedLogErrors.stream(), tx.logErrors.stream())
-                .filter(AppLog::devServerError).findFirst();
+                .filter(AppLog::frontendError).findFirst();
     }
 
     /** Enough of a log line to recognise it by, where there is room for one. */
     private static String brief(String line) {
-        // The layout boilerplate goes first, not last: a Spring Boot prefix is
-        // about a hundred characters of timestamp, level, pid, thread and
-        // abbreviated logger, and truncating with it still attached spends the
-        // whole budget saying nothing and cuts off the half that would let the
-        // reader fix the problem without opening the log at all.
-        String trimmed = AppLog.message(line).replace(AppLog.SEGMENT, " | ");
+        String trimmed = detail(line);
         return trimmed.length() <= 160 ? trimmed
                 : trimmed.substring(0, 157) + "...";
+    }
+
+    /**
+     * A log line as a reason reads it: whole, with its parts told apart.
+     * <p>
+     * The layout boilerplate goes first, not last. A Spring Boot prefix is
+     * about a hundred characters of timestamp, level, pid, thread and
+     * abbreviated logger, and keeping it spends the budget of any line built
+     * from this on saying nothing.
+     * <p>
+     * Not truncated. A reason that has to fit one row uses {@link #brief};
+     * everything rendered on a verdict is wrapped instead, because a compiler's
+     * message is the one output whose tail matters as much as its head -
+     * stopping just before "Unterminated string constant" leaves the reader
+     * with nothing but an instruction to go and open the log.
+     */
+    private static String detail(String line) {
+        return AppLog.message(line).replace(AppLog.SEGMENT, " | ");
     }
 
     /**
@@ -1361,6 +1411,30 @@ final class TransactionEngine {
                         + rest.substring(0, cut).strip());
                 rest = rest.substring(cut).strip();
             }
+        }
+        return rows;
+    }
+
+    /**
+     * A verdict's reason, as the rows it needs.
+     * <p>
+     * The first row stays flush left, so the reason still reads as the line
+     * under the verdict and an assertion or an eye looking for it finds it
+     * where it always was; the continuations are indented like a quoted log
+     * line, so a wrapped reason cannot be mistaken for a second reason.
+     */
+    private static List<String> reasonRows(String reason) {
+        List<String> rows = new ArrayList<>();
+        String rest = reason.strip();
+        while (!rest.isEmpty()) {
+            if (rows.size() == QUOTE_ROWS) {
+                rows.add("    ...");
+                return rows;
+            }
+            int cut = breakAt(rest);
+            rows.add((rows.isEmpty() ? "" : "    ")
+                    + rest.substring(0, cut).strip());
+            rest = rest.substring(cut).strip();
         }
         return rows;
     }
@@ -1571,6 +1645,13 @@ final class TransactionEngine {
                 tx.logErrors = tx.logErrors.stream()
                         .filter(line -> !AppLog.devServerError(line)).toList();
             }
+            // The same reasoning on the checker's own verdict: quoting a report
+            // it has since withdrawn would put a type error under a Stable
+            // that is entirely correct.
+            if (tx.checkerFailure == null) {
+                tx.logErrors = tx.logErrors.stream()
+                        .filter(line -> !AppLog.checkerError(line)).toList();
+            }
             // A superseded transaction is not the answer to "what is the
             // state?".
             if (verdict != Outcome.SUPERSEDED) {
@@ -1660,7 +1741,7 @@ final class TransactionEngine {
                 message.hint().ifPresent(hint -> lines.add("  → " + hint));
             });
             if (tx.diagnostics.isEmpty() && !tx.reason.isEmpty()) {
-                lines.add(tx.reason);
+                lines.addAll(reasonRows(tx.reason));
             }
         }
         case COMPILED -> {

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
@@ -1084,8 +1084,14 @@ final class TransactionEngine {
             return;
         }
         Optional<String> reply = active
-                .command("FRONTEND_CHECK " + join(modules), 30);
+                .command("FRONTEND_CHECK " + joinFiles(modules), 30);
         if (reply.isEmpty() || !reply.get().startsWith("OK")) {
+            // Empty means the connector did not answer inside the backstop; an
+            // ERR means the app could not conclude - a timeout, a reset, a dev
+            // server that just went down. Either way devServerAsked stays
+            // false,
+            // so the verdict falls back to the log rather than reading an
+            // inconclusive check as "served every file".
             return;
         }
         Map<String, String> fields = Connector.fields(reply.get());
@@ -1124,6 +1130,19 @@ final class TransactionEngine {
     private static String join(List<Path> paths) {
         return paths.stream().map(Path::toString)
                 .collect(java.util.stream.Collectors.joining(","));
+    }
+
+    /**
+     * The file list for {@code FRONTEND_CHECK}, joined with the unit separator
+     * rather than a comma. A comma is a legal character in a Unix path, so one
+     * in a filename would reach the app as two files it cannot resolve -
+     * undercounting the check and missing a refusal on that file. The unit
+     * separator cannot occur in a path, and matches what
+     * {@code DevLoopRedefiner.frontendCheck} splits the argument on.
+     */
+    private static String joinFiles(List<Path> paths) {
+        return paths.stream().map(Path::toString)
+                .collect(java.util.stream.Collectors.joining(AppLog.SEGMENT));
     }
 
     /**

--- a/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
+++ b/flow-devloop-daemon/src/main/java/com/vaadin/flow/devloop/daemon/TransactionEngine.java
@@ -1423,7 +1423,7 @@ final class TransactionEngine {
      * where it always was; the continuations are indented like a quoted log
      * line, so a wrapped reason cannot be mistaken for a second reason.
      */
-    private static List<String> reasonRows(String reason) {
+    static List<String> reasonRows(String reason) {
         List<String> rows = new ArrayList<>();
         String rest = reason.strip();
         while (!rest.isEmpty()) {

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/AppLogTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/AppLogTest.java
@@ -207,6 +207,46 @@ class AppLogTest {
     }
 
     @Test
+    void report_keepsTheDiagnosisAndDropsTheDrawing() {
+        // The whole message, as the dev server hands it back when asked
+        // directly rather than as lines arriving in the log. Verbatim from a
+        // real run.
+        List<String> lines = List.of("Transform failed with 1 error:", "",
+                "[PARSE_ERROR] Expected `}` but found `EOF`",
+                "   \u256d\u2500[ src/main/frontend/greeting.ts?t=1756384057:1:55 ]",
+                "   \u2502",
+                " 1 \u2502 export function greeting(): string { return 'x'",
+                "   \u2502                                    ^",
+                "    at transformWithOxc (file:///node_modules/vite/dist/node.js:1:1)");
+
+        String report = AppLog.report(lines);
+
+        // Three parts, each its own segment: what broke, why, and where. The
+        // excerpt, the caret row and the stack are the developer's own code
+        // and the log's business.
+        assertEquals(
+                List.of("Transform failed with 1 error:",
+                        "[PARSE_ERROR] Expected `}` but found `EOF`",
+                        "src/main/frontend/greeting.ts:1:55"),
+                List.of(report.split(AppLog.SEGMENT)));
+    }
+
+    @Test
+    void report_leavesAOneLineFailureWhole() {
+        // Babel puts the file, the reason and the position on a single line,
+        // and that line names a path - so nothing may be mistaken for a
+        // source location worth splitting off, and nothing may be dropped.
+        String report = AppLog.report(List.of(
+                "[BabelError] C:\\project\\src\\main\\frontend\\views\\@index.tsx:"
+                        + " Unterminated string constant. (18:20)"));
+
+        assertEquals(
+                "[BabelError] C:\\project\\src\\main\\frontend\\views\\@index.tsx:"
+                        + " Unterminated string constant. (18:20)",
+                report);
+    }
+
+    @Test
     void message_stripsTheLayoutBoilerplateAndNothingElse() {
         // Roughly a hundred characters of prefix, which is most of the budget a
         // one-line summary has to work with.
@@ -221,6 +261,66 @@ class AppLogTest {
         // A line with no prefix - a bare stack-trace header - is left alone.
         assertEquals("java.lang.IllegalStateException: boom",
                 AppLog.message("java.lang.IllegalStateException: boom"));
+    }
+
+    @Test
+    void watch_checkerTypeError_isFoundAndKeptToOneError() throws IOException {
+        Path log = log("INFO up\n");
+        AppLog.Watch watch = new AppLog.Watch(log);
+        watch.drain();
+
+        // A type error the transform cannot see: oxc strips the types without
+        // checking them, so the module is served with a 200 and only the
+        // checker knows. Verbatim from a real run, minus the timestamps.
+        append(log,
+                """
+                        INFO c.v.b.d.DevServerOutputTracker :  ERROR(TypeScript)  TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+                        INFO c.v.b.d.DevServerOutputTracker :  FILE  C:\\project\\src\\main\\frontend\\stray.tsx:4:7
+                        INFO c.v.b.d.DevServerOutputTracker :
+                        INFO c.v.b.d.DevServerOutputTracker :     2 |   return (
+                        INFO c.v.b.d.DevServerOutputTracker :   > 4 |       >
+                        INFO c.v.b.d.DevServerOutputTracker :       |       ^
+                        INFO c.v.b.d.DevServerOutputTracker : [TypeScript] Found 1 error(s)
+                        """);
+
+        List<String> errors = watch.errors();
+
+        // One error, not two: the "Found 1 error(s)" line comes after the
+        // report and would double-count it - and reads "Found 0 error(s)" on a
+        // clean run.
+        assertEquals(1, errors.size());
+        assertTrue(AppLog.checkerError(errors.get(0)), errors.get(0));
+        // A transform error it is not, which is the distinction a clean fetch
+        // turns on: fetching this module comes back 200.
+        assertFalse(AppLog.devServerError(errors.get(0)), errors.get(0));
+        // The position is carried the same way, so the reader is told which
+        // file to open; the excerpt with its "> 4 |" gutter is not.
+        assertTrue(errors.get(0).contains("stray.tsx:4:7"), errors.get(0));
+        assertFalse(errors.get(0).contains("return ("), errors.get(0));
+    }
+
+    @Test
+    void watch_checkerVerdict_isSupersededAndSurvivesAMark()
+            throws IOException {
+        Path log = log("INFO up\n");
+        AppLog.Watch watch = new AppLog.Watch(log);
+        watch.drain();
+        append(log, "INFO t :  ERROR(TypeScript)  TS2322: Type 'number' is"
+                + " not assignable to type 'string'.\n");
+
+        assertTrue(watch.checkerFailure().isPresent());
+
+        // An apply in between: the verdict is the state of the project, not an
+        // event in one window, so it has to outlive the boundary - the checker
+        // re-announces only when something changes.
+        watch.mark();
+        assertTrue(watch.checkerFailure().isPresent());
+
+        // Put the file back and save: the checker says so, and that supersedes
+        // the report still sitting in the log above it.
+        append(log, "INFO t : [TypeScript] No errors\n");
+
+        assertTrue(watch.checkerFailure().isEmpty());
     }
 
     @Test

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
@@ -117,6 +117,33 @@ class TransactionEngineTest {
     }
 
     @Test
+    void devServerFailure_isTheVerdictWhenTheDevServerRefusedTheModule() {
+        // Asked rather than overheard. Vite compiles a module when something
+        // requests it, so with no browser re-fetching there is nothing in the
+        // log at all - and the apply used to call that Stable.
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.devServerAsked = true;
+        tx.devServerRefusal = "greeting.ts: Transform failed with 1 error:"
+                + " [PARSE_ERROR] Expected `}` but found `EOF`";
+
+        assertEquals(Optional.of(tx.devServerRefusal),
+                TransactionEngine.devServerFailure(tx));
+    }
+
+    @Test
+    void devServerFailure_aServedModuleOverrulesTheErrorStillInTheLog() {
+        // The edit that fixes the file: the dev server serves it now, but the
+        // log still holds the report from before - and the daemon's own
+        // request for the broken version is one of the things that put it
+        // there. Trusting the log here fails the apply that fixed the problem.
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.devServerAsked = true;
+        tx.carriedLogErrors = List.of(VITE_ERROR);
+
+        assertTrue(TransactionEngine.devServerFailure(tx).isEmpty());
+    }
+
+    @Test
     void devServerFailure_needsAFrontendFileInTheChangeSet() {
         // Somebody else's save, mid-apply: this change touched no frontend
         // file, so the dev server cannot be complaining about it.

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
@@ -144,6 +144,36 @@ class TransactionEngineTest {
     }
 
     @Test
+    void devServerFailure_aServedModuleDoesNotOverruleTheChecker() {
+        // The gap a clean fetch cannot close: types are stripped without being
+        // checked, so a module with a type error is served with a 200 and the
+        // fetch has no opinion on it. Treating that answer as the last word
+        // let a broken .tsx through as Stable.
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.devServerAsked = true;
+        tx.checkerFailure = " ERROR(TypeScript)  TS1382: Unexpected token.";
+
+        assertEquals(Optional.of(tx.checkerFailure),
+                TransactionEngine.devServerFailure(tx));
+    }
+
+    @Test
+    void devServerFailure_ignoresACheckerReportTheCheckerHasWithdrawn() {
+        // Break a file, save, put it back, save: the checker's report for the
+        // broken version is still in the log, but it has since said the
+        // project is clean. Reading its errors rather than its verdict failed
+        // the apply that repaired the problem.
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.devServerAsked = true;
+        tx.checkerFailure = null;
+        tx.carriedLogErrors = List
+                .of(" ERROR(TypeScript)  TS2322: Type 'number' is not"
+                        + " assignable to type 'string'.");
+
+        assertTrue(TransactionEngine.devServerFailure(tx).isEmpty());
+    }
+
+    @Test
     void devServerFailure_needsAFrontendFileInTheChangeSet() {
         // Somebody else's save, mid-apply: this change touched no frontend
         // file, so the dev server cannot be complaining about it.

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
@@ -218,6 +218,143 @@ class TransactionEngineTest {
         assertEquals("    ...", rows.get(rows.size() - 1));
     }
 
+    @Test
+    void finish_dropsAServedDevServerErrorFromTheQuotedLog() {
+        // The dev server was asked about these very files and served them all,
+        // so a transform error still in the log describes the version this edit
+        // replaced - the daemon's own request for the broken one put it there.
+        // Quoting it under a Stable verdict reads as a green answer over a
+        // broken page, which is the confusion this whole leg exists to prevent.
+        TransactionEngine engine = new TransactionEngine(null, null);
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.devServerAsked = true;
+        String appOwn = "2026-08-31 ERROR 1 --- [http-nio-8080-exec-1] c.e.Foo"
+                + "  : could not reach the pricing API";
+        tx.logErrors = List.of(VITE_ERROR, appOwn);
+
+        engine.finish(tx, TransactionEngine.Outcome.STABLE, "", "hmr", "",
+                System.nanoTime());
+
+        // The stale dev-server report is gone; the app's own error, which is
+        // still about the run, stays and is the one the render quotes.
+        assertEquals(List.of(appOwn), tx.logErrors);
+        assertTrue(engine.render(tx).stream()
+                .noneMatch(line -> line.contains("Transform failed")));
+    }
+
+    @Test
+    void finish_keepsADevServerErrorTheServerWasNeverAskedAbout() {
+        // Only a clean answer overrules the log. When the app could not be
+        // asked - too old to know the command, connector unreachable - the log
+        // is all there is, so its errors must survive to be quoted.
+        TransactionEngine engine = new TransactionEngine(null, null);
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.devServerAsked = false;
+        tx.logErrors = List.of(VITE_ERROR);
+
+        engine.finish(tx, TransactionEngine.Outcome.STABLE, "", "hmr", "",
+                System.nanoTime());
+
+        assertEquals(List.of(VITE_ERROR), tx.logErrors);
+        assertTrue(engine.render(tx).stream()
+                .anyMatch(line -> line.startsWith("app log:")));
+    }
+
+    @Test
+    void finish_dropsACheckerReportTheCheckerHasWithdrawn() {
+        // The checker has since said the project type-checks, so a report of
+        // its still in the log is superseded and must not be quoted under a
+        // verdict that is entirely correct.
+        TransactionEngine engine = new TransactionEngine(null, null);
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.checkerFailure = null;
+        String checker = " ERROR(TypeScript)  TS2322: Type 'number' is not"
+                + " assignable to type 'string'.";
+        tx.logErrors = List.of(checker);
+
+        engine.finish(tx, TransactionEngine.Outcome.STABLE, "", "hmr", "",
+                System.nanoTime());
+
+        assertTrue(tx.logErrors.isEmpty(), tx.logErrors.toString());
+    }
+
+    @Test
+    void finish_keepsACheckerReportWhoseVerdictStillStands() {
+        // The verdict has not been withdrawn, so its report stays: this is the
+        // failure the apply is reporting, not one to filter away.
+        TransactionEngine engine = new TransactionEngine(null, null);
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.checkerFailure = "the project does not type-check";
+        String checker = " ERROR(TypeScript)  TS2322: Type 'number' is not"
+                + " assignable to type 'string'.";
+        tx.logErrors = List.of(checker);
+
+        engine.finish(tx, TransactionEngine.Outcome.FAILED,
+                "dev server: type error", "hmr", "fix it", System.nanoTime());
+
+        assertEquals(List.of(checker), tx.logErrors);
+    }
+
+    @Test
+    void finish_mergesCarriedErrorsAheadOfTheWindow() {
+        // A dev server compiles on save, so its complaint about a file in this
+        // change-set is already in the log before the window opens. It is
+        // carried across and folded back in ahead of what the window collected,
+        // so no leg reports Stable while an inherited error goes unmentioned.
+        TransactionEngine engine = new TransactionEngine(null, null);
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.carriedLogErrors = List.of(VITE_ERROR);
+        String appOwn = "2026-08-31 ERROR 1 --- [http-nio-8080-exec-1] c.e.Foo"
+                + "  : could not reach the pricing API";
+        tx.logErrors = List.of(appOwn);
+
+        engine.finish(tx, TransactionEngine.Outcome.FAILED, "boom", "hmr",
+                "fix it", System.nanoTime());
+
+        assertEquals(List.of(VITE_ERROR, appOwn), tx.logErrors);
+    }
+
+    @Test
+    void render_namesTheViteClauseForAFrontendStable() {
+        // A Vite-applied frontend change reports Stable through the hmr leg,
+        // and
+        // the detail line names what happened to the files and where.
+        TransactionEngine engine = new TransactionEngine(null, null);
+        TransactionEngine.Transaction tx = frontendChange();
+        tx.frontendMode = "vite";
+        tx.frontend = "up:49401";
+
+        engine.finish(tx, TransactionEngine.Outcome.STABLE, "", "hmr", "",
+                System.nanoTime());
+        List<String> lines = engine.render(tx);
+
+        assertTrue(lines.get(0).startsWith("frontend → Stable"), lines.get(0));
+        assertTrue(
+                lines.stream()
+                        .anyMatch(line -> line.contains("hmr: ")
+                                && line.contains("applied by Vite")
+                                && line.contains("up:49401")),
+                lines.toString());
+    }
+
+    @Test
+    void render_wrapsTheReasonUnderAFrontendFailed() {
+        // A frontend failure names the frontend phase, not "compiling", and its
+        // reason gets its own wrapped row rather than being cut off.
+        TransactionEngine engine = new TransactionEngine(null, null);
+        TransactionEngine.Transaction tx = frontendChange();
+        String reason = "dev server: greeting.ts | Transform failed with 1"
+                + " error: [PARSE_ERROR] Expected `}` but found `EOF`";
+
+        engine.finish(tx, TransactionEngine.Outcome.FAILED, reason, "hmr",
+                "fix the file", System.nanoTime());
+        List<String> lines = engine.render(tx);
+
+        assertEquals("frontend → Failed", lines.get(0));
+        assertEquals(reason, String.join(" ", lines.subList(1, lines.size()))
+                .replaceAll("\\s+", " ").strip());
+    }
+
     private static TransactionEngine.Transaction frontendChange() {
         TransactionEngine.Transaction tx = new TransactionEngine.Transaction(1);
         tx.frontendFiles = 1;

--- a/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
+++ b/flow-devloop-daemon/src/test/java/com/vaadin/flow/devloop/daemon/TransactionEngineTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -181,6 +182,40 @@ class TransactionEngineTest {
         tx.logErrors = List.of(VITE_ERROR);
 
         assertTrue(TransactionEngine.devServerFailure(tx).isEmpty());
+    }
+
+    @Test
+    void reasonRows_keepsTheFirstRowFlushAndIndentsTheRest() {
+        // A reason short enough to fit one row is one row, flush left, so it
+        // still reads as the line under the verdict and an eye looking for it
+        // finds it where it always was.
+        assertEquals(List.of("Transform failed"),
+                TransactionEngine.reasonRows("Transform failed"));
+
+        // A longer one wraps on a space; the continuation is indented like a
+        // quoted log line so it cannot be mistaken for a second reason.
+        String reason = "Transform failed with 1 error: [PARSE_ERROR] Expected"
+                + " a closing brace but found the end of the file instead,"
+                + " which usually means a brace above it was never opened";
+        List<String> rows = TransactionEngine.reasonRows(reason);
+
+        assertTrue(rows.size() > 1, rows.toString());
+        assertFalse(rows.get(0).startsWith(" "), rows.get(0));
+        assertTrue(rows.get(1).startsWith("    "), rows.get(1));
+        // Wrapping loses nothing: the rows, re-joined, are the reason back.
+        assertEquals(reason,
+                String.join(" ", rows).replaceAll("\\s+", " ").strip());
+    }
+
+    @Test
+    void reasonRows_stopsAtTheRowBudgetWithAnEllipsis() {
+        // A compiler can print a wall of text; a verdict quotes only so much of
+        // it before it says "...", the same cap a quoted log line gets.
+        String wall = ("word ".repeat(400)).strip();
+
+        List<String> rows = TransactionEngine.reasonRows(wall);
+
+        assertEquals("    ...", rows.get(rows.size() - 1));
     }
 
     private static TransactionEngine.Transaction frontendChange() {

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
@@ -44,13 +44,14 @@ that refreshes the data provider) or reload the page to see it. Do not re-apply;
 nothing left to compile.
 
 In **Vite mode** a TypeScript or JavaScript compile error reaches you as a `frontend → Failed`
-with `dev server:` under it, and `apply` exits `1`. Vite compiles on save rather than on apply,
-so its errors are in the log before `apply` runs and before the browser shows its red overlay;
-`apply` carries them into its own window and fails on them rather than answering a clean
-`Stable` over a file the browser is refusing to load. This is the one failure the daemon
-reports without escalating — a restart cannot compile a broken module. Fix the file and
-re-apply — the next apply is clean. A Java edit that arrived in the same change-set is already
-live; the dev server's error is about the frontend half.
+with `dev server:` under it, and `apply` exits `1`. Vite compiles a module when something
+requests it, so `apply` asks it — fetching each changed file the way the browser would — rather
+than waiting to overhear a complaint in the log. That answer does not depend on whether a page
+is open or happened to re-fetch, so a broken module is reported every time and never as a clean
+`Stable`. This is the one failure the daemon reports without escalating — a restart cannot
+compile a broken module. Fix the file and re-apply — the next apply is clean, because the dev
+server is asked again and serves the fixed file. A Java edit that arrived in the same
+change-set is already live; the dev server's error is about the frontend half.
 
 An `app log:` line means the app logged an error while the change went live — the bytes are
 live, the code did something wrong. `Stable` with this line under it is not a green result:

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
@@ -117,6 +117,18 @@ final class DevLoopRedefiner {
      */
     private static final String VITE_ERROR_MESSAGE_KEY = "\"message\":\"";
 
+    /**
+     * What the report's lines are joined with on the way back.
+     * <p>
+     * A reply is one line, so the newlines cannot survive as themselves - and
+     * flattening them to spaces would leave the daemon unable to tell the
+     * opening line from the caret diagram under it, which is what decides which
+     * parts are worth quoting. A unit separator cannot occur in the text; it
+     * matches {@code AppLog.SEGMENT} in the daemon, which is the only reader of
+     * this field.
+     */
+    private static final char REPORT_SEPARATOR = '\u001f';
+
     private DevLoopRedefiner() {
     }
 
@@ -697,10 +709,14 @@ final class DevLoopRedefiner {
                 .length(); i++) {
             char c = body.charAt(i);
             if (c == '\\' && i + 1 < body.length()) {
-                // The excerpt and caret diagram are drawn with newlines and
-                // tabs; flattened to spaces because this answer is one line.
+                // A line break becomes the separator the daemon splits the
+                // report on; a tab is only ever indentation inside one.
                 char next = body.charAt(++i);
-                text.append(next == 'n' || next == 't' ? ' ' : next);
+                if (next == 'n') {
+                    text.append(REPORT_SEPARATOR);
+                } else {
+                    text.append(next == 't' ? ' ' : next);
+                }
             } else if (c == '"') {
                 break;
             } else {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
@@ -23,6 +23,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.base.devserver.PublicResourcesLiveUpdater;
 import com.vaadin.base.devserver.ThemeLiveUpdater;
+import com.vaadin.base.devserver.ViteHandler;
 import com.vaadin.base.devserver.hotswap.Hotswapper;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.dependency.CssImport;
@@ -108,6 +110,12 @@ final class DevLoopRedefiner {
     private static final String[] PUBLIC_RESOURCE_ROOTS = {
             "/META-INF/resources/", "/static/", "/public/", "/resources/",
             "/webapp/" };
+
+    /**
+     * Where Vite puts the failure in the error page it serves for a module it
+     * could not transform - the JSON its own overlay renders.
+     */
+    private static final String VITE_ERROR_MESSAGE_KEY = "\"message\":\"";
 
     private DevLoopRedefiner() {
     }
@@ -552,6 +560,163 @@ final class DevLoopRedefiner {
         return "OK frontend=" + frontendStatus() + " mode=" + mode + " themes="
                 + join(activeThemes(service)) + " agree="
                 + agreesOnFolder(service, daemonFolder);
+    }
+
+    /**
+     * Whether the dev server can actually compile the frontend files this
+     * change touched, asked by fetching each one exactly as the browser would.
+     * <p>
+     * The log cannot answer this. Vite compiles a module when something
+     * requests it, not when {@code apply} runs, so whether an error is written
+     * while the daemon is watching depends on whether a browser happened to
+     * re-fetch - and one already showing the error overlay does not. The report
+     * then sits in the log from an earlier window, the new window is silent,
+     * and the apply reports a clean {@code Stable} over a file the page cannot
+     * load. A request is the same question with a definite answer, and it
+     * answers in both directions: {@code 500} while the file is broken,
+     * {@code 200} once it is fixed, so no stale verdict has to be remembered.
+     * <p>
+     * Only a {@code 500} is a refusal. A {@code 404} means the dev server does
+     * not serve that path at all - a file outside its root - which is not this
+     * change being broken, and failing an apply over one would be a worse
+     * answer than the truth.
+     *
+     * @param csv
+     *            the changed files, absolute, comma-separated: they ride in as
+     *            the argument rather than as a reply field because a Windows
+     *            path can contain a space
+     * @return the reply line, naming the first file the dev server refused
+     */
+    static String frontendCheck(String csv) {
+        VaadinService service = DevLoopRegistration.service();
+        if (service == null) {
+            return "ERR kind=no-service message=service-not-registered";
+        }
+        ViteHandler vite = viteHandler(service);
+        if (vite == null) {
+            // A dev bundle was built before the app started, so there is no
+            // dev server to ask and nothing compiles on demand.
+            return "OK checked=0 refused=0";
+        }
+        Path root = frontendRoot(service);
+        if (root == null) {
+            return "OK checked=0 refused=0";
+        }
+        int checked = 0;
+        for (String value : csv.split(",")) {
+            String trimmed = value.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            String relative = relativeName(root, trimmed);
+            if (relative == null) {
+                continue;
+            }
+            checked++;
+            String refusal = refusalFor(vite,
+                    vite.getPathToVaadin() + "/" + relative);
+            if (refusal != null) {
+                return "OK checked=" + checked + " refused=1 file="
+                        + oneLine(relative) + " message=" + oneLine(refusal);
+            }
+        }
+        return "OK checked=" + checked + " refused=0";
+    }
+
+    private static Path frontendRoot(VaadinService service) {
+        try {
+            return service.getDeploymentConfiguration().getFrontendFolder()
+                    .toPath().toAbsolutePath().normalize();
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    /**
+     * The file's path under the frontend folder, with forward slashes, or
+     * {@code null} for one that does not live there - the dev server's root is
+     * that folder, so nothing else has a URL on it.
+     */
+    private static String relativeName(Path root, String file) {
+        try {
+            Path path = Paths.get(file).toAbsolutePath().normalize();
+            if (!path.startsWith(root) || path.equals(root)) {
+                return null;
+            }
+            return root.relativize(path).toString().replace(File.separatorChar,
+                    '/');
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    /**
+     * What the dev server said about one module, or {@code null} if it served
+     * it. A connection that cannot be made is not a refusal either: a dev
+     * server that is unreachable is what {@link #frontendStatus()} answers, and
+     * failing an apply here would report the same thing twice.
+     */
+    private static String refusalFor(ViteHandler vite, String url) {
+        try {
+            HttpURLConnection connection = vite.prepareConnection(url, "GET");
+            int code = connection.getResponseCode();
+            if (code != HttpURLConnection.HTTP_INTERNAL_ERROR) {
+                return null;
+            }
+            return viteErrorMessage(errorBody(connection), url);
+        } catch (IOException | RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static String errorBody(HttpURLConnection connection) {
+        try (java.io.InputStream in = connection.getErrorStream()) {
+            return in == null ? ""
+                    : new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    /**
+     * The diagnosis out of the dev server's error page.
+     * <p>
+     * Vite answers a module it could not transform with an HTML page carrying
+     * the failure as a JSON object for its own overlay to render, so the
+     * {@code message} field in it is the same text Vite logs. Read best-effort
+     * and never load-bearing: the refusal is the verdict, and a page whose
+     * shape has moved still fails the apply - it just says so less precisely.
+     */
+    private static String viteErrorMessage(String body, String url) {
+        int at = body.indexOf(VITE_ERROR_MESSAGE_KEY);
+        if (at < 0) {
+            return "the dev server could not compile " + url;
+        }
+        StringBuilder text = new StringBuilder();
+        for (int i = at + VITE_ERROR_MESSAGE_KEY.length(); i < body
+                .length(); i++) {
+            char c = body.charAt(i);
+            if (c == '\\' && i + 1 < body.length()) {
+                // The excerpt and caret diagram are drawn with newlines and
+                // tabs; flattened to spaces because this answer is one line.
+                char next = body.charAt(++i);
+                text.append(next == 'n' || next == 't' ? ' ' : next);
+            } else if (c == '"') {
+                break;
+            } else {
+                text.append(c);
+            }
+        }
+        String message = text.toString().trim();
+        return message.isEmpty() ? "the dev server could not compile " + url
+                : message;
+    }
+
+    /** The dev server, or {@code null} when the app runs off a dev bundle. */
+    private static ViteHandler viteHandler(VaadinService service) {
+        return DevModeHandlerManager.getDevModeHandler(service)
+                .filter(ViteHandler.class::isInstance)
+                .map(ViteHandler.class::cast).orElse(null);
     }
 
     private static Set<String> activeThemes(VaadinService service) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
@@ -40,6 +40,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,6 +132,39 @@ final class DevLoopRedefiner {
      * this field.
      */
     private static final char REPORT_SEPARATOR = '\u001f';
+
+    /**
+     * What the {@code FRONTEND_CHECK} argument's file list is split on. A comma
+     * cannot serve: it is a legal character in a Unix path, so a filename
+     * carrying one would split into two fragments the probe then fails to
+     * resolve - undercounting the check and missing a refusal on that file. The
+     * unit separator ({@code U+001F}) cannot occur in a path, and matches what
+     * the daemon joins the list with.
+     */
+    private static final char FILE_SEPARATOR = 0x1f;
+
+    /**
+     * How long the whole check may run before it answers inconclusively.
+     * <p>
+     * The daemon abandons the {@code FRONTEND_CHECK} reply after 30s and reads
+     * the silence as "not asked", falling back to the log race this command
+     * exists to remove. Each probe makes Vite compile a module on demand, and a
+     * cold or restarting dev server over several files can outlast that
+     * backstop, so the check bounds itself well under it and reports what it
+     * could not finish rather than blocking past the point the answer is still
+     * wanted.
+     */
+    private static final long CHECK_BUDGET_MILLIS = Long
+            .getLong("vaadin.devloop.frontendCheckMillis", 20_000L);
+
+    /**
+     * Connect and read timeout for one probe, overriding the dev server
+     * handler's 120s default. A single unresponsive module has to fail fast so
+     * the whole check stays inside {@link #CHECK_BUDGET_MILLIS} rather than
+     * hitting a timeout only the daemon would notice.
+     */
+    private static final int PROBE_TIMEOUT_MILLIS = Integer
+            .getInteger("vaadin.devloop.frontendProbeMillis", 10_000);
 
     private DevLoopRedefiner() {
     }
@@ -591,13 +628,28 @@ final class DevLoopRedefiner {
      * Only a {@code 500} is a refusal. A {@code 404} means the dev server does
      * not serve that path at all - a file outside its root - which is not this
      * change being broken, and failing an apply over one would be a worse
-     * answer than the truth.
+     * answer than the truth. A request that cannot be answered at all - a
+     * reset, a dev server that just went down, or one so slow the whole check
+     * outruns its budget - is not a clean answer either: it is reported
+     * inconclusively so the daemon falls back to the log rather than reading a
+     * swallowed error as a {@code 200}.
+     * <p>
+     * Bounded on its own thread. Each probe makes Vite compile a module on
+     * demand, which a cold or restarting dev server can be slow at, and the
+     * daemon abandons this reply after 30s - so the check answers inside
+     * {@link #CHECK_BUDGET_MILLIS}, well under that backstop. Blocking past it
+     * would leave the daemon reading the silence as "not asked" and falling
+     * back to the very log race this command exists to remove, and would risk
+     * desyncing the reply the daemon reads next off the connection. The worker
+     * never writes to that connection, so abandoning it on timeout is safe.
      *
      * @param csv
-     *            the changed files, absolute, comma-separated: they ride in as
-     *            the argument rather than as a reply field because a Windows
-     *            path can contain a space
-     * @return the reply line, naming the first file the dev server refused
+     *            the changed files, absolute, joined with
+     *            {@link #FILE_SEPARATOR}: they ride in as the argument rather
+     *            than as a reply field because a Windows path can contain a
+     *            space
+     * @return the reply line, naming the first file the dev server refused, or
+     *         an {@code ERR} line when the check could not conclude
      */
     static String frontendCheck(String csv) {
         VaadinService service = DevLoopRegistration.service();
@@ -614,8 +666,40 @@ final class DevLoopRedefiner {
         if (root == null) {
             return "OK checked=0 refused=0";
         }
+        FutureTask<String> probe = new FutureTask<>(
+                () -> probeAll(vite, root, csv));
+        Thread worker = new Thread(probe, "devloop-frontend-check");
+        worker.setDaemon(true);
+        worker.start();
+        try {
+            return probe.get(CHECK_BUDGET_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            // Inconclusive, not served: a clean answer would overrule a log
+            // that may correctly hold the error, so a check that ran out of
+            // budget falls back to the log instead. The worker ends on its own
+            // once the request it is blocked on returns under its own timeout.
+            probe.cancel(true);
+            return "ERR kind=timeout message=dev-server-did-not-answer-in-time";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            probe.cancel(true);
+            return "ERR kind=interrupted message=frontend-check-interrupted";
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            return "ERR kind=internal message="
+                    + oneLine(String.valueOf(cause.getMessage()));
+        }
+    }
+
+    /**
+     * Fetches each changed frontend file in turn, stopping at the first the dev
+     * server refuses. Runs on the bounded worker {@link #frontendCheck} starts,
+     * so its only time limit is the per-request one in {@link #refusalFor}; the
+     * caller enforces the overall budget.
+     */
+    private static String probeAll(ViteHandler vite, Path root, String csv) {
         int checked = 0;
-        for (String value : csv.split(",")) {
+        for (String value : csv.split(String.valueOf(FILE_SEPARATOR), -1)) {
             String trimmed = value.trim();
             if (trimmed.isEmpty()) {
                 continue;
@@ -625,11 +709,22 @@ final class DevLoopRedefiner {
                 continue;
             }
             checked++;
-            String refusal = refusalFor(vite,
-                    vite.getPathToVaadin() + "/" + relative);
-            if (refusal != null) {
-                return "OK checked=" + checked + " refused=1 file="
-                        + oneLine(relative) + " message=" + oneLine(refusal);
+            try {
+                String refusal = refusalFor(vite,
+                        vite.getPathToVaadin() + "/" + relative);
+                if (refusal != null) {
+                    return "OK checked=" + checked + " refused=1 file="
+                            + oneLine(relative) + " message="
+                            + oneLine(refusal);
+                }
+            } catch (IOException | RuntimeException e) {
+                // The request failed rather than being answered - a connection
+                // reset mid-response, a dev server that just went down. That is
+                // not proof the module compiles, so it is not reported as
+                // served: inconclusive instead, so the verdict falls back to
+                // the log rather than a clean answer that would overrule it.
+                return "ERR kind=unreachable checked=" + checked + " file="
+                        + oneLine(relative);
             }
         }
         return "OK checked=" + checked + " refused=0";
@@ -663,22 +758,31 @@ final class DevLoopRedefiner {
     }
 
     /**
-     * What the dev server said about one module, or {@code null} if it served
-     * it. A connection that cannot be made is not a refusal either: a dev
-     * server that is unreachable is what {@link #frontendStatus()} answers, and
-     * failing an apply here would report the same thing twice.
+     * What the dev server said about one module: its message on a {@code 500},
+     * or {@code null} on any other code, which means it served the module.
+     * <p>
+     * Throws rather than guessing when the request cannot be answered at all. A
+     * reset mid-response or a connection that will not open is not proof the
+     * module compiles, so the caller reports it inconclusively and the daemon
+     * falls back to the log - a swallowed {@code IOException} read as a served
+     * {@code 200} is exactly how a broken module used to pass as
+     * {@code Stable}. A dev server that is genuinely unreachable is still
+     * {@link #frontendStatus()}'s to report; this only refuses to call an
+     * unanswered request a clean answer.
      */
-    private static String refusalFor(ViteHandler vite, String url) {
-        try {
-            HttpURLConnection connection = vite.prepareConnection(url, "GET");
-            int code = connection.getResponseCode();
-            if (code != HttpURLConnection.HTTP_INTERNAL_ERROR) {
-                return null;
-            }
-            return viteErrorMessage(errorBody(connection), url);
-        } catch (IOException | RuntimeException e) {
+    private static String refusalFor(ViteHandler vite, String url)
+            throws IOException {
+        HttpURLConnection connection = vite.prepareConnection(url, "GET");
+        // Override the dev server handler's 120s default: this probe is on the
+        // apply's critical path, inside the daemon's 30s backstop, so a single
+        // unresponsive module has to fail fast rather than hold the check open.
+        connection.setConnectTimeout(PROBE_TIMEOUT_MILLIS);
+        connection.setReadTimeout(PROBE_TIMEOUT_MILLIS);
+        int code = connection.getResponseCode();
+        if (code != HttpURLConnection.HTTP_INTERNAL_ERROR) {
             return null;
         }
+        return viteErrorMessage(errorBody(connection), url);
     }
 
     private static String errorBody(HttpURLConnection connection) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRedefiner.java
@@ -649,7 +649,7 @@ final class DevLoopRedefiner {
      * {@code null} for one that does not live there - the dev server's root is
      * that folder, so nothing else has a URL on it.
      */
-    private static String relativeName(Path root, String file) {
+    static String relativeName(Path root, String file) {
         try {
             Path path = Paths.get(file).toAbsolutePath().normalize();
             if (!path.startsWith(root) || path.equals(root)) {
@@ -699,7 +699,7 @@ final class DevLoopRedefiner {
      * and never load-bearing: the refusal is the verdict, and a page whose
      * shape has moved still fails the apply - it just says so less precisely.
      */
-    private static String viteErrorMessage(String body, String url) {
+    static String viteErrorMessage(String body, String url) {
         int at = body.indexOf(VITE_ERROR_MESSAGE_KEY);
         if (at < 0) {
             return "the dev server could not compile " + url;

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRegistration.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/devloop/DevLoopRegistration.java
@@ -227,6 +227,13 @@ final class DevLoopRegistration {
             if (request.equals("FRONTEND")) {
                 return DevLoopRedefiner.frontend(null);
             }
+            // The paths ride in as the argument for the same reason the
+            // frontend folder does above: a reply is parsed on whitespace and
+            // a Windows path can contain a space.
+            if (request.startsWith("FRONTEND_CHECK ")) {
+                return DevLoopRedefiner.frontendCheck(
+                        request.substring("FRONTEND_CHECK ".length()).trim());
+            }
             if (request.equals("PING")) {
                 return "OK pong";
             }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/devloop/DevLoopRedefinerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/devloop/DevLoopRedefinerTest.java
@@ -16,6 +16,9 @@
 package com.vaadin.base.devserver.devloop;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -190,5 +193,72 @@ class DevLoopRedefinerTest {
         assertTrue(reply.contains(" mode="), reply);
         assertTrue(reply.contains(" themes="), reply);
         assertTrue(reply.contains(" agree=?"), reply);
+    }
+
+    @Test
+    void frontendCheck_withoutAService_reportsItInTheProtocolVocabulary() {
+        // Nothing is registered in a unit test, so the connector has to say so
+        // in one line - the daemon reads "kind" and falls back to the log
+        // rather than blocking on a reply that never comes.
+        String reply = DevLoopRedefiner.frontendCheck("/tmp/a.ts");
+
+        assertTrue(reply.startsWith("ERR kind=no-service"), reply);
+    }
+
+    @Test
+    void relativeName_isTheForwardSlashedPathUnderTheFrontendRoot() {
+        Path root = Paths.get("/p/src/main/frontend").toAbsolutePath();
+
+        // A file below the root has a URL on the dev server; the name is that
+        // path, always with forward slashes so it reads as a URL on Windows
+        // too.
+        assertEquals("views/hello.tsx", DevLoopRedefiner.relativeName(root,
+                root.resolve("views/hello.tsx").toString()));
+    }
+
+    @Test
+    void relativeName_isNullForAFileOutsideTheRootOrTheRootItself() {
+        Path root = Paths.get("/p/src/main/frontend").toAbsolutePath();
+
+        // The dev server's root is the frontend folder, so nothing above or
+        // beside it has a URL - and failing an apply over a file the server was
+        // never going to serve would be a worse answer than the truth.
+        assertNull(DevLoopRedefiner.relativeName(root,
+                Paths.get("/p/src/main/java/View.java").toAbsolutePath()
+                        .toString()));
+        // The root itself is not a module either.
+        assertNull(DevLoopRedefiner.relativeName(root, root.toString()));
+    }
+
+    @Test
+    void viteErrorMessage_readsTheReportOutOfVitesErrorPage() {
+        // Vite answers a module it could not transform with an HTML page that
+        // carries the failure as a JSON message its overlay renders. A line
+        // break rides back as the separator the daemon splits on; a tab, only
+        // ever indentation, flattens to a space.
+        String body = "<html><script>{\"message\":\"Transform failed with 1"
+                + " error:\\n[PARSE_ERROR] Expected `}`\\t^\"}</script></html>";
+
+        String message = DevLoopRedefiner.viteErrorMessage(body, "any/url");
+
+        // The unit separator ('\u001f') is what AppLog.SEGMENT is on the
+        // daemon side, the only reader of this field.
+        assertEquals(
+                List.of("Transform failed with 1 error:",
+                        "[PARSE_ERROR] Expected `}` ^"),
+                List.of(message.split("\u001f")));
+    }
+
+    @Test
+    void viteErrorMessage_fallsBackWhenThePageHasNoMessage() {
+        // Best-effort and never load-bearing: the refusal is the verdict, so a
+        // page whose shape has moved - or one with an empty message - still
+        // fails the apply, just less precisely.
+        assertEquals("the dev server could not compile my/module.ts",
+                DevLoopRedefiner.viteErrorMessage("not an error page at all",
+                        "my/module.ts"));
+        assertEquals("the dev server could not compile my/module.ts",
+                DevLoopRedefiner.viteErrorMessage("{\"message\":\"\"}",
+                        "my/module.ts"));
     }
 }


### PR DESCRIPTION
Vite compiles a module when something requests it, not on save and not on apply. So whether its complaint lands in the daemon's watch window depended on whether a browser happened to re-fetch during those few hundred milliseconds - and a page already showing the error overlay does not re-fetch at all. The report then sat in app.log from an earlier window, behind Watch.mark(), the new window was silent, and every other signal said the change went fine: apply reported Stable over a module the page could not load, then no_changes on the next apply, because Vite mode marked the file applied regardless.

The frontend leg now asks instead of overhearing. FRONTEND_CHECK has the connector fetch each changed frontend file through DevModeHandler.prepareConnection, as the browser would and on the base Vite was launched with, so a context-path app works too. A 500 is a refusal and carries Vite's own message; a 200 means the module compiles; a 404 is not a refusal at all.

The answer settles it in both directions, which is the load-bearing part. devServerAsked tells "served every file" apart from "nobody could be asked": a clean answer overrules the log, because an error left in it describes the version the edit just replaced - the daemon's own request for the broken one among them - and only an unaskable dev server falls back to the log. A refusal also leaves the file unmarked, so a repeat apply asks again rather than going quiet. The log line and the quoted errors follow suit: no claim that Vite applied a file it refused, and no stale parse error under Stable.

Verified by hand in Vite mode per the README sequence, which now covers the broken-then-fixed case. Vite mode has no IT for the reason the README gives.