### PR TITLE
ci: cache npm downloads in the API diff job

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -614,6 +614,14 @@ jobs:
         with:
           ref: ${{env._HEAD_SHA}}
           fetch-depth: 0
+      # The base build and the apicmp build each run npm install in
+      # flow-client, flow-polymer2lit and vaadin-dev-server. Without a warm
+      # ~/.npm those six installs dominate the job and exhaust its timeout.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24.20.0'
+          cache: npm
+          cache-dependency-path: 'flow-client/package-lock.json'
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:


### PR DESCRIPTION
The api-diff-labeling job runs two full builds under a 15 minute timeout, and each runs npm install in flow-client, flow-polymer2lit and vaadin-dev-server. Only ~/.m2/repository was cached, so every install resolved its packages from the registry again.

In the run that prompted this, the first build spent 9m47s in npm of the 14m42s it survived, 5m43s of that in flow-client alone. Everything else took under two minutes.

The lock file path has to be named because there is none at the repository root. This also stops the job building on the runner's default node, v22.23.2, while the rest of the workflow pins 24.20.0.
