### PR TITLE
fix(devloop): spawn the dev-loop daemon in a session of its own

### DIFF
--- a/flow-devloop-daemon/README.md
+++ b/flow-devloop-daemon/README.md
@@ -69,6 +69,18 @@ handshake authorizes commands to the daemon, so the goal also installs
 `.vaadin/.gitignore` naming `daemon.properties` — the one file there that must
 not be shared.
 
+The CLI spawns the daemon into a **session of its own** — `setsid`, or perl's
+`POSIX::setsid` where no `setsid` binary ships — and not merely with SIGHUP
+ignored. A `nohup`'d child stays in the process group of the shell that spawned
+it, and the runners this CLI is driven from (agent sandboxes, CI steps, `timeout
+--kill-after`) end a command by killing that group: the daemon, and the app it
+owns as its child, would die with the very command that started them. The next
+command would then find a handshake naming a dead pid, spawn a second daemon and
+report the app as stopped — the loop failing to hold across two commands, which
+is the one thing the daemon exists to do. A handshake left behind by a dead pid
+is evidence of exactly that, because a daemon that shuts down deletes its own
+record, so the CLI reports it rather than quietly reaping it.
+
 A request is one line, `<token> <verb> <args...>`. The reply is zero or more
 `> text` progress lines followed by exactly one `EXIT <code>`, which becomes the
 CLI's exit status. Progress-then-code is the shape `apply` needs, so every verb

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
@@ -120,6 +120,14 @@ test can cover.
   from the app's own log, with the tail printed under it; `status` repeats the reason. The
   whole log is the target application's `target/devloop/app.log`. Daemon wedged → `shutdown`,
   then any command respawns it.
+- Every command reports a fresh daemon (`up=0s`) and the app as `stopped`, and `vaadin-dev`
+  says the recorded daemon "left its handshake behind" — something outside the loop is killing
+  the processes each command created, so the daemon and the application it owns die with the
+  command that started them and the loop never holds across two commands. On POSIX the daemon
+  is spawned into a session of its own for exactly this reason, and that is defeated only where
+  neither `setsid` nor `perl` exists; on Windows a runner whose job object closes over the
+  command takes the daemon with it whichever launcher ran. Where it happens, `start` the app
+  from a shell that stays open for as long as the loop is needed, and run `apply` from another.
 - `this project does not depend on the dev-loop daemon` — the application's `pom.xml` is
   missing `com.vaadin:vaadin-dev` (declare it `<optional>true</optional>`, as a generated
   starter does).

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/vaadin-dev
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/vaadin-dev
@@ -303,15 +303,57 @@ daemon_jar() {
     daemon_jar_resolve
 }
 
+# Starts a command in a session of its own and returns immediately.
+#
+# Ignoring SIGHUP is not enough, which is all a bare `nohup ... &` buys. The
+# child stays in the process group of the shell that spawned it, and the runners
+# this script is driven from - agent sandboxes, CI steps, `timeout --kill-after`,
+# a terminal being closed - end a command by killing that whole group. The
+# daemon and the application it owns then die with the very command that started
+# them: the next command finds a handshake pointing at nothing, spawns a second
+# daemon and reports the app as stopped. The loop never holds across two
+# commands, and every edit looks like it needs a fresh `start`.
+#
+# A new session is not reached by a kill aimed at the old process group. setsid
+# does that in one step, and forks first when it is already a group leader.
+# macOS ships no setsid binary, so perl's POSIX::setsid stands in - forking
+# first for the same reason, since setsid() refuses for a group leader. With
+# neither available the old behaviour is what is left, which is still right
+# everywhere nothing kills the group.
+#
+# The perl fallback is POSIX-only: on Windows there is no process group to
+# escape, and the perl there is git-bash's, whose fork is an emulation nothing
+# should be asked to exec through.
+posix_host() {
+    case "$(uname -s 2>/dev/null)" in
+        MINGW*|MSYS*|CYGWIN*|Windows*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+detach() { # $1... the command to run, with its output appended to the daemon log
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "$@" </dev/null >>"$DAEMON_LOG" 2>&1 &
+    elif posix_host && command -v perl >/dev/null 2>&1; then
+        # The eval keeps a perl without POSIX::setsid from taking the daemon
+        # with it: a daemon in the old session still runs, and that is the
+        # behaviour of the last branch anyway.
+        nohup perl -e 'exit 0 if fork; eval { require POSIX; POSIX::setsid() };
+            exec @ARGV or die "vaadin-dev: cannot exec the daemon: $!"' \
+            -- "$@" </dev/null >>"$DAEMON_LOG" 2>&1 &
+    else
+        nohup "$@" </dev/null >>"$DAEMON_LOG" 2>&1 &
+    fi
+    disown 2>/dev/null || true
+}
+
 spawn_daemon() {
     local jar
     jar="$(daemon_jar)" || return 70
     mkdir -p "$WORK_DIR"
-    # Detached: the daemon outlives this shell so later commands reuse it.
-    nohup "$(java_bin)" ${VAADIN_DEV_DAEMON_OPTS:-} \
-        -jar "$jar" "$ROOT" \
-        >>"$DAEMON_LOG" 2>&1 &
-    disown 2>/dev/null || true
+    # Unquoted deliberately: VAADIN_DEV_DAEMON_OPTS is a list of JVM options and
+    # has to split into words here, before detach receives them as "$@".
+    detach "$(java_bin)" ${VAADIN_DEV_DAEMON_OPTS:-} -jar "$jar" "$ROOT"
 
     # Wait for the handshake file rather than sleeping a fixed amount.
     local waited=0
@@ -486,7 +528,29 @@ main() {
 
     # 99 means the recorded daemon is not answering: the record is stale, so reap
     # it and try once more with a fresh daemon.
+    #
+    # Said out loud, because the application went with it. A daemon that shuts
+    # down deletes its own handshake, so a handshake still naming a dead process
+    # is evidence of a kill and not of an exit - and the reader is otherwise
+    # about to be told the app is stopped without being told what stopped it.
     if (( status == 99 )); then
+        local recorded
+        recorded="$(read_prop pid || true)"
+        if [[ -n "$recorded" ]] && kill -0 "$recorded" 2>/dev/null; then
+            echo "vaadin-dev: the daemon recorded for $ROOT (pid $recorded) is" \
+                 "running but not answering. Reaping the record and starting a" \
+                 "fresh daemon." >&2
+        else
+            echo "vaadin-dev: the daemon recorded for $ROOT (pid" \
+                 "${recorded:-unknown}) is gone and left its handshake behind," \
+                 "so it was killed rather than shut down - the application it" \
+                 "owned stopped with it. Starting a fresh daemon; the app needs" \
+                 "'vaadin-dev start' again." >&2
+            echo "vaadin-dev: if that repeats on every command, whatever runs" \
+                 "vaadin-dev is killing the process group each command runs in;" \
+                 "see \"When it goes wrong\" in the vaadin-devloop skill" \
+                 "reference." >&2
+        fi
         rm -f "$HANDSHAKE"
         spawn_daemon || exit 70
         port="$(read_prop port)"; token="$(read_prop token)"

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/vaadin-dev.ps1
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/vaadin-dev.ps1
@@ -515,7 +515,35 @@ try {
 
     # 99 means the recorded daemon is not answering: the record is stale, so reap
     # it and try once more with a fresh daemon.
+    #
+    # Said out loud, because the application went with it. A daemon that shuts
+    # down deletes its own handshake, so a handshake still naming a process that
+    # is gone is evidence of a kill and not of an exit - and the reader is
+    # otherwise about to be told the app is stopped without being told what
+    # stopped it.
     if ($status -eq 99) {
+        $recorded = Read-Handshake 'pid'
+        $alive = $false
+        if ($recorded) {
+            try { $alive = [bool] (Get-Process -Id ([int]$recorded) -ErrorAction Stop) }
+            catch { $alive = $false }
+        }
+        if ($alive) {
+            [Console]::Error.WriteLine("vaadin-dev: the daemon recorded for " +
+                "$root (pid $recorded) is running but not answering. Reaping " +
+                "the record and starting a fresh daemon.")
+        } else {
+            $named = if ($recorded) { $recorded } else { 'unknown' }
+            [Console]::Error.WriteLine("vaadin-dev: the daemon recorded for " +
+                "$root (pid $named) is gone and left its handshake behind, so " +
+                "it was killed rather than shut down - the application it " +
+                "owned stopped with it. Starting a fresh daemon; the app needs " +
+                "'vaadin-dev start' again.")
+            [Console]::Error.WriteLine("vaadin-dev: if that repeats on every " +
+                "command, whatever runs vaadin-dev is killing the processes " +
+                "each command created; see ""When it goes wrong"" in the " +
+                "vaadin-devloop skill reference.")
+        }
         Remove-Item -LiteralPath $handshake -Force -ErrorAction SilentlyContinue
         if (-not (Start-Daemon)) { exit 70 }
         $port = Read-Handshake 'port'

--- a/flow-tests/test-devloop/devloop-app/src/test/java/com/vaadin/flow/devloop/test/it/DevLoopDaemonSurvivalIT.java
+++ b/flow-tests/test-devloop/devloop-app/src/test/java/com/vaadin/flow/devloop/test/it/DevLoopDaemonSurvivalIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.devloop.test.it;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * The daemon has to outlive the command that spawned it, and surviving the
+ * shell is not the same thing as surviving its process group.
+ * <p>
+ * Agent runners, CI steps, {@code timeout --kill-after} and a closing terminal
+ * all end a command by killing the whole process group it ran in. A daemon that
+ * is only {@code nohup}'d stays in that group, so it - and the application it
+ * owns - dies with the very command that started it. The next command then
+ * finds a handshake pointing at nothing, spawns a second daemon and reports the
+ * app as stopped, which is how the loop stops holding across two commands.
+ * <p>
+ * What is asserted here is the property that prevents it: the daemon runs in a
+ * session of its own, which no kill aimed at the spawning group can reach. The
+ * kill itself is not staged - the only group this JVM could aim at is its own,
+ * and the daemon under test is the one the other ITs share, so shutting it down
+ * to spawn a killable one would cost the run a cold start to prove what the
+ * session id already says.
+ */
+@Isolated
+class DevLoopDaemonSurvivalIT {
+
+    @Test
+    void daemon_runsInASessionOfItsOwn() {
+        Assumptions.assumeFalse(VaadinDevCli.WINDOWS,
+                "process groups and sessions are a POSIX notion");
+        Assumptions.assumeTrue(onPath("setsid") || onPath("perl"),
+                "no setsid and no perl, so this platform has nothing to detach with");
+
+        VaadinDevCli cli = VaadinDevCli.of(AbstractDevLoopIT.APP);
+        // ping rather than start: the session is decided when the daemon is
+        // spawned, and an application is not needed to read it.
+        cli.run("ping").assertExitCode(0);
+
+        long daemon = daemonPid();
+        Assertions.assertTrue(ProcessHandle.of(daemon).isPresent(),
+                "the daemon the handshake names (pid " + daemon
+                        + ") is not running");
+
+        String own = session(ProcessHandle.current().pid());
+        String daemonSession = session(daemon);
+        Assumptions.assumeFalse(own.isEmpty() || daemonSession.isEmpty(),
+                "ps here cannot report a session id");
+
+        // The CLI is a child of this JVM and does not change session, so the
+        // daemon sharing this session is exactly the state a group kill takes
+        // down with the command.
+        Assertions.assertNotEquals(own, daemonSession,
+                "the daemon runs in this test JVM's session (" + own
+                        + "), so a kill aimed at the spawning command's process "
+                        + "group would take the daemon and its application down "
+                        + "with it");
+    }
+
+    /** The pid the daemon recorded for itself, as the CLI reads it. */
+    private static long daemonPid() {
+        Path handshake = AbstractDevLoopIT.APP
+                .resolve(".vaadin/daemon.properties");
+        Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(handshake)) {
+            properties.load(in);
+        } catch (IOException e) {
+            throw new AssertionError("could not read " + handshake, e);
+        }
+        String pid = properties.getProperty("pid", "");
+        Assertions.assertFalse(pid.isEmpty(),
+                handshake + " carries no pid, so no daemon can be found");
+        return Long.parseLong(pid.trim());
+    }
+
+    /**
+     * The session id of a process, or empty when {@code ps} cannot say.
+     */
+    private static String session(long pid) {
+        return run(List.of("ps", "-o", "sess=", "-p", String.valueOf(pid)));
+    }
+
+    private static boolean onPath(String command) {
+        return !run(List.of("sh", "-c", "command -v " + command)).isEmpty();
+    }
+
+    private static String run(List<String> command) {
+        try {
+            Process process = new ProcessBuilder(command)
+                    .redirectErrorStream(true).start();
+            String output;
+            try (InputStream in = process.getInputStream()) {
+                output = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                return "";
+            }
+            return process.exitValue() == 0 ? output.trim() : "";
+        } catch (IOException e) {
+            return "";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
A nohup'd daemon stays in the process group of the command that spawned it, and the runners vaadin-dev is driven from - agent sandboxes, CI steps, timeout --kill-after - end a command by killing that group. The daemon and the application it owned died with the very command that started them, so every later command found a stale handshake, spawned a fresh daemon and reported the app as stopped: the loop never held across two commands.

setsid, or perl's POSIX::setsid where no setsid binary ships, puts it out of reach of that kill. A handshake left behind by a dead pid is now reported instead of quietly reaped, since a daemon that shuts down deletes its own.