### PR TITLE
chore: install githooks only for root module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -854,6 +854,9 @@
     <profile>
       <id>install-git-hooks</id>
       <activation>
+        <property>
+          <name>!env.CI</name>
+        </property>
         <file>
           <missing>${maven.multiModuleProjectDirectory}/.husky/_</missing>
         </file>
@@ -864,6 +867,7 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>${maven.exec.plugin.version}</version>
+            <inherited>false</inherited>
             <executions>
               <execution>
                 <id>install-git-hooks</id>


### PR DESCRIPTION
Prevents githooks installation to be performed by every module in the reactor. The hooks installation execution profile is guarded by a missing file, but active profiles are computed eagerly, not per module. So, if the profile is activated, the installation runs for all modules, even if the guard file is created by the first execution.

Setting inherited to false in the plugin configuration fixes the problem.
