### PR TITLE
docs: Clarify Binder bind(String) does not add BeanValidator #19423

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -581,9 +581,9 @@ public class Binder<BEAN> implements Serializable {
          * <p>
          * For a <code>Binder</code> created using the
          * {@link Binder#Binder(Class)} constructor, introspection will be used
-         * to find a Java Bean property. If a JSR-303 bean validation
-         * implementation is present on the classpath, a {@link BeanValidator}
-         * is also added to the binding.
+         * to find a Java Bean property. A regular {@code Binder} does not add
+         * a {@link BeanValidator} even if a JSR-303 implementation is on the
+         * classpath; use {@link BeanValidationBinder} for that.
          * <p>
          * The property must have an accessible getter method. It need not have
          * an accessible setter; in that case the property value is never
@@ -622,9 +622,9 @@ public class Binder<BEAN> implements Serializable {
          * <p>
          * For a <code>Binder</code> created using the
          * {@link Binder#Binder(Class)} constructor, introspection will be used
-         * to find a Java Bean property. If a JSR-303 bean validation
-         * implementation is present on the classpath, a {@link BeanValidator}
-         * is also added to the binding.
+         * to find a Java Bean property. A regular {@code Binder} does not add
+         * a {@link BeanValidator} even if a JSR-303 implementation is on the
+         * classpath; use {@link BeanValidationBinder} for that.
          * <p>
          * The property must have an accessible getter method.
          *
@@ -2530,9 +2530,10 @@ public class Binder<BEAN> implements Serializable {
      * setter of the property are looked up using a {@link PropertySet}.
      * <p>
      * For a <code>Binder</code> created using the {@link Binder#Binder(Class)}
-     * constructor, introspection will be used to find a Java Bean property. If
-     * a JSR-303 bean validation implementation is present on the classpath, a
-     * {@link BeanValidator} is also added to the binding.
+     * constructor, introspection will be used to find a Java Bean property. A
+     * regular {@code Binder} does not add a {@link BeanValidator} even if a
+     * JSR-303 implementation is on the classpath; use
+     * {@link BeanValidationBinder} for that.
      * <p>
      * The property must have an accessible getter method. It need not have an
      * accessible setter; in that case the property value is never updated and
@@ -2575,9 +2576,10 @@ public class Binder<BEAN> implements Serializable {
      * not written back to the bean so the binding is read-only.
      * <p>
      * For a <code>Binder</code> created using the {@link Binder#Binder(Class)}
-     * constructor, introspection will be used to find a Java Bean property. If
-     * a JSR-303 bean validation implementation is present on the classpath, a
-     * {@link BeanValidator} is also added to the binding.
+     * constructor, introspection will be used to find a Java Bean property. A
+     * regular {@code Binder} does not add a {@link BeanValidator} even if a
+     * JSR-303 implementation is on the classpath; use
+     * {@link BeanValidationBinder} for that.
      * <p>
      * The property must have an accessible getter method.
      *

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -581,8 +581,8 @@ public class Binder<BEAN> implements Serializable {
          * <p>
          * For a <code>Binder</code> created using the
          * {@link Binder#Binder(Class)} constructor, introspection will be used
-         * to find a Java Bean property. A regular {@code Binder} does not add
-         * a {@link BeanValidator} even if a JSR-303 implementation is on the
+         * to find a Java Bean property. A regular {@code Binder} does not add a
+         * {@link BeanValidator} even if a JSR-303 implementation is on the
          * classpath; use {@link BeanValidationBinder} for that.
          * <p>
          * The property must have an accessible getter method. It need not have
@@ -622,8 +622,8 @@ public class Binder<BEAN> implements Serializable {
          * <p>
          * For a <code>Binder</code> created using the
          * {@link Binder#Binder(Class)} constructor, introspection will be used
-         * to find a Java Bean property. A regular {@code Binder} does not add
-         * a {@link BeanValidator} even if a JSR-303 implementation is on the
+         * to find a Java Bean property. A regular {@code Binder} does not add a
+         * {@link BeanValidator} even if a JSR-303 implementation is on the
          * classpath; use {@link BeanValidationBinder} for that.
          * <p>
          * The property must have an accessible getter method.


### PR DESCRIPTION
`Binder.bind(String)` and `BindingBuilder.bind(String)` said a `BeanValidator` is added whenever JSR-303 is on the classpath. That only happens with `BeanValidationBinder`.

I updated those four javadocs.

Fixes #19423