### PR TITLE
fix: serve the PWA offline stub as same-origin frameable

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
@@ -48,6 +48,10 @@ const offlinePath = OFFLINE_PATH;
 // Example: http://localhost:8888/scope-path/sw.js => /scope-path/
 const scope = new URL(self.registration.scope);
 
+// The offline stub served by PwaHandler, rendered by the Flow client within an
+// <iframe> in the app shell when a server view cannot be reached.
+const offlineStubPath = `${scope.pathname}offline-stub.html`;
+
 /**
  * Replaces <base href> in pre-cached response HTML with the service worker’s
  * scope URL.
@@ -58,6 +62,58 @@ const scope = new URL(self.registration.scope);
 async function rewriteBaseHref(response: Response) {
   const html = await response.text();
   return new Response(html.replace(/<base\s+href=[^>]*>/, `<base href="${self.registration.scope}">`), response);
+}
+
+// Matches the frame-ancestors directive of a content security policy.
+const frameAncestorsDirective = /^\s*frame-ancestors(\s|$)/i;
+
+/**
+ * Restricts framing of a document to the same origin, instead of denying it
+ * altogether.
+ *
+ * The offline stub is rendered in a same-origin iframe, but the response served
+ * for it carries the headers of the origin server, which are stored in the
+ * pre-cache as well. A security filter, a reverse proxy or a CDN commonly adds
+ * `X-Frame-Options: DENY` to every response, in which case the browser displays
+ * its own error page instead of the offline stub. Downgrading the headers to
+ * same-origin framing keeps a third party page from framing the stub.
+ *
+ * @param response response to serve for the offline stub
+ * @returns response the app shell is allowed to render within an iframe
+ */
+async function allowSameOriginFraming(response: Response) {
+  const frameOptions = response.headers.get('X-Frame-Options');
+  const contentSecurityPolicy = response.headers.get('Content-Security-Policy');
+  if (frameOptions === null && !contentSecurityPolicy?.includes('frame-ancestors')) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  if (frameOptions !== null) {
+    headers.set('X-Frame-Options', 'SAMEORIGIN');
+  }
+  if (contentSecurityPolicy !== null) {
+    // Of a content security policy, only frame-ancestors prevents framing,
+    // the other directives are served as they are.
+    headers.set(
+      'Content-Security-Policy',
+      contentSecurityPolicy
+        .split(',')
+        .map((policy) =>
+          policy
+            .split(';')
+            .map((directive) => (frameAncestorsDirective.test(directive) ? " frame-ancestors 'self'" : directive))
+            .join(';')
+        )
+        .join(',')
+    );
+  }
+
+  return new Response(await response.blob(), {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
 }
 
 /**
@@ -123,25 +179,32 @@ registerRoute(
       return serveOfflineFallback();
     }
 
-    // Try to serve the resource from the cache when offline is detected.
-    if (!self.navigator.onLine) {
-      const response = await serveResourceFromCache();
-      if (response) {
-        return response;
+    async function serveNavigationRequest() {
+      // Try to serve the resource from the cache when offline is detected.
+      if (!self.navigator.onLine) {
+        const response = await serveResourceFromCache();
+        if (response) {
+          return response;
+        }
+      }
+
+      // Sometimes navigator.onLine is not reliable,
+      // try to serve the resource from the cache also in the case of a network failure.
+      try {
+        return await networkOnly.handle(context);
+      } catch (error) {
+        const response = await serveResourceFromCache();
+        if (response) {
+          return response;
+        }
+        throw error;
       }
     }
 
-    // Sometimes navigator.onLine is not reliable,
-    // try to serve the resource from the cache also in the case of a network failure.
-    try {
-      return await networkOnly.handle(context);
-    } catch (error) {
-      const response = await serveResourceFromCache();
-      if (response) {
-        return response;
-      }
-      throw error;
-    }
+    const response = await serveNavigationRequest();
+    // Only the offline stub is served as frameable, so that a third party page
+    // cannot frame the application itself.
+    return context.url.pathname === offlineStubPath ? allowSameOriginFraming(response) : response;
   })
 );
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
@@ -68,15 +68,62 @@ async function rewriteBaseHref(response: Response) {
 const frameAncestorsDirective = /^\s*frame-ancestors(\s|$)/i;
 
 /**
- * Restricts framing of a document to the same origin, instead of denying it
+ * Adds the same origin to the source list of a frame-ancestors directive,
+ * leaving the origins that the deployment allows in place.
+ *
+ * @param directive frame-ancestors directive to extend
+ * @returns directive that allows the same origin as well
+ */
+function allowSelfAsAncestor(directive: string) {
+  const sources = directive
+    .trim()
+    .split(/\s+/)
+    .slice(1)
+    // 'none' is only valid as the single source of a list, so it gives way to
+    // the same origin.
+    .filter((source) => source.toLowerCase() !== "'none'");
+  if (sources.some((source) => source.toLowerCase() === "'self'")) {
+    // Keep the directive as it is, so that a policy that needs no rewrite is
+    // recognizable by comparing it with the original one.
+    return directive;
+  }
+  sources.unshift("'self'");
+  return `${directive.match(/^\s*/)![0]}frame-ancestors ${sources.join(' ')}`;
+}
+
+/**
+ * Rewrites a content security policy so that framing by the same origin is
+ * allowed on top of whatever the policy already allows.
+ *
+ * @param contentSecurityPolicy policy served for the offline stub
+ * @returns policy that allows the same origin to frame the offline stub
+ */
+function allowSelfAsAncestorInPolicy(contentSecurityPolicy: string) {
+  // Of a content security policy, only frame-ancestors prevents framing,
+  // the other directives are served as they are.
+  return contentSecurityPolicy
+    .split(',')
+    .map((policy) =>
+      policy
+        .split(';')
+        .map((directive) => (frameAncestorsDirective.test(directive) ? allowSelfAsAncestor(directive) : directive))
+        .join(';')
+    )
+    .join(',');
+}
+
+/**
+ * Allows framing of a document by the same origin, instead of denying it
  * altogether.
  *
  * The offline stub is rendered in a same-origin iframe, but the response served
  * for it carries the headers of the origin server, which are stored in the
  * pre-cache as well. A security filter, a reverse proxy or a CDN commonly adds
  * `X-Frame-Options: DENY` to every response, in which case the browser displays
- * its own error page instead of the offline stub. Downgrading the headers to
- * same-origin framing keeps a third party page from framing the stub.
+ * its own error page instead of the offline stub. Adding the same origin,
+ * rather than restricting the headers to it, keeps a third party page from
+ * framing the stub without dropping the ancestors that the deployment allows
+ * for the application itself.
  *
  * @param response response to serve for the offline stub
  * @returns response the app shell is allowed to render within an iframe
@@ -84,29 +131,21 @@ const frameAncestorsDirective = /^\s*frame-ancestors(\s|$)/i;
 async function allowSameOriginFraming(response: Response) {
   const frameOptions = response.headers.get('X-Frame-Options');
   const contentSecurityPolicy = response.headers.get('Content-Security-Policy');
-  if (frameOptions === null && !contentSecurityPolicy?.includes('frame-ancestors')) {
+  // A policy that already allows the same origin comes back unchanged, so the
+  // comparison also tells whether there is a frame-ancestors directive at all.
+  const framingPolicy = contentSecurityPolicy === null ? null : allowSelfAsAncestorInPolicy(contentSecurityPolicy);
+  if (frameOptions === null && framingPolicy === contentSecurityPolicy) {
     return response;
   }
 
   const headers = new Headers(response.headers);
   if (frameOptions !== null) {
+    // X-Frame-Options has no source list to extend, and is ignored altogether
+    // when the policy has a frame-ancestors directive.
     headers.set('X-Frame-Options', 'SAMEORIGIN');
   }
-  if (contentSecurityPolicy !== null) {
-    // Of a content security policy, only frame-ancestors prevents framing,
-    // the other directives are served as they are.
-    headers.set(
-      'Content-Security-Policy',
-      contentSecurityPolicy
-        .split(',')
-        .map((policy) =>
-          policy
-            .split(';')
-            .map((directive) => (frameAncestorsDirective.test(directive) ? " frame-ancestors 'self'" : directive))
-            .join(';')
-        )
-        .join(',')
-    );
+  if (framingPolicy !== null) {
+    headers.set('Content-Security-Policy', framingPolicy);
   }
 
   return new Response(await response.blob(), {

--- a/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/DenyFramingFilter.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/DenyFramingFilter.java
@@ -18,28 +18,77 @@ package com.vaadin.flow.navigate;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Denies framing of the offline stub, the way Spring Security and other
  * security filters do for every response by default.
  * <p>
  * The Flow client renders the offline stub within an iframe, so the service
- * worker is expected to serve it without this header. See
- * {@code ServiceWorkerIT.offlineStub_framingDeniedByServer_offlineStubShown}.
+ * worker is expected to serve it as frameable. Which of the two headers that
+ * deny framing is sent depends on the {@value #DENY_FRAMING_HEADER_COOKIE}
+ * cookie, so that a test can cover both. See
+ * {@code ServiceWorkerIT.offlineStub_framingDeniedByServer_offlineStubShown}
+ * and
+ * {@code ServiceWorkerIT.offlineStub_framingDeniedByPolicy_offlineStubShown}.
  */
 @WebFilter(urlPatterns = "/offline-stub.html")
 public class DenyFramingFilter extends HttpFilter {
+
+    /**
+     * Name of the cookie that selects the header denying framing.
+     */
+    public static final String DENY_FRAMING_HEADER_COOKIE = "denyFramingHeader";
+
+    /**
+     * Value of {@value #DENY_FRAMING_HEADER_COOKIE} that denies framing with a
+     * content security policy instead of {@code X-Frame-Options}.
+     */
+    public static final String CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+
+    /**
+     * Policy denying framing altogether, sent when the
+     * {@value #DENY_FRAMING_HEADER_COOKIE} cookie asks for it.
+     * <p>
+     * The directive name is spelled in mixed case on purpose: directive names
+     * are case-insensitive, so the service worker has to recognize the
+     * directive however the deployment happens to spell it.
+     */
+    public static final String DENY_FRAMING_POLICY = "Frame-Ancestors 'none'";
+
+    /**
+     * Header denying framing by default, the way a security filter that knows
+     * nothing about content security policies does.
+     */
+    public static final String FRAME_OPTIONS = "X-Frame-Options";
+
+    /**
+     * Value of {@value #FRAME_OPTIONS} denying framing altogether.
+     */
+    public static final String DENY = "DENY";
 
     @Override
     protected void doFilter(HttpServletRequest request,
             HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        response.setHeader("X-Frame-Options", "DENY");
+        if (deniesFramingWithPolicy(request)) {
+            response.setHeader(CONTENT_SECURITY_POLICY, DENY_FRAMING_POLICY);
+        } else {
+            response.setHeader(FRAME_OPTIONS, DENY);
+        }
         chain.doFilter(request, response);
+    }
+
+    private boolean deniesFramingWithPolicy(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        return cookies != null && Arrays.stream(cookies).anyMatch(
+                cookie -> DENY_FRAMING_HEADER_COOKIE.equals(cookie.getName())
+                        && CONTENT_SECURITY_POLICY.equals(cookie.getValue()));
     }
 }

--- a/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/DenyFramingFilter.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/DenyFramingFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.navigate;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * Denies framing of the offline stub, the way Spring Security and other
+ * security filters do for every response by default.
+ * <p>
+ * The Flow client renders the offline stub within an iframe, so the service
+ * worker is expected to serve it without this header. See
+ * {@code ServiceWorkerIT.offlineStub_framingDeniedByServer_offlineStubShown}.
+ */
+@WebFilter(urlPatterns = "/offline-stub.html")
+public class DenyFramingFilter extends HttpFilter {
+
+    @Override
+    protected void doFilter(HttpServletRequest request,
+            HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        response.setHeader("X-Frame-Options", "DENY");
+        chain.doFilter(request, response);
+    }
+}

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
@@ -24,6 +24,7 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import tools.jackson.databind.node.ObjectNode;
@@ -273,23 +274,28 @@ public class ServiceWorkerIT extends ChromeDeviceTest {
         // it, so the service worker has to serve it as frameable itself
         Assert.assertEquals(
                 "Expected the server to deny framing of the offline stub",
-                "DENY", getFrameOptionsHeader("/offline-stub.html"));
+                DenyFramingFilter.DENY, getHeader("/offline-stub.html",
+                        DenyFramingFilter.FRAME_OPTIONS, null));
 
-        getDevTools().setOfflineEnabled(true);
-        try {
-            waitUntil(driver -> $("main-view").first().$("a").id("menu-hello"))
-                    .click();
+        assertOfflineStubShownWhenOffline();
+    }
 
-            waitForElementPresent(By.tagName("iframe"));
-            WebElement offlineStub = findElement(By.tagName("iframe"));
-            driver.switchTo().frame(offlineStub);
-            Assert.assertNotNull(
-                    "Offline stub should be rendered in the iframe even when the server denies framing",
-                    findElement(By.className("offline")));
-        } finally {
-            driver.switchTo().defaultContent();
-            getDevTools().setOfflineEnabled(false);
-        }
+    @Test
+    public void offlineStub_framingDeniedByPolicy_offlineStubShown()
+            throws IOException {
+        // The stub is pre-cached on the first page load, so the server has to
+        // deny framing with a content security policy before that happens
+        denyFramingWithContentSecurityPolicy();
+        openPageAndPreCacheWhenDevelopmentMode("/");
+
+        Assert.assertEquals(
+                "Expected the server to deny framing of the offline stub with a content security policy",
+                DenyFramingFilter.DENY_FRAMING_POLICY,
+                getHeader("/offline-stub.html",
+                        DenyFramingFilter.CONTENT_SECURITY_POLICY,
+                        denyFramingHeaderCookie()));
+
+        assertOfflineStubShownWhenOffline();
     }
 
     @Test
@@ -330,12 +336,50 @@ public class ServiceWorkerIT extends ChromeDeviceTest {
         }
     }
 
-    private String getFrameOptionsHeader(String path) throws IOException {
+    private void assertOfflineStubShownWhenOffline() {
+        getDevTools().setOfflineEnabled(true);
+        try {
+            waitUntil(driver -> $("main-view").first().$("a").id("menu-hello"))
+                    .click();
+
+            waitForElementPresent(By.tagName("iframe"));
+            WebElement offlineStub = findElement(By.tagName("iframe"));
+            driver.switchTo().frame(offlineStub);
+            Assert.assertNotNull(
+                    "Offline stub should be rendered in the iframe even when the server denies framing",
+                    findElement(By.className("offline")));
+        } finally {
+            driver.switchTo().defaultContent();
+            getDevTools().setOfflineEnabled(false);
+        }
+    }
+
+    private void denyFramingWithContentSecurityPolicy() {
+        // A cookie can only be added once the browser is on the domain, and
+        // the stub itself is a plain page that does not register the service
+        // worker yet
+        getDriver().get(getRootURL() + "/offline-stub.html");
+        getDriver().manage()
+                .addCookie(new Cookie(
+                        DenyFramingFilter.DENY_FRAMING_HEADER_COOKIE,
+                        DenyFramingFilter.CONTENT_SECURITY_POLICY, "/"));
+    }
+
+    private String denyFramingHeaderCookie() {
+        return DenyFramingFilter.DENY_FRAMING_HEADER_COOKIE + "="
+                + DenyFramingFilter.CONTENT_SECURITY_POLICY;
+    }
+
+    private String getHeader(String path, String name, String cookie)
+            throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(
                 getRootURL() + path).openConnection();
         try {
             connection.setRequestMethod("HEAD");
-            return connection.getHeaderField("X-Frame-Options");
+            if (cookie != null) {
+                connection.setRequestProperty("Cookie", cookie);
+            }
+            return connection.getHeaderField(name);
         } finally {
             connection.disconnect();
         }

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
@@ -15,6 +15,10 @@
  */
 package com.vaadin.flow.navigate;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -261,6 +265,34 @@ public class ServiceWorkerIT extends ChromeDeviceTest {
     }
 
     @Test
+    public void offlineStub_framingDeniedByServer_offlineStubShown()
+            throws IOException {
+        openPageAndPreCacheWhenDevelopmentMode("/");
+
+        // The offline stub is pre-cached with the headers the server sent for
+        // it, so the service worker has to serve it as frameable itself
+        Assert.assertEquals(
+                "Expected the server to deny framing of the offline stub",
+                "DENY", getFrameOptionsHeader("/offline-stub.html"));
+
+        getDevTools().setOfflineEnabled(true);
+        try {
+            waitUntil(driver -> $("main-view").first().$("a").id("menu-hello"))
+                    .click();
+
+            waitForElementPresent(By.tagName("iframe"));
+            WebElement offlineStub = findElement(By.tagName("iframe"));
+            driver.switchTo().frame(offlineStub);
+            Assert.assertNotNull(
+                    "Offline stub should be rendered in the iframe even when the server denies framing",
+                    findElement(By.className("offline")));
+        } finally {
+            driver.switchTo().defaultContent();
+            getDevTools().setOfflineEnabled(false);
+        }
+    }
+
+    @Test
     public void offlineStub_backOnline_stubRemoved_serverViewShown() {
         openPageAndPreCacheWhenDevelopmentMode("/");
         getDevTools().setOfflineEnabled(true);
@@ -295,6 +327,17 @@ public class ServiceWorkerIT extends ChromeDeviceTest {
             Assert.assertTrue(json.has("short_name"));
         } finally {
             getDevTools().setOfflineEnabled(false);
+        }
+    }
+
+    private String getFrameOptionsHeader(String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(
+                getRootURL() + path).openConnection();
+        try {
+            connection.setRequestMethod("HEAD");
+            return connection.getHeaderField("X-Frame-Options");
+        } finally {
+            connection.disconnect();
         }
     }
 


### PR DESCRIPTION
The Flow client renders the offline page inside a same-origin iframe pointing at offline-stub.html. What the browser gets for that navigation comes from the service worker, which replays the headers the origin server sent — including the X-Frame-Options: DENY that Spring Security, a servlet filter, a reverse proxy or a CDN adds to every response. The browser then refuses to render the stub and shows its own error page, so the offline page is never seen.

The service worker now rebuilds the response for the offline stub so that the same origin is allowed to frame it: X-Frame-Options becomes SAMEORIGIN, and 'self' is added to the source list of a frame-ancestors directive. Directive names are case-insensitive, so the directive is recognized however the deployment spells it.

The same origin is added to the source list rather than replacing it, which keeps the ancestors a deployment allows for the application itself. An application embedded in a partner portal sends frame-ancestors 'self' https://portal.example.com, and the directive is matched against every ancestor of the stub, so replacing the list would block the stub the same way the header it replaced did. A frame-ancestors 'none' gives way to 'self', being valid only as the single source of a list.

Scoping the rewrite to that single path leaves the app shell's own protection untouched. Both the pre-cached and the network response are rewritten, so the stub also renders when the server is reachable but the Flow client fails to start.

Fixes #25492
