### PR TITLE
test: build the dev loop daemon before the Maven plugin ITs

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -126,6 +126,16 @@
           <postBuildHookScript>verify</postBuildHookScript>
           <addTestClassPath>true</addTestClassPath>
         </configuration>
+        <!-- extraArtifacts come from the repositories, not the reactor, so
+             the daemon has to be built first. Nothing else orders it before
+             this module, so this dependency is what does. -->
+        <dependencies>
+          <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-devloop-daemon</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>integration-test</id>


### PR DESCRIPTION
The invoker plugin resolves extraArtifacts from the repositories rather than the reactor, and nothing ordered flow-devloop-daemon before flow-maven-plugin, so a build with a fresh version looked for the daemon remotely and failed. Declaring it on the invoker plugin adds the missing reactor edge.
