### PR TITLE
fix: leave default PWA icons out of a bundle with a custom icon path

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/JarContentsManager.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/JarContentsManager.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -262,6 +263,45 @@ public class JarContentsManager {
     public Set<String> copyIncludedFilesFromJarTrimmingBasePath(File jar,
             String jarDirectoryToCopyFrom, File outputDirectory,
             String... wildcardPathInclusions) {
+        return copyIncludedFilesFromJarTrimmingBasePath(jar,
+                jarDirectoryToCopyFrom, outputDirectory, List.of(),
+                wildcardPathInclusions);
+    }
+
+    /**
+     * Copies files matching the inclusion filters, but not the exclusion
+     * filters, from the jar file to the output directory.
+     *
+     * @param jar
+     *            jar file to look for files in, not {@code null}
+     * @param jarDirectoryToCopyFrom
+     *            a path relative to jar root, only files from this path will be
+     *            copied, can be {@code null}, which is treated as a root of the
+     *            jar. Files will be copied relative to this path (i.e. only
+     *            path part after this path is preserved in output directory)
+     * @param outputDirectory
+     *            the directory to copy files to, not {@code null}
+     * @param wildcardPathExclusions
+     *            wildcard exclusions that are used to check each path against
+     *            before copying, taking precedence over the inclusions
+     * @param wildcardPathInclusions
+     *            wildcard inclusions that are used to check each path against
+     *            before copying
+     * @return names of the files that were either copied or already existed in
+     *         the output directory
+     * @throws IllegalArgumentException
+     *             if jar file specified is not a file or does not exist or if
+     *             output directory is not a directory or does not exist
+     * @throws NullPointerException
+     *             if jar file or output directory is {@code null}
+     * @throws UncheckedIOException
+     *             if {@link IOException} occurs during the operation, for
+     *             instance, when jar file specified is not a jar file
+     */
+    public Set<String> copyIncludedFilesFromJarTrimmingBasePath(File jar,
+            String jarDirectoryToCopyFrom, File outputDirectory,
+            Collection<String> wildcardPathExclusions,
+            String... wildcardPathInclusions) {
         requireFileExistence(jar);
 
         if (!Objects.requireNonNull(outputDirectory).isDirectory()) {
@@ -278,6 +318,8 @@ public class JarContentsManager {
                     .filter(file -> file.getName().toLowerCase(Locale.ENGLISH)
                             .startsWith(basePath.toLowerCase(Locale.ENGLISH)))
                     .filter(file -> includeFile(file, wildcardPathInclusions))
+                    .filter(file -> isFileIncluded(file,
+                            wildcardPathExclusions))
                     .map(jarEntry -> copyJarEntryTrimmingBasePath(jarFile,
                             jarEntry, basePath, outputDirectory))
                     .collect(Collectors.toSet());
@@ -298,8 +340,13 @@ public class JarContentsManager {
     }
 
     private boolean isFileIncluded(ZipEntry file, String... pathExclusions) {
+        return isFileIncluded(file, List.of(pathExclusions));
+    }
+
+    private boolean isFileIncluded(ZipEntry file,
+            Collection<String> pathExclusions) {
         String filePath = file.getName();
-        return Stream.of(pathExclusions).noneMatch(exclusionRule -> FileIOUtils
+        return pathExclusions.stream().noneMatch(exclusionRule -> FileIOUtils
                 .wildcardMatch(filePath, exclusionRule));
     }
 

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -125,6 +125,17 @@ public class NodeTasks implements FallibleCommand {
 
         Set<String> webComponentTags = new HashSet<>();
 
+        String themeName = "";
+        PwaConfiguration pwa;
+        if (frontendDependencies != null) {
+            if (frontendDependencies.getThemeDefinition() != null) {
+                themeName = frontendDependencies.getThemeDefinition().getName();
+            }
+            pwa = frontendDependencies.getPwaConfiguration();
+        } else {
+            pwa = new PwaConfiguration();
+        }
+
         if (options.isFrontendHotdeploy()) {
             UsageStatistics.markAsUsed("flow/hotdeploy", null);
         }
@@ -138,7 +149,7 @@ public class NodeTasks implements FallibleCommand {
                 options.withRunNpmInstall(needBuild);
                 options.withBundleBuild(needBuild);
                 if (!needBuild) {
-                    commands.add(new TaskPrepareProdBundle(options));
+                    commands.add(new TaskPrepareProdBundle(options, pwa));
                     File prodBundle = ProdBundleUtils
                             .getProdBundle(options.getNpmFolder());
                     if (prodBundle.exists()) {
@@ -266,16 +277,6 @@ public class NodeTasks implements FallibleCommand {
             commands.add(new TaskCopyNpmAssetsFiles(options));
         }
 
-        String themeName = "";
-        PwaConfiguration pwa;
-        if (frontendDependencies != null) {
-            if (frontendDependencies.getThemeDefinition() != null) {
-                themeName = frontendDependencies.getThemeDefinition().getName();
-            }
-            pwa = frontendDependencies.getPwaConfiguration();
-        } else {
-            pwa = new PwaConfiguration();
-        }
         if (options.isProductionMode() && pwa.isEnabled()) {
             commands.add(new TaskGeneratePWAIcons(options, pwa));
         }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.Constants;
@@ -91,7 +92,12 @@ public class TaskGeneratePWAIcons implements FallibleCommand {
             System.setProperty(HEADLESS_PROPERTY, Boolean.TRUE.toString());
         }
 
-        LOGGER.debug("Generating PWA icons from '{}'",
+        // A custom icon path is worth reporting: it lets the developer see
+        // which image the shipped icons were actually scaled from.
+        boolean customIcon = !PwaConfiguration.DEFAULT_ICON
+                .equals(pwaConfiguration.getIconPath());
+        LOGGER.atLevel(customIcon ? Level.INFO : Level.DEBUG).log(
+                "Generating PWA icons from '{}'",
                 pwaConfiguration.getIconPath());
 
         try {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
@@ -34,7 +34,6 @@ import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.Constants;
@@ -94,11 +93,16 @@ public class TaskGeneratePWAIcons implements FallibleCommand {
 
         // A custom icon path is worth reporting: it lets the developer see
         // which image the shipped icons were actually scaled from.
-        boolean customIcon = !PwaConfiguration.DEFAULT_ICON
-                .equals(pwaConfiguration.getIconPath());
-        LOGGER.atLevel(customIcon ? Level.INFO : Level.DEBUG).log(
-                "Generating PWA icons from '{}'",
-                pwaConfiguration.getIconPath());
+        // The fluent SLF4J 2 API is off limits here: this code runs inside
+        // Maven, which exports its own slf4j-api 1.7 to plugin class loaders.
+        if (PwaConfiguration.DEFAULT_ICON
+                .equals(pwaConfiguration.getIconPath())) {
+            LOGGER.debug("Generating PWA icons from '{}'",
+                    pwaConfiguration.getIconPath());
+        } else {
+            LOGGER.info("Generating PWA icons from '{}'",
+                    pwaConfiguration.getIconPath());
+        }
 
         try {
             BufferedImage baseImage = loadBaseImage(iconURL);

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskPrepareProdBundle.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskPrepareProdBundle.java
@@ -23,12 +23,15 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
 
 import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.internal.FileIOUtils;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.PwaConfiguration;
 
 import static com.vaadin.flow.server.Constants.APPLICATION_THEME_ROOT;
 import static com.vaadin.flow.shared.ApplicationConstants.VAADIN_STATIC_FILES_PATH;
@@ -46,9 +49,12 @@ import static com.vaadin.flow.shared.ApplicationConstants.VAADIN_STATIC_FILES_PA
 public class TaskPrepareProdBundle implements FallibleCommand {
 
     private final Options options;
+    private final PwaConfiguration pwaConfiguration;
 
-    public TaskPrepareProdBundle(Options options) {
+    public TaskPrepareProdBundle(Options options,
+            PwaConfiguration pwaConfiguration) {
         this.options = options;
+        this.pwaConfiguration = pwaConfiguration;
     }
 
     @Override
@@ -112,11 +118,28 @@ public class TaskPrepareProdBundle implements FallibleCommand {
             JarContentsManager jarContentsManager = new JarContentsManager();
             jarContentsManager.copyIncludedFilesFromJarTrimmingBasePath(
                     new File(jarUri), Constants.PROD_BUNDLE_NAME,
-                    options.getResourceOutputDirectory(), "**/*.*");
+                    options.getResourceOutputDirectory(),
+                    defaultPwaIconsExclusions(), "**/*.*");
         } catch (URISyntaxException e) {
             throw new ExecutionFailedException(
                     "Couldn't copy production bundle files", e);
         }
+    }
+
+    /**
+     * The default bundle ships PWA icons scaled from
+     * {@link PwaConfiguration#DEFAULT_ICON}. They are never served when the
+     * application points {@code @PWA(iconPath)} somewhere else, since
+     * {@link TaskGeneratePWAIcons} then writes the scaled icons under the
+     * configured path instead, so they are left out of the production artifact.
+     */
+    private Collection<String> defaultPwaIconsExclusions() {
+        if (PwaConfiguration.DEFAULT_ICON
+                .equals(pwaConfiguration.getIconPath())) {
+            return List.of();
+        }
+        return List.of(Constants.PROD_BUNDLE_JAR_PATH + Constants.VAADIN_WEBAPP
+                + Constants.VAADIN_PWA_ICONS + "*");
     }
 
     private boolean hasProdBundle() {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskPrepareProdBundleTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskPrepareProdBundleTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.PwaConfiguration;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TaskPrepareProdBundleTest {
+
+    private static final String PWA_ICONS_IN_BUNDLE = "webapp/pwa-icons";
+    // The layout the vaadin-prod-bundle artifact ships: icons scaled from
+    // PwaConfiguration.DEFAULT_ICON, named after the default icon path.
+    private static final Set<String> DEFAULT_ICONS_IN_BUNDLE = Set.of(
+            PWA_ICONS_IN_BUNDLE + "/icons/icon-16x16.png",
+            PWA_ICONS_IN_BUNDLE + "/icons/icon-512x512.png");
+    private static final String BUNDLE_ENTRY_POINT = "webapp/VAADIN/build/main.js";
+
+    @TempDir
+    File temporaryFolder;
+
+    private Options options;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        File projectDirectory = new File(temporaryFolder, "my-project");
+        Path resourceOutputDirectory = projectDirectory.toPath()
+                .resolve(Path.of("target", "classes", "META-INF", "VAADIN"));
+        Files.createDirectories(resourceOutputDirectory);
+
+        File bundleJar = new File(temporaryFolder, "vaadin-prod-bundle.jar");
+        createDefaultProdBundleJar(bundleJar);
+
+        ClassFinder classFinder = new ClassFinder.DefaultClassFinder(
+                new URLClassLoader(new URL[] { bundleJar.toURI().toURL() },
+                        null));
+        options = new Options(Mockito.mock(Lookup.class), classFinder,
+                projectDirectory).withBuildResultFolders(
+                        resourceOutputDirectory.resolve("webapp").toFile(),
+                        resourceOutputDirectory.toFile());
+    }
+
+    @Test
+    void execute_defaultIconPath_defaultIconsCopied()
+            throws ExecutionFailedException {
+        new TaskPrepareProdBundle(options,
+                pwaConfiguration(PwaConfiguration.DEFAULT_ICON)).execute();
+
+        assertTrue(copiedFile(BUNDLE_ENTRY_POINT).exists(),
+                "Bundle files should have been copied");
+        assertEquals(DEFAULT_ICONS_IN_BUNDLE, copiedPwaIcons(),
+                "Icons generated from the default icon are the ones served, "
+                        + "so they should have been copied");
+    }
+
+    @Test
+    void execute_customIconPath_defaultIconsNotCopied()
+            throws ExecutionFailedException {
+        new TaskPrepareProdBundle(options,
+                pwaConfiguration("custom/icons/logo.png")).execute();
+
+        assertTrue(copiedFile(BUNDLE_ENTRY_POINT).exists(),
+                "Bundle files other than the PWA icons should have been copied");
+        assertEquals(Set.of(), copiedPwaIcons(),
+                "Icons generated from the default icon are never served with a "
+                        + "custom icon path, so they should not have been copied");
+    }
+
+    private File copiedFile(String relativePath) {
+        return new File(options.getResourceOutputDirectory(), relativePath);
+    }
+
+    /**
+     * The paths, relative to the bundle root, of every file copied under the
+     * PWA icons folder.
+     */
+    private Set<String> copiedPwaIcons() {
+        Path outputDirectory = options.getResourceOutputDirectory().toPath();
+        Path pwaIcons = outputDirectory.resolve(PWA_ICONS_IN_BUNDLE);
+        if (!Files.isDirectory(pwaIcons)) {
+            return Set.of();
+        }
+        try (Stream<Path> files = Files.walk(pwaIcons)) {
+            return files.filter(Files::isRegularFile)
+                    .map(file -> outputDirectory.relativize(file).toString()
+                            .replace(File.separatorChar, '/'))
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static PwaConfiguration pwaConfiguration(String iconPath) {
+        return new PwaConfiguration(true, PwaConfiguration.DEFAULT_NAME,
+                "Flow PWA", "", PwaConfiguration.DEFAULT_BACKGROUND_COLOR,
+                PwaConfiguration.DEFAULT_THEME_COLOR, iconPath,
+                PwaConfiguration.DEFAULT_PATH,
+                PwaConfiguration.DEFAULT_OFFLINE_PATH,
+                PwaConfiguration.DEFAULT_DISPLAY,
+                PwaConfiguration.DEFAULT_START_URL, new String[] {}, false);
+    }
+
+    private static void createDefaultProdBundleJar(File jar)
+            throws IOException {
+        try (JarOutputStream out = new JarOutputStream(
+                Files.newOutputStream(jar.toPath()))) {
+            writeEntry(out, "config/stats.json", "{\"npmModules\":{}}");
+            writeEntry(out, BUNDLE_ENTRY_POINT, "console.log('bundle');");
+            for (String icon : DEFAULT_ICONS_IN_BUNDLE) {
+                writeEntry(out, icon, "default icon");
+            }
+        }
+    }
+
+    private static void writeEntry(JarOutputStream out, String path,
+            String content) throws IOException {
+        out.putNextEntry(new JarEntry("vaadin-prod-bundle/" + path));
+        out.write(content.getBytes(StandardCharsets.UTF_8));
+        out.closeEntry();
+    }
+}


### PR DESCRIPTION
The default production bundle ships PWA icons scaled from icons/icon.png. When an application points `@PWA(iconPath)` somewhere else, TaskGeneratePWAIcons writes the scaled icons under the configured path instead, so the ones unpacked from the bundle are never served and only add around 700 kB of unused images to the production artifact. Skip them while copying the bundle in that case.

Also report which image the icons are generated from at INFO level when the icon path is customized, so that the source of the shipped icons is visible without enabling debug logging.

Fixes #21411
