### PR TITLE
test: remove the dead JUnit 4 RunListener from the surefire config

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -22,7 +22,6 @@
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <testListener/>
     <flow.apicmp.skip>true</flow.apicmp.skip>
   </properties>
 

--- a/flow-plugins/pom.xml
+++ b/flow-plugins/pom.xml
@@ -17,7 +17,6 @@
   </modules>
   <properties>
     <bnd.skip>true</bnd.skip>
-    <testListener/>
     <flow.apicmp.skip>true</flow.apicmp.skip>
   </properties>
   <profiles>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -36,7 +36,6 @@
     <!-- This property is needed to allow some Win-specific IT tests -->
     <!-- to be disabled via system property in CI until they got fixed-->
     <exclude.windows.failed.it.tests/>
-    <testListener/>
 
     <!-- Skip these categories in validation, use -Pslow-tests to run them -->
     <excludedGroups>com.vaadin.flow.testcategory.SlowTests,

--- a/pom.xml
+++ b/pom.xml
@@ -159,8 +159,6 @@
     <!-- to be disabled via system property in CI until they got fixed -->
     <exclude.windows.failed.tests/>
 
-    <testListener>com.vaadin.flow.testutil.CurrentInstanceCleaner</testListener>
-
     <!-- Extra JVM arguments for surefire forks; modules override this
          when their tests need e.g. add-opens flags. The empty default
          keeps the argLine expression resolvable everywhere. -->
@@ -485,12 +483,6 @@
               <exclude>${exclude.windows.failed.tests}</exclude>
             </excludes>
             <argLine>@{jacoco.agent.argLine} ${surefire.argLine}</argLine>
-            <properties>
-              <property>
-                <name>listener</name>
-                <value>${testListener}</value>
-              </property>
-            </properties>
             <enableAssertions>true</enableAssertions>
             <classpathDependencyExcludes>
               <classpathDependencyExclude>org.osgi:org.osgi.core</classpathDependencyExclude>


### PR DESCRIPTION
The surefire `listener` property pointed at CurrentInstanceCleaner, a JUnit 4 RunListener. Because the root pom puts junit-jupiter and junit-vintage-engine on every module's test classpath, surefire always selects JUnitPlatformProvider, which ignores that property. The RunListener has therefore not run since CurrentInstanceCleanerListener was added as a ServiceLoader-registered TestExecutionListener; that listener clears the thread locals before every test, vintage JUnit 4 tests included, so the property contributed nothing.

Surefire 3.6.0 (SUREFIRE-1639) teaches the platform provider to read `listener` after all, which turns the dead configuration into a build failure: modules that do not have flow-test-generic on their test classpath — flow-webpush and flow-devloop-daemon — abort with ClassNotFoundException before running a single test. Modules that do have it instead gain a redundant class-level invocation alongside the per-test one.

Remove the property, along with the three <testListener/> overrides that existed only to blank it in modules lacking flow-test-generic.
