### PR TITLE
chore: upgrade project version to 25.4

### DIFF
--- a/.github/RELEASE_DIGEST.md
+++ b/.github/RELEASE_DIGEST.md
@@ -13,7 +13,7 @@ Every run writes the message it built into the job summary, posted or not.
 One entry per branch that has unreleased work, always including `main`:
 
 - the branch and the version it would be released as (`25.2.6` → `25.2.7`,
-  `25.3.0-alpha7` → `25.3.0-alpha8`);
+  `25.4.0-alpha7` → `25.4.0-alpha8`);
 - how many unreleased commits there are, split into feat/fix, dependency bumps,
   and everything else;
 - the commit subjects, feat/fix first, with a link to the full diff;
@@ -26,7 +26,7 @@ Branches with nothing worth releasing collapse into a single closing line.
 **Branch list.** Read from `on.push.branches` in
 [`validation.yml`](workflows/validation.yml), so CI remains the single source of
 truth. `main` is added by the digest and its version line comes from its POM
-version, because pre-releases are tagged `25.3.0-alphaN`, not `main.N`.
+version, because pre-releases are tagged `25.4.0-alphaN`, not `main.N`.
 
 **Commit classification** ([`checkReleases.js`](../scripts/checkReleases.js)) —
 every commit since the branch's latest tag, by conventional-commit type:

--- a/.github/workflows/update-frontend-dependencies.yml
+++ b/.github/workflows/update-frontend-dependencies.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, '25.2', '25.1', '24.10', '24.9']
+        branch: [main, '25.3', '25.2', '25.1', '24.10', '24.9']
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,7 +1,7 @@
 name: Flow Validation
 on:
   push:
-    branches: ['25.2', '25.1', '25.0', '24.10', '24.9', '23.7', '23.6']
+    branches: ['25.3', '25.2', '25.1', '25.0', '24.10', '24.9', '23.7', '23.6']
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Since [Vaadin platform 23.0](https://github.com/vaadin/platform), Flow major and
 | 2.13   | 14.14 (LATEST commercial with Java 8+ support and Servlet 3)            | 2.13                                                    |
 | 23.6   | 23.6 (LATEST commercial with Java 11+ support and Servlet 3)            | 23.6                                                    |
 | 24.10  | 24.10 (LATEST 24 minor release, Java 17+, Jakarta EE 10, Spring-boot 3) | 24.10                                                   |
-| 25.1   | 25.1 (LATEST release, Java 21+, Jakarta EE 11, Spring-boot 4)           | 25.1                                                    |
-| 25.2   | 25.2 (Vaadin 25.2 pre-release, Java 21+, Jakarta EE 11, Spring-boot 4)  | 25.2                                                    |
-| main   | 25.3 (Vaadin 25.3 preparations, Java 21+, Jakarta EE 11, Spring-boot 4) | 25.3                                                    |
+| 25.2   | 25.2 (LATEST release, Java 21+, Jakarta EE 11, Spring-boot 4)           | 25.2                                                    |
+| 25.3   | 25.3 (Vaadin 25.3 pre-release, Java 21+, Jakarta EE 11, Spring-boot 4)  | 25.3                                                    |
+| main   | 25.4 (Vaadin 25.4 preparations, Java 21+, Jakarta EE 11, Spring-boot 4) | 25.4                                                    |

--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>flow-bom</artifactId>
-  <version>25.3-SNAPSHOT</version>
+  <version>25.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Flow Bill of Materials</name>
   <description>Flow Bill of Materials</description>

--- a/flow-build-tools/pom.xml
+++ b/flow-build-tools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-build-tools</artifactId>
   <packaging>jar</packaging>

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-client</artifactId>
   <packaging>jar</packaging>

--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-data</artifactId>
   <packaging>jar</packaging>

--- a/flow-devloop-daemon/pom.xml
+++ b/flow-devloop-daemon/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-devloop-daemon</artifactId>
   <packaging>jar</packaging>

--- a/flow-dnd/pom.xml
+++ b/flow-dnd/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-dnd</artifactId>

--- a/flow-html-components-testbench/pom.xml
+++ b/flow-html-components-testbench/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-html-components-testbench</artifactId>
   <packaging>jar</packaging>

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-html-components</artifactId>
   <packaging>jar</packaging>

--- a/flow-jandex/pom.xml
+++ b/flow-jandex/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-jandex</artifactId>

--- a/flow-lit-template/pom.xml
+++ b/flow-lit-template/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-lit-template</artifactId>
   <packaging>jar</packaging>

--- a/flow-plugins/flow-dev-bundle-plugin/pom.xml
+++ b/flow-plugins/flow-dev-bundle-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-plugins</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-dev-bundle-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/flow-plugins/flow-gradle-plugin/README.md
+++ b/flow-plugins/flow-gradle-plugin/README.md
@@ -210,7 +210,7 @@ Alternatively, you can build and publish the Flow Gradle plugin into the local M
 
 1. Clone the Base Starter Gradle project.
 2. Add `mavenLocal()` to `buildscript.repositories` as the first place to look up.
-3. Add `dependencies { classpath 'com.vaadin:flow-gradle-plugin:25.3-SNAPSHOT' }` to `buildscript.repositories`.
+3. Add `dependencies { classpath 'com.vaadin:flow-gradle-plugin:25.4-SNAPSHOT' }` to `buildscript.repositories`.
 4. Run `./gradlew clean build publishToMavenLocal` in the `flow-plugins/flow-gradle-plugin` repo folder.
 5. Run the previous command with `-x functionalTest` to skip functional tests.
 6. If you now run `./gradlew vaadinPrepareFrontend` in the Starter project folder, Gradle will use the local version of the Flow plugin. You can verify that by adding `println()` statements into the `VaadinPrepareFrontendTask` class.

--- a/flow-plugins/flow-gradle-plugin/pom.xml
+++ b/flow-plugins/flow-gradle-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-plugins</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-gradle-plugin</artifactId>

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
@@ -56,7 +56,7 @@ abstract class AbstractGradleTest {
 
     private companion object {
         const val VERSION_ENV = "vaadin.version"
-        const val FALLBACK_VERSION = "25.3-SNAPSHOT"
+        const val FALLBACK_VERSION = "25.4-SNAPSHOT"
 
         /**
          * The version the generated test projects build against, taken from the

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-plugins</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/FrontendScannerConfigTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/FrontendScannerConfigTest.java
@@ -139,14 +139,14 @@ class FrontendScannerConfigTest {
     // <groupId>:<artifactId>:<type>:<classifier>:<version>:<scope> (optional)
     //
     private static final String TEST_DEPENDENCIES_LIST = """
-            com.vaadin:vaadin:jar:25.3-SNAPSHOT:compile
-            com.vaadin:vaadin-internal:jar:25.3-SNAPSHOT:compile
-            com.vaadin:vaadin-core-internal:jar:25.3-SNAPSHOT:compile
-            com.vaadin:vaadin-accordion-flow:jar:25.3-SNAPSHOT:compile
-            com.vaadin:vaadin-avatar-flow:jar:25.3-SNAPSHOT:compile
-            com.vaadin:vaadin-checkbox-flow:jar:25.3-SNAPSHOT:compile
-            com.vaadin:flow-server:jar:25.3-SNAPSHOT:compile
-            com.vaadin:flow-push:jar:25.3-SNAPSHOT:compile
+            com.vaadin:vaadin:jar:25.4-SNAPSHOT:compile
+            com.vaadin:vaadin-internal:jar:25.4-SNAPSHOT:compile
+            com.vaadin:vaadin-core-internal:jar:25.4-SNAPSHOT:compile
+            com.vaadin:vaadin-accordion-flow:jar:25.4-SNAPSHOT:compile
+            com.vaadin:vaadin-avatar-flow:jar:25.4-SNAPSHOT:compile
+            com.vaadin:vaadin-checkbox-flow:jar:25.4-SNAPSHOT:compile
+            com.vaadin:flow-server:jar:25.4-SNAPSHOT:compile
+            com.vaadin:flow-push:jar:25.4-SNAPSHOT:compile
             com.vaadin.external.atmosphere:atmosphere-runtime:jar:3.0.5.slf4jvaadin1:compile
             com.vaadin.servletdetector:throw-if-servlet3:jar:1.0.2:compile
             org.jspecify:jspecify:jar:1.0.0:compile
@@ -168,7 +168,7 @@ class FrontendScannerConfigTest {
             org.apache.commons:commons-compress:jar:1.27.1:compile
             commons-codec:commons-codec:jar:1.17.1:compile
             org.apache.commons:commons-lang3:jar:3.16.0:compile
-            com.vaadin:flow-client:jar:25.3-SNAPSHOT:compile
+            com.vaadin:flow-client:jar:25.4-SNAPSHOT:compile
             org.yaml:snakeyaml:jar:2.2:compile
             org.yaml:snakeyaml:jar:android:1.23:compile
             org.springframework.boot:spring-boot-autoconfigure:jar:3.4.3:compile

--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-plugins</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-plugin-base</artifactId>
   <name>Flow Plugin Base</name>

--- a/flow-plugins/pom.xml
+++ b/flow-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-plugins</artifactId>
   <packaging>pom</packaging>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-polymer-template</artifactId>
   <packaging>jar</packaging>

--- a/flow-polymer2lit/README.md
+++ b/flow-polymer2lit/README.md
@@ -42,7 +42,7 @@ mvn vaadin:convert-polymer
 To convert a project that is based on Vaadin < 24, use the full Maven goal:
 
 ```bash
-mvn com.vaadin:vaadin-maven-plugin:25.3-SNAPSHOT:convert-polymer
+mvn com.vaadin:vaadin-maven-plugin:25.4-SNAPSHOT:convert-polymer
 ```
 
 Or, in the case of using Gradle, add the following to `build.gradle`:
@@ -50,7 +50,7 @@ Or, in the case of using Gradle, add the following to `build.gradle`:
 ```gradle
 buildscript {
   repositories {
-    classpath 'com.vaadin:flow-gradle-plugin:25.3-SNAPSHOT'
+    classpath 'com.vaadin:flow-gradle-plugin:25.4-SNAPSHOT'
   }
 }
 ```

--- a/flow-polymer2lit/pom.xml
+++ b/flow-polymer2lit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-polymer2lit</artifactId>
   <packaging>jar</packaging>

--- a/flow-push/pom.xml
+++ b/flow-push/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-push</artifactId>
   <packaging>jar</packaging>

--- a/flow-react/pom.xml
+++ b/flow-react/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-react</artifactId>

--- a/flow-server-production-mode/pom.xml
+++ b/flow-server-production-mode/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-server-production-mode</artifactId>
   <packaging>jar</packaging>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-server</artifactId>
   <packaging>jar</packaging>

--- a/flow-test-generic/pom.xml
+++ b/flow-test-generic/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-generic</artifactId>

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-util</artifactId>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-tests</artifactId>
   <packaging>pom</packaging>

--- a/flow-tests/servlet-containers/pom.xml
+++ b/flow-tests/servlet-containers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-servlet-containers-test</artifactId>
   <packaging>pom</packaging>

--- a/flow-tests/servlet-containers/tomcat10/pom.xml
+++ b/flow-tests/servlet-containers/tomcat10/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-servlet-containers-test</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-tomcat10-server</artifactId>
     <name>Flow Tomcat 9 Test</name>

--- a/flow-tests/test-application-theme/pom.xml
+++ b/flow-tests/test-application-theme/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-application-theme</artifactId>

--- a/flow-tests/test-application-theme/reusable-theme/pom.xml
+++ b/flow-tests/test-application-theme/reusable-theme/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-application-theme</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>reusable-theme</artifactId>

--- a/flow-tests/test-application-theme/test-reusable-as-parent-vite/pom.xml
+++ b/flow-tests/test-application-theme/test-reusable-as-parent-vite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-application-theme</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-use-reusable-as-parent-vite</artifactId>

--- a/flow-tests/test-application-theme/test-theme-component-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-application-theme</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-application-theme-component-live-reload</artifactId>
 

--- a/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-application-theme</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-application-theme-live-reload</artifactId>
 

--- a/flow-tests/test-application-theme/test-theme-reusable-vite/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-reusable-vite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-application-theme</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-application-theme-reusable-vite</artifactId>

--- a/flow-tests/test-aura/pom.xml
+++ b/flow-tests/test-aura/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-aura</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-ccdm-flow-navigation/pom-production.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom-production.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-ccdm-flow-navigation/pom.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-ccdm-flow-navigation</artifactId>

--- a/flow-tests/test-ccdm/pom-production.xml
+++ b/flow-tests/test-ccdm/pom-production.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-ccdm/pom.xml
+++ b/flow-tests/test-ccdm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-ccdm</artifactId>

--- a/flow-tests/test-client-queue/pom.xml
+++ b/flow-tests/test-client-queue/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-client-queue-test</artifactId>
 

--- a/flow-tests/test-commercial-banner/commercial-addon/pom.xml
+++ b/flow-tests/test-commercial-banner/commercial-addon/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-commercial-banner</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-commercial-addon</artifactId>

--- a/flow-tests/test-commercial-banner/flow-application/pom.xml
+++ b/flow-tests/test-commercial-banner/flow-application/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-commercial-banner</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-commercial-banner-webapp</artifactId>
 

--- a/flow-tests/test-commercial-banner/integration-test/pom.xml
+++ b/flow-tests/test-commercial-banner/integration-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-commercial-banner</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-commercial-banner-it</artifactId>
 

--- a/flow-tests/test-commercial-banner/pom.xml
+++ b/flow-tests/test-commercial-banner/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-commercial-banner</artifactId>
 

--- a/flow-tests/test-common/pom.xml
+++ b/flow-tests/test-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-common</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-custom-frontend-directory/pom.xml
+++ b/flow-tests/test-custom-frontend-directory/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-custom-frontend-directory</artifactId>

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/pom-generatedTsDir.xml
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/pom-generatedTsDir.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-custom-frontend-directory</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-themes-custom-generatedTs-directory</artifactId>
     <name>Flow themes tests in NPM mode with custom generatedTs directory</name>

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/pom.xml
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-custom-frontend-directory</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-themes-custom-frontend-directory-vite</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-custom-route-registry/pom.xml
+++ b/flow-tests/test-custom-route-registry/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-custom-route-registry</artifactId>
 

--- a/flow-tests/test-default/pom.xml
+++ b/flow-tests/test-default/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-default</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-dev-mode/pom.xml
+++ b/flow-tests/test-dev-mode/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-dev-mode</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-devloop/devloop-app/pom.xml
+++ b/flow-tests/test-devloop/devloop-app/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-devloop</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-devloop-app</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-devloop/devloop-shared/pom.xml
+++ b/flow-tests/test-devloop/devloop-shared/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-devloop</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-devloop-shared</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-devloop/pom.xml
+++ b/flow-tests/test-devloop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-devloop</artifactId>
   <packaging>pom</packaging>

--- a/flow-tests/test-eager-bootstrap/pom.xml
+++ b/flow-tests/test-eager-bootstrap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-eager-bootstrap</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-embedding/embedding-reusable-custom-theme/pom.xml
+++ b/flow-tests/test-embedding/embedding-reusable-custom-theme/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-reusable-embedded-theme</artifactId>

--- a/flow-tests/test-embedding/embedding-test-assets/pom.xml
+++ b/flow-tests/test-embedding/embedding-test-assets/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-embedding-test-assets</artifactId>

--- a/flow-tests/test-embedding/pom.xml
+++ b/flow-tests/test-embedding/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-embedding</artifactId>

--- a/flow-tests/test-embedding/test-embedding-application-theme/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-application-theme/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-embedding-app-theme</artifactId>

--- a/flow-tests/test-embedding/test-embedding-generic/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-generic/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-embedding-generic</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-embedding-production</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-embedding-reusable-theme</artifactId>

--- a/flow-tests/test-embedding/test-embedding-style-containment/pom-production.xml
+++ b/flow-tests/test-embedding/test-embedding-style-containment/pom-production.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-embedding-style-containment-production</artifactId>

--- a/flow-tests/test-embedding/test-embedding-style-containment/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-style-containment/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-embedding-style-containment</artifactId>

--- a/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-embedding</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-embedding-theme-variant</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-express-build/frontend-add-on/pom.xml
+++ b/flow-tests/test-express-build/frontend-add-on/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-add-on</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-express-build/java-add-on/pom.xml
+++ b/flow-tests/test-express-build/java-add-on/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>java-add-on</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-express-build/pom.xml
+++ b/flow-tests/test-express-build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-express-build</artifactId>

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/pom.xml
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-dev-bundle-frontend-add-on</artifactId>

--- a/flow-tests/test-express-build/test-dev-bundle-java-add-on/pom.xml
+++ b/flow-tests/test-express-build/test-dev-bundle-java-add-on/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-dev-bundle-java-add-on</artifactId>

--- a/flow-tests/test-express-build/test-dev-bundle-no-plugin/pom.xml
+++ b/flow-tests/test-express-build/test-dev-bundle-no-plugin/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-dev-bundle-no-plugin</artifactId>

--- a/flow-tests/test-express-build/test-dev-bundle/pom.xml
+++ b/flow-tests/test-express-build/test-dev-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-dev-bundle</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-express-build/test-embedding-express-build/pom.xml
+++ b/flow-tests/test-express-build/test-embedding-express-build/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-embedding-express-build</artifactId>

--- a/flow-tests/test-express-build/test-flow-maven-plugin/pom.xml
+++ b/flow-tests/test-express-build/test-flow-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-flow-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/flow-tests/test-express-build/test-parent-theme-express-build/pom.xml
+++ b/flow-tests/test-express-build/test-parent-theme-express-build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-parent-theme-express-bundle</artifactId>
 

--- a/flow-tests/test-express-build/test-parent-theme-in-frontend-prod/pom.xml
+++ b/flow-tests/test-express-build/test-parent-theme-in-frontend-prod/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-parent-theme-in-frontend-prod</artifactId>
 

--- a/flow-tests/test-express-build/test-parent-theme-in-frontend/pom.xml
+++ b/flow-tests/test-express-build/test-parent-theme-in-frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-parent-theme-in-frontend</artifactId>
 

--- a/flow-tests/test-express-build/test-parent-theme-prod/pom.xml
+++ b/flow-tests/test-express-build/test-parent-theme-prod/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-parent-theme-prod</artifactId>
 

--- a/flow-tests/test-express-build/test-prod-bundle-no-plugin/pom.xml
+++ b/flow-tests/test-express-build/test-prod-bundle-no-plugin/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-prod-bundle-no-plugin</artifactId>

--- a/flow-tests/test-express-build/test-prod-bundle/pom.xml
+++ b/flow-tests/test-express-build/test-prod-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-prod-bundle</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-express-build/test-reusable-theme-express-build/pom.xml
+++ b/flow-tests/test-express-build/test-reusable-theme-express-build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-reusable-theme-express-build</artifactId>
 

--- a/flow-tests/test-express-build/test-reusable-theme-no-assets/pom.xml
+++ b/flow-tests/test-express-build/test-reusable-theme-no-assets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-reusable-theme-no-assets</artifactId>
 

--- a/flow-tests/test-express-build/test-reusing-theme-express-build/pom.xml
+++ b/flow-tests/test-express-build/test-reusing-theme-express-build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-reusing-theme-express-bundle</artifactId>
 

--- a/flow-tests/test-express-build/test-theme-dev-bundle/pom.xml
+++ b/flow-tests/test-express-build/test-theme-dev-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-theme-dev-bundle</artifactId>
 

--- a/flow-tests/test-express-build/test-theme-legacy-components-css-prod/pom.xml
+++ b/flow-tests/test-express-build/test-theme-legacy-components-css-prod/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-express-build</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-theme-legacy-components-css-prod</artifactId>
 

--- a/flow-tests/test-frontend/addon-with-templates/pom.xml
+++ b/flow-tests/test-frontend/addon-with-templates/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>addon-with-templates</artifactId>

--- a/flow-tests/test-frontend/pom.xml
+++ b/flow-tests/test-frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-frontend</artifactId>
   <packaging>pom</packaging>

--- a/flow-tests/test-frontend/test-bun/pom-production.xml
+++ b/flow-tests/test-frontend/test-bun/pom-production.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>test-frontend</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-bun-production</artifactId>
     <name>Flow tests in bun and production mode</name>

--- a/flow-tests/test-frontend/test-bun/pom.xml
+++ b/flow-tests/test-frontend/test-bun/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>test-frontend</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-bun-dev-mode</artifactId>
     <name>Flow tests in bun and development mode</name>

--- a/flow-tests/test-frontend/test-npm-legacy-lit-addon/pom.xml
+++ b/flow-tests/test-frontend/test-npm-legacy-lit-addon/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-npm-legacy-lit-addon</artifactId>
 

--- a/flow-tests/test-frontend/test-npm/pom-production.xml
+++ b/flow-tests/test-frontend/test-npm/pom-production.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>test-frontend</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-npm-production</artifactId>
     <name>Flow tests in npm and production mode</name>

--- a/flow-tests/test-frontend/test-npm/pom.xml
+++ b/flow-tests/test-frontend/test-npm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-npm-dev-mode</artifactId>
 

--- a/flow-tests/test-frontend/test-pnpm/pom-production.xml
+++ b/flow-tests/test-frontend/test-pnpm/pom-production.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>test-frontend</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pnpm-production</artifactId>
     <name>Flow tests in pnpm and production mode</name>

--- a/flow-tests/test-frontend/test-pnpm/pom.xml
+++ b/flow-tests/test-frontend/test-pnpm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-pnpm-dev-mode</artifactId>
 

--- a/flow-tests/test-frontend/vite-basics/pom.xml
+++ b/flow-tests/test-frontend/vite-basics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-basics</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-context-path/pom-production.xml
+++ b/flow-tests/test-frontend/vite-context-path/pom-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-frontend</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>vite-context-path-production</artifactId>
     <name>Vite with a context path (production mode)</name>

--- a/flow-tests/test-frontend/vite-context-path/pom.xml
+++ b/flow-tests/test-frontend/vite-context-path/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-context-path</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-embedded-no-theme/pom-production.xml
+++ b/flow-tests/test-frontend/vite-embedded-no-theme/pom-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-frontend</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>vite-embedded-no-theme-production</artifactId>
     <name>Vite embedded app not theme (production mode)</name>

--- a/flow-tests/test-frontend/vite-embedded-no-theme/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-no-theme/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-embedded-no-theme</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync-longpolling/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync-longpolling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-embedded-webcomponent-resync-long-polling</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync-ws/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync-ws/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-embedded-webcomponent-resync-ws</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync-wsxhr/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync-wsxhr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-embedded-webcomponent-resync-wsxhr</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-embedded-webcomponent-resync</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-embedded/pom-production.xml
+++ b/flow-tests/test-frontend/vite-embedded/pom-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-frontend</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>vite-embedded-production</artifactId>
     <name>Vite embedded app (production mode)</name>

--- a/flow-tests/test-frontend/vite-embedded/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-embedded</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-production-custom-frontend/pom.xml
+++ b/flow-tests/test-frontend/vite-production-custom-frontend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-production-custom-frontend</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-production/pom.xml
+++ b/flow-tests/test-frontend/vite-production/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-production</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-frontend</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>vite-pwa-custom-offline-path-production</artifactId>
     <name>Vite PWA app with a custom offline path (production mode)</name>

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-pwa-custom-offline-path</artifactId>
 

--- a/flow-tests/test-frontend/vite-pwa-custom-sw/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-sw/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-pwa-custom-sw</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-pwa-disabled-offline/pom-production.xml
+++ b/flow-tests/test-frontend/vite-pwa-disabled-offline/pom-production.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>test-frontend</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>vite-pwa-disabled-offline-production</artifactId>
     <name>Vite PWA app with disabled offline (production mode)</name>

--- a/flow-tests/test-frontend/vite-pwa-disabled-offline/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-disabled-offline/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-pwa-disabled-offline</artifactId>
 

--- a/flow-tests/test-frontend/vite-pwa-production/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-production/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-pwa-production</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-pwa/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vite-pwa</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-frontend/vite-test-assets/pom.xml
+++ b/flow-tests/test-frontend/vite-test-assets/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>test-frontend</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>vite-test-assets</artifactId>

--- a/flow-tests/test-legacy-frontend/pom.xml
+++ b/flow-tests/test-legacy-frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-legacy-frontend</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-live-reload-multimodule-devbundle/pom.xml
+++ b/flow-tests/test-live-reload-multimodule-devbundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-live-reload-multimodule-devbundle</artifactId>
 

--- a/flow-tests/test-live-reload-multimodule/library/pom-devbundle.xml
+++ b/flow-tests/test-live-reload-multimodule/library/pom-devbundle.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-test-live-reload-multimodule-devbundle</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
         <relativePath>../../test-live-reload-multimodule-devbundle/pom.xml</relativePath>
     </parent>
     <artifactId>flow-test-live-reload-multimodule-library-devbundle</artifactId>

--- a/flow-tests/test-live-reload-multimodule/library/pom.xml
+++ b/flow-tests/test-live-reload-multimodule/library/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-live-reload-multimodule-hotdeploy</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-live-reload-multimodule-library-hotdeploy</artifactId>
 

--- a/flow-tests/test-live-reload-multimodule/pom.xml
+++ b/flow-tests/test-live-reload-multimodule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-live-reload-multimodule-hotdeploy</artifactId>
 

--- a/flow-tests/test-live-reload-multimodule/theme/pom-devbundle.xml
+++ b/flow-tests/test-live-reload-multimodule/theme/pom-devbundle.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-test-live-reload-multimodule-devbundle</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
         <relativePath>../../test-live-reload-multimodule-devbundle/pom.xml</relativePath>
     </parent>
     <artifactId>flow-test-live-reload-multimodule-theme-devbundle</artifactId>

--- a/flow-tests/test-live-reload-multimodule/theme/pom.xml
+++ b/flow-tests/test-live-reload-multimodule/theme/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-live-reload-multimodule-hotdeploy</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-live-reload-multimodule-theme-hotdeploy</artifactId>
 

--- a/flow-tests/test-live-reload-multimodule/ui/pom-devbundle.xml
+++ b/flow-tests/test-live-reload-multimodule/ui/pom-devbundle.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-test-live-reload-multimodule-devbundle</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
         <relativePath>../../test-live-reload-multimodule-devbundle/pom.xml</relativePath>
     </parent>
     <artifactId>flow-test-live-reload-multimodule-ui-devbundle</artifactId>

--- a/flow-tests/test-live-reload-multimodule/ui/pom.xml
+++ b/flow-tests/test-live-reload-multimodule/ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-live-reload-multimodule-hotdeploy</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-live-reload-multimodule-ui-hotdeploy</artifactId>
 

--- a/flow-tests/test-live-reload/pom.xml
+++ b/flow-tests/test-live-reload/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-live-reload-mode</artifactId>
 

--- a/flow-tests/test-lumo-theme/pom.xml
+++ b/flow-tests/test-lumo-theme/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-lumo-theme</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-lumo/pom.xml
+++ b/flow-tests/test-lumo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-lumo</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-misc/pom.xml
+++ b/flow-tests/test-misc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-misc-test</artifactId>
 

--- a/flow-tests/test-multi-war/deployment/pom.xml
+++ b/flow-tests/test-multi-war/deployment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-multi-war</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-multi-war-bundle</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-multi-war/pom.xml
+++ b/flow-tests/test-multi-war/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-multi-war</artifactId>
   <packaging>pom</packaging>

--- a/flow-tests/test-multi-war/test-war1/pom.xml
+++ b/flow-tests/test-multi-war/test-war1/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-multi-war</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-multi-war1</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-multi-war/test-war2/pom.xml
+++ b/flow-tests/test-multi-war/test-war2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-multi-war</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-multi-war2</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-no-theme/pom.xml
+++ b/flow-tests/test-no-theme/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-no-theme</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-npm-only-features/pom.xml
+++ b/flow-tests/test-npm-only-features/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-npm-only-features</artifactId>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-npm-only-features</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-npm-custom-frontend-directory</artifactId>

--- a/flow-tests/test-npm-only-features/test-npm-general/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-general/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-npm-only-features</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-npm-general</artifactId>

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-npm-only-features</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-test-npm-no-buildmojo</artifactId>

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-test-npm-only-features</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-npm-performance-regression</artifactId>
 

--- a/flow-tests/test-pwa-disabled-offline/pom-production.xml
+++ b/flow-tests/test-pwa-disabled-offline/pom-production.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pwa-disabled-offline-prod</artifactId>
     <name>Flow tests for PWA annotation with disabled offline (production mode)</name>

--- a/flow-tests/test-pwa-disabled-offline/pom.xml
+++ b/flow-tests/test-pwa-disabled-offline/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-pwa-disabled-offline</artifactId>
 

--- a/flow-tests/test-pwa/pom-production.xml
+++ b/flow-tests/test-pwa/pom-production.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pwa-prod</artifactId>
     <name>Flow tests for PWA annotation (production mode)</name>

--- a/flow-tests/test-pwa/pom.xml
+++ b/flow-tests/test-pwa/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-pwa</artifactId>
 

--- a/flow-tests/test-react-adapter/pom-production.xml
+++ b/flow-tests/test-react-adapter/pom-production.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-react-adapter-prod</artifactId>
     <name>Flow tests for React adapter in production mode</name>

--- a/flow-tests/test-react-adapter/pom.xml
+++ b/flow-tests/test-react-adapter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-react-adapter</artifactId>
 

--- a/flow-tests/test-redeployment-no-cache/pom.xml
+++ b/flow-tests/test-redeployment-no-cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-redeployment-no-cache</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-redeployment/pom.xml
+++ b/flow-tests/test-redeployment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-redeployment</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-resources/pom.xml
+++ b/flow-tests/test-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-resources</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-root-context-npm</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-router-custom-context-encoded-prod/pom.xml
+++ b/flow-tests/test-router-custom-context-encoded-prod/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-router-custom-context-encoded-production</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-router-custom-context-encoded/pom.xml
+++ b/flow-tests/test-router-custom-context-encoded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-router-custom-context-encoded</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-router-custom-context/pom.xml
+++ b/flow-tests/test-router-custom-context/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-router-custom-context</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-servlet/pom.xml
+++ b/flow-tests/test-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-servlet</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-tailwindcss/pom.xml
+++ b/flow-tests/test-tailwindcss/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-tailwindcss</artifactId>
 

--- a/flow-tests/test-theme-no-polymer/pom.xml
+++ b/flow-tests/test-theme-no-polymer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-theme-no-polymer</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-themes/pom-devbundle.xml
+++ b/flow-tests/test-themes/pom-devbundle.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-themes-devbundle</artifactId>
     <name>Flow themes tests, dev bundle</name>

--- a/flow-tests/test-themes/pom-production.xml
+++ b/flow-tests/test-themes/pom-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-themes-production</artifactId>
     <name>Flow themes tests, production</name>

--- a/flow-tests/test-themes/pom.xml
+++ b/flow-tests/test-themes/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-themes-hotdeploy</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/test-vaadin-router/pom.xml
+++ b/flow-tests/test-vaadin-router/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-vaadin-router</artifactId>
 

--- a/flow-tests/test-webpush/pom.xml
+++ b/flow-tests/test-webpush/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow-test-webpush</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-spring-tests</artifactId>
 

--- a/flow-tests/vaadin-spring-tests/test-mvc-without-endpoints/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-mvc-without-endpoints/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-ts-mvc-without-endpoints</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-plain-spring-boot-reload-time</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-contextpath/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-boot-contextpath</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-jar/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-jar/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-boot-jar</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-boot-prepare</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-boot-reload-time</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-boot-reverseproxy</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-scan/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-scan/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-boot-scan</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-undertow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spring-tests</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>25.4-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-test-spring-boot-undertow</artifactId>
     <name>Vaadin Spring Boot integration tests when running on Undertow</name>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-boot</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-common/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-common</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/allowed-ui/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/allowed-ui/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test-spring-filter-packages</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-filter-packages-allowed-ui</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test-spring-filter-packages</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-filter-packages-lib-allowed</artifactId>
 

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test-spring-filter-packages</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-filter-packages-lib-blocked</artifactId>
 

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-exclude/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-exclude/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test-spring-filter-packages</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-filter-packages-lib-exclude</artifactId>
 

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-filter-packages</artifactId>
 

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-test-spring-filter-packages</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-filter-packages-ui</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-helpers/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-helpers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-helpers</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-contextpath/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-contextpath/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-contextpath</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-methodsecurity</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-reverseproxy/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-reverseproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-revereproxy</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-routepathaccesscheker</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-standalone-routepathaccesscheker</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-contextpath/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-contextpath/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-themes-contextpath</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-urlmapping/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-urlmapping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-themes-urlmapping</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-urlmapping/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-urlmapping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-urlmapping</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-websocket/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-websocket/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow-websocket</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-flow</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-webicons-urlmapping/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-webicons-urlmapping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-webicons-urlmapping</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-webicons/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-webicons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>test-spring-security-webicons</artifactId>
   <packaging>jar</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-war/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-war</artifactId>
   <packaging>war</packaging>

--- a/flow-tests/vaadin-spring-tests/test-spring-white-list/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-white-list/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring-white-list</artifactId>
 

--- a/flow-tests/vaadin-spring-tests/test-spring/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spring-tests</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-test-spring</artifactId>
   <packaging>war</packaging>

--- a/flow-webpush/pom.xml
+++ b/flow-webpush/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>flow-webpush</artifactId>

--- a/flow/pom.xml
+++ b/flow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>flow</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>flow-project</artifactId>
-  <version>25.3-SNAPSHOT</version>
+  <version>25.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Flow</name>
   <url>https://vaadin.com/flow</url>

--- a/scripts/checkReleases.js
+++ b/scripts/checkReleases.js
@@ -8,7 +8,7 @@
  * (the `on.push.branches` list) so this stays in sync with CI and there is no
  * second list to keep up to date. `--include-main` adds `main`, whose version
  * line comes from its POM version rather than its branch name because
- * pre-releases (`25.3.0-alphaN`) are cut from it.
+ * pre-releases (`25.4.0-alphaN`) are cut from it.
  *
  * For each branch it finds the latest tag on that version line and classifies
  * every commit merged since then by its conventional-commit type, into the
@@ -74,7 +74,7 @@ function readMaintainedBranches() {
 
 /**
  * The version line `main` is currently building, taken from the `flow-project`
- * POM version (`25.3-SNAPSHOT` -> `25.3`). Unlike a maintained branch, `main`
+ * POM version (`25.4-SNAPSHOT` -> `25.4`). Unlike a maintained branch, `main`
  * is not named after its line, so its tags cannot be found from the branch
  * name alone.
  */
@@ -143,7 +143,7 @@ function latestTagFor(line) {
 /**
  * The version the pending changes would be released as: the next patch for a
  * final release, or the next iteration of the same pre-release series so `main`
- * gets a concrete `25.3.0-alpha8` rather than a placeholder.
+ * gets a concrete `25.4.0-alpha8` rather than a placeholder.
  */
 function suggestNextVersion(version) {
   if (!version) return null;

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-dev-server</artifactId>
   <packaging>jar</packaging>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>flow-project</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>25.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-spring</artifactId>


### PR DESCRIPTION
Bump the project version to 25.4-SNAPSHOT and shift the branch/version references that follow it:

- README version table: 25.2 becomes the latest release, 25.3 the pre-release, main the 25.4 preparations.
- validation.yml tracks the new 25.3 maintenance branch, which also makes it the branch list for the release check and the release digest.
- update-frontend-dependencies.yml gets frontend dependency PRs for 25.3.
- Version literals in the Gradle plugin fallback, the polymer2lit and Gradle plugin READMEs, and the frontend scanner test fixture.

The Atsince tags, the pinned themable-mixin test version and the TestBench version are all maintained on their own cadence and stay as they are.