### PR TITLE
docs: Add usage notes and MDN links to HTML components #21749

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Abbr.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Abbr.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;abbr&gt;</code> element.
+ * <p>
+ * Marks an abbreviation or acronym. Set the title attribute when the expanded
+ * form should be available to users.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/abbr">MDN:
+ *      &lt;abbr&gt;</a>
  * @author Vaadin Ltd
  * @since 25.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -37,7 +37,12 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing an <code>&lt;a&gt;</code> element.
+ * <p>
+ * A hyperlink to another URL, a download, or a location in the page.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a">MDN:
+ *      &lt;a&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Article.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Article.java
@@ -23,7 +23,13 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;article&gt;</code> element.
+ * <p>
+ * A self-contained composition, such as a post, story or comment, that still
+ * makes sense on its own.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article">MDN:
+ *      &lt;article&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Aside.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Aside.java
@@ -23,7 +23,13 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;aside&gt;</code> element.
+ * <p>
+ * Content that is only indirectly related to the surrounding page, typically a
+ * sidebar or call-out.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/aside">MDN:
+ *      &lt;aside&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Code.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Code.java
@@ -24,7 +24,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;code&gt;</code> element.
+ * <p>
+ * A short fragment of computer code. Whitespace is not preserved; use Pre when
+ * layout must stay intact.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/code">MDN:
+ *      &lt;code&gt;</a>
  * @author Vaadin Ltd
  * @since 24.9
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/DescriptionList.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/DescriptionList.java
@@ -27,7 +27,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;dl&gt;</code> element.
+ * <p>
+ * A list of terms and their descriptions, using Term (<dt>) and Description
+ * (<dd>) children.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl">MDN:
+ *      &lt;dl&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */
@@ -37,7 +43,13 @@ public class DescriptionList extends HtmlContainer
 
     /**
      * Component representing a <code>&lt;dt&gt;</code> element.
+     * <p>
+     * A term in a description list. Follow it with one or more Description
+     * children.
      *
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dt">MDN:
+     *      &lt;dt&gt;</a>
      * @author Vaadin Ltd
      */
     @Tag(Tag.DT)
@@ -75,7 +87,12 @@ public class DescriptionList extends HtmlContainer
 
     /**
      * Component representing a <code>&lt;dd&gt;</code> element.
+     * <p>
+     * The description of the preceding Term in a description list.
      *
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dd">MDN:
+     *      &lt;dd&gt;</a>
      * @author Vaadin Ltd
      */
     @Tag(Tag.DD)

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/DescriptionList.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/DescriptionList.java
@@ -28,8 +28,8 @@ import com.vaadin.flow.signals.Signal;
 /**
  * Component representing a <code>&lt;dl&gt;</code> element.
  * <p>
- * A list of terms and their descriptions, using Term (<dt>) and Description
- * (<dd>) children.
+ * A list of terms and their descriptions, using Term (<code>&lt;dt&gt;</code>)
+ * and Description (<code>&lt;dd&gt;</code>) children.
  *
  * @see <a href=
  *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl">MDN:

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Div.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Div.java
@@ -26,7 +26,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;div&gt;</code> element.
+ * <p>
+ * A generic block container with no meaning of its own. Prefer a more specific
+ * element when one fits.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div">MDN:
+ *      &lt;div&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Emphasis.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Emphasis.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;em&gt;</code> element.
+ * <p>
+ * Text that should be stressed. Screen readers typically change pronunciation
+ * for this element.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/em">MDN:
+ *      &lt;em&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -29,7 +29,10 @@ import com.vaadin.flow.signals.Signal;
  * Represents an HTML <code>&lt;fieldset&gt;</code> element. This component is
  * used to group several UI components within a form, enhancing form
  * accessibility and organization.
- * 
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset">MDN:
+ *      &lt;fieldset&gt;</a>
  * @since 24.5
  */
 @Tag("fieldset")
@@ -37,6 +40,13 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
 
     /**
      * Represents an HTML <code>&lt;legend&gt;</code> element.
+     * <p>
+     * Caption for the enclosing field set. Assistive technologies use it as the
+     * name of the group.
+     *
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/legend">MDN:
+     *      &lt;legend&gt;</a>
      */
     @Tag("legend")
     public static class Legend extends HtmlContainer {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Footer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Footer.java
@@ -23,7 +23,13 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;footer&gt;</code> element.
+ * <p>
+ * Footer for the nearest sectioning ancestor: copyright, author, or related
+ * links.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/footer">MDN:
+ *      &lt;footer&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/H1.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/H1.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;h1&gt;</code> element.
+ * <p>
+ * The highest-rank heading on the page. Use one as the document title; lower
+ * ranks follow in order.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/h1">MDN:
+ *      &lt;h1&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/H2.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/H2.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;h2&gt;</code> element.
+ * <p>
+ * A rank-2 heading. Keep heading ranks sequential rather than skipping levels
+ * for style.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/h2">MDN:
+ *      &lt;h2&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/H3.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/H3.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;h3&gt;</code> element.
+ * <p>
+ * A rank-3 heading. Keep heading ranks sequential rather than skipping levels
+ * for style.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/h3">MDN:
+ *      &lt;h3&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/H4.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/H4.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;h4&gt;</code> element.
+ * <p>
+ * A rank-4 heading. Keep heading ranks sequential rather than skipping levels
+ * for style.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/h4">MDN:
+ *      &lt;h4&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/H5.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/H5.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;h5&gt;</code> element.
+ * <p>
+ * A rank-5 heading. Keep heading ranks sequential rather than skipping levels
+ * for style.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/h5">MDN:
+ *      &lt;h5&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/H6.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/H6.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;h6&gt;</code> element.
+ * <p>
+ * A rank-6 heading. Keep heading ranks sequential rather than skipping levels
+ * for style.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/h6">MDN:
+ *      &lt;h6&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Header.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Header.java
@@ -23,7 +23,12 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;header&gt;</code> element.
+ * <p>
+ * Introductory content or navigation for the nearest sectioning ancestor.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/header">MDN:
+ *      &lt;header&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Hr.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Hr.java
@@ -20,7 +20,13 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;hr&gt;</code> element.
+ * <p>
+ * A thematic break between paragraphs, such as a change of topic. It is not
+ * only a visual line.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hr">MDN:
+ *      &lt;hr&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -33,9 +33,14 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;object&gt;</code> element.
+ * <p>
+ * Embeds an external resource such as an image, nested document or plugin.
+ * Prefer Image or IFrame when those fit.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/object">MDN:
+ *      &lt;object&gt;</a>
  * @author Vaadin Ltd
- *
  * @since 9.0
  */
 @Tag(Tag.OBJECT)

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -33,6 +33,9 @@ import com.vaadin.flow.server.streams.DownloadHandler;
 
 /**
  * Component representing a <code>&lt;iframe&gt;</code> element.
+ * <p>
+ * A nested browsing context that embeds another HTML page. Prefer this over
+ * HtmlObject for documents.
  *
  * @author Vaadin Ltd
  * @since 1.3

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -34,7 +34,13 @@ import com.vaadin.flow.server.streams.DownloadResponse;
 
 /**
  * Component representing a <code>&lt;img&gt;</code> element.
+ * <p>
+ * Embeds an image. Always set alternative text so the content is available when
+ * the image cannot be shown.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img">MDN:
+ *      &lt;img&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Input.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Input.java
@@ -30,7 +30,13 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 
 /**
  * Component representing an <code>&lt;input&gt;</code> element.
+ * <p>
+ * An empty form field. The type attribute selects the control (text, checkbox,
+ * and so on).
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input">MDN:
+ *      &lt;input&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/ListItem.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/ListItem.java
@@ -25,7 +25,12 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;li&gt;</code> element.
+ * <p>
+ * One item in an ordered or unordered list.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li">MDN:
+ *      &lt;li&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Main.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Main.java
@@ -24,7 +24,13 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;main&gt;</code> element.
+ * <p>
+ * The dominant content of the page. There should typically be only one, and it
+ * should not sit inside article, aside, footer, header or nav.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main">MDN:
+ *      &lt;main&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeButton.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeButton.java
@@ -28,7 +28,12 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;button&gt;</code> element.
+ * <p>
+ * A clickable control that submits a form, resets it, or runs an action.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button">MDN:
+ *      &lt;button&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -34,7 +34,12 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;details&gt;</code> element.
+ * <p>
+ * A disclosure widget the user can open to reveal extra information.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details">MDN:
+ *      &lt;details&gt;</a>
  * @author Vaadin Ltd
  * @since 6.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Nav.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Nav.java
@@ -24,7 +24,12 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;nav&gt;</code> element.
+ * <p>
+ * A section of major navigation links, not every group of links on the page.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav">MDN:
+ *      &lt;nav&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/OrderedList.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/OrderedList.java
@@ -25,7 +25,12 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;ol&gt;</code> element.
+ * <p>
+ * A numbered list of items. Use UnorderedList when order does not matter.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol">MDN:
+ *      &lt;ol&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Paragraph.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Paragraph.java
@@ -25,7 +25,12 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;p&gt;</code> element.
+ * <p>
+ * A paragraph of text.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/p">MDN:
+ *      &lt;p&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Param.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Param.java
@@ -25,13 +25,16 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.signals.Signal;
 
 /**
- * Component representing a <code>&lt;param&gt;</code> element for
- * <code>&lt;param&gt;</code> element.
+ * Component representing a <code>&lt;param&gt;</code> element.
+ * <p>
+ * A parameter for a parent HtmlObject. The name and value attributes are passed
+ * to the embedded resource.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/param">MDN:
+ *      &lt;param&gt;</a>
  * @see HtmlObject
- *
  * @author Vaadin Ltd
- *
  * @since 9.0
  */
 @Tag(Tag.PARAM)

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Pre.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Pre.java
@@ -25,7 +25,12 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;pre&gt;</code> element.
+ * <p>
+ * Preformatted text. Whitespace and line breaks are shown as written.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/pre">MDN:
+ *      &lt;pre&gt;</a>
  * @author Vaadin Ltd
  * @since 2.1
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
@@ -36,7 +36,10 @@ import com.vaadin.flow.signals.Signal;
  * <p>
  * Note: Slider doesn't support the read-only mode and will disable itself
  * instead.
- * 
+ *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range">MDN:
+ *      &lt;input type=&quot;range&quot;&gt;</a>
  * @since 24.3
  */
 @Tag(Tag.INPUT)

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Section.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Section.java
@@ -24,7 +24,12 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;section&gt;</code> element.
+ * <p>
+ * A standalone section of the document, usually with its own heading.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section">MDN:
+ *      &lt;section&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Span.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Span.java
@@ -25,7 +25,13 @@ import com.vaadin.flow.signals.Signal;
 
 /**
  * Component representing a <code>&lt;span&gt;</code> element.
+ * <p>
+ * A generic inline container with no meaning of its own. Prefer a more specific
+ * element when one fits.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/span">MDN:
+ *      &lt;span&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/UnorderedList.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/UnorderedList.java
@@ -21,7 +21,12 @@ import com.vaadin.flow.component.Tag;
 
 /**
  * Component representing a <code>&lt;ul&gt;</code> element.
+ * <p>
+ * A bulleted list of items. Use OrderedList when the sequence matters.
  *
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul">MDN:
+ *      &lt;ul&gt;</a>
  * @author Vaadin Ltd
  * @since 1.0
  */


### PR DESCRIPTION
HTML components such as Div, Span and Main only named the tag. I added a short usage note and an MDN link on each, matching the Table family. NativeLabel and the Table types already had that coverage.

Fixes #21749
