### PR TITLE
fix(devloop): make the dev-loop skill load before the first edit

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/verify.bsh
+++ b/flow-plugins/flow-maven-plugin/src/it/install-dev-cli/verify.bsh
@@ -42,24 +42,64 @@ if (ignore.indexOf("daemon.properties") < 0) {
             ".vaadin/.gitignore should keep the handshake out of the repository");
 }
 
-// --- the Claude adapter's relative link resolves ----------------------------
-File adapter = new File(basedir, ".claude/skills/vaadin-devloop/SKILL.md");
-String adapterContent = read(adapter);
-String link = "../../../.agents/skills/vaadin-devloop/SKILL.md";
-if (adapterContent.indexOf(link) < 0) {
-    throw new RuntimeException(
-            "the Claude adapter should link to the shared instructions");
-}
-if (!new File(adapter.getParentFile(), link).getCanonicalFile().isFile()) {
-    throw new RuntimeException("the adapter's link to " + link
-            + " does not resolve; the two skill trees must install as siblings");
-}
-
 // --- the command examples name the installed location -----------------------
 String skill = read(new File(basedir, ".agents/skills/vaadin-devloop/SKILL.md"));
 if (skill.indexOf(".vaadin/vaadin-dev status") < 0) {
     throw new RuntimeException(
             "the skill should invoke the script where the goal installs it");
+}
+
+// --- the Claude adapter is composed out of the shared instructions ----------
+File adapter = new File(basedir, ".claude/skills/vaadin-devloop/SKILL.md");
+String adapterContent = read(adapter);
+if (adapterContent.indexOf("{{") >= 0) {
+    throw new RuntimeException(
+            "a template placeholder survived composition: " + adapterContent);
+}
+// Inlined, not linked: reaching the cycle used to cost a tool call.
+if (adapterContent.indexOf("## The cycle") < 0
+        || adapterContent.indexOf(".vaadin/vaadin-dev apply") < 0) {
+    throw new RuntimeException(
+            "the adapter should carry the cycle and the command set inline");
+}
+// A skill that restricts the tool set cannot be loaded before the first edit,
+// which is exactly when this one has to be.
+if (adapterContent.indexOf("allowed-tools") >= 0) {
+    throw new RuntimeException("the adapter must not restrict the tool set");
+}
+// The description drives skill selection, so the two copies of it must not
+// drift: the adapter's is the shared one, verbatim.
+int at = skill.indexOf("description: ");
+int newline = skill.indexOf("\n", at);
+if (at < 0 || newline < 0) {
+    throw new RuntimeException(
+            "the shared skill should carry a single-line description");
+}
+String description = skill.substring(at, newline);
+if (description.endsWith("\r")) {
+    description = description.substring(0, description.length() - 1);
+}
+if (adapterContent.indexOf(description) < 0) {
+    throw new RuntimeException(
+            "the adapter should reuse the shared description verbatim");
+}
+
+// --- the Claude adapter's relative link resolves ----------------------------
+// The adapter carries no reference.md of its own, so the detail it points at
+// is the .agents copy - which only resolves because both trees install as
+// siblings under one directory.
+String link = "../../../.agents/skills/vaadin-devloop/reference.md";
+if (adapterContent.indexOf(link) < 0) {
+    throw new RuntimeException(
+            "the Claude adapter should link to the shared reference");
+}
+if (!new File(adapter.getParentFile(), link).getCanonicalFile().isFile()) {
+    throw new RuntimeException("the adapter's link to " + link
+            + " does not resolve; the two skill trees must install as siblings");
+}
+if (adapterContent.indexOf("](reference.md)") >= 0) {
+    throw new RuntimeException(
+            "the adapter links to a reference.md that is not beside it");
 }
 
 // --- run 1 replaced the edited file, run 2 wrote nothing --------------------

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/DevCliInstaller.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/DevCliInstaller.java
@@ -55,8 +55,8 @@ import com.vaadin.flow.internal.FileIOUtils;
  * this module; see there for why.
  * <p>
  * Everything is installed relative to one directory, and the two skill trees
- * are installed as siblings, because the Claude adapter links to the shared
- * instructions by relative path.
+ * are installed as siblings, because the Claude adapter reaches the shared
+ * reference by relative path.
  * <p>
  * All of it is meant to be <em>committed</em> by the developer: it is project
  * tooling, like {@code mvnw}, and the point is that every agent and every
@@ -76,6 +76,19 @@ public final class DevCliInstaller {
      * see {@link #provisionHotswapAgent}.
      */
     private static final String PROVISIONER = "com.vaadin.flow.devloop.daemon.HotswapAgentJar";
+
+    /** The shared, tool-agnostic instructions: the single source of truth. */
+    private static final String SHARED_SKILL = "agents-skill/vaadin-devloop/SKILL.md";
+
+    /** The Claude Code adapter, a template around {@link #SHARED_SKILL}. */
+    private static final String CLAUDE_SKILL = "claude-skill/vaadin-devloop/SKILL.md";
+
+    private static final String DESCRIPTION_PLACEHOLDER = "{{shared-description}}";
+
+    private static final String INSTRUCTIONS_PLACEHOLDER = "{{shared-instructions}}";
+
+    /** Where the adapter reaches the shared reference, once installed. */
+    private static final String SHARED_REFERENCE_LINK = "../../../.agents/skills/vaadin-devloop/reference.md";
 
     /**
      * What is installed where, resource path to project-relative path.
@@ -101,14 +114,12 @@ public final class DevCliInstaller {
         files.put("gitignore", ".vaadin/.gitignore");
         // The canonical, tool-agnostic instructions: the single source of truth
         // for the loop's behaviour, and what a non-Claude agent reads.
-        files.put("agents-skill/vaadin-devloop/SKILL.md",
-                ".agents/skills/vaadin-devloop/SKILL.md");
+        files.put(SHARED_SKILL, ".agents/skills/vaadin-devloop/SKILL.md");
         files.put("agents-skill/vaadin-devloop/reference.md",
                 ".agents/skills/vaadin-devloop/reference.md");
-        // A thin adapter carrying the frontmatter Claude Code requires and the
-        // tool bindings for it; it links to the .agents copy above.
-        files.put("claude-skill/vaadin-devloop/SKILL.md",
-                ".claude/skills/vaadin-devloop/SKILL.md");
+        // The frontmatter Claude Code requires and the tool notes for it,
+        // wrapped around a copy of the shared instructions; see compose().
+        files.put(CLAUDE_SKILL, ".claude/skills/vaadin-devloop/SKILL.md");
         return Map.copyOf(files);
     }
 
@@ -162,7 +173,7 @@ public final class DevCliInstaller {
             String relative = entry.getValue();
             Path target = targetDirectory.resolve(relative);
             if (FileIOUtils.writeIfChanged(target.toFile(),
-                    read(entry.getKey()))) {
+                    content(entry.getKey()))) {
                 written.add(target);
             } else {
                 unchanged.add(target);
@@ -280,6 +291,71 @@ public final class DevCliInstaller {
         } catch (UnsupportedOperationException | IOException e) {
             LOGGER.debug("Could not set the executable bit on {}", target, e);
         }
+    }
+
+    /**
+     * The bytes to install for a payload resource: the resource itself, except
+     * for the Claude adapter, which is composed.
+     */
+    private static String content(String resource) throws IOException {
+        return CLAUDE_SKILL.equals(resource) ? compose() : read(resource);
+    }
+
+    /**
+     * Composes the Claude Code adapter by folding the shared instructions into
+     * its template.
+     * <p>
+     * The adapter used to be three paragraphs telling the agent to go and read
+     * the shared file, and that indirection cost a tool call before the first
+     * command and got the detail behind it read only sometimes. So the cycle,
+     * the command set and the outcome table are inlined here instead, and the
+     * adapter carries only what is specific to Claude Code: the frontmatter
+     * that tool requires and which of its tools to reach for.
+     * <p>
+     * Inlined at install time rather than checked in twice, so the shared file
+     * stays the single source of truth for behaviour <em>and</em> for the
+     * description - the text an agent decides on when picking a skill, and the
+     * last thing that should be allowed to drift between the two copies.
+     */
+    private static String compose() throws IOException {
+        String shared = read(SHARED_SKILL);
+        String template = read(CLAUDE_SKILL);
+        // The shared body links to a reference.md sitting beside it, which the
+        // adapter's own directory does not have.
+        String body = stripFrontmatter(shared).replace("](reference.md)",
+                "](" + SHARED_REFERENCE_LINK + ")");
+        // Stripped: the template already spaces the placeholder off from what
+        // surrounds it, so the body must contribute no blank line of its own.
+        return template.replace(DESCRIPTION_PLACEHOLDER, description(shared))
+                .replace(INSTRUCTIONS_PLACEHOLDER, body.strip());
+    }
+
+    /**
+     * The {@code description:} line of a skill's frontmatter, verbatim.
+     * <p>
+     * One line by construction: a folded YAML value would arrive here as the
+     * first line of several, so the shared file keeps it on one.
+     */
+    private static String description(String skill) throws IOException {
+        return skill.lines().filter(line -> line.startsWith("description: "))
+                .findFirst()
+                .orElseThrow(() -> new IOException("the shared skill "
+                        + SHARED_SKILL + " has no single-line description in "
+                        + "its frontmatter; this is a build error"));
+    }
+
+    private static String stripFrontmatter(String markdown) throws IOException {
+        if (!markdown.startsWith("---\n")) {
+            throw new IOException("the shared skill " + SHARED_SKILL
+                    + " does not open with YAML frontmatter; this is a build "
+                    + "error");
+        }
+        int end = markdown.indexOf("\n---\n", 3);
+        if (end < 0) {
+            throw new IOException("the frontmatter of the shared skill "
+                    + SHARED_SKILL + " is never closed; this is a build error");
+        }
+        return markdown.substring(end + "\n---\n".length());
     }
 
     private static String read(String resource) throws IOException {

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/SKILL.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vaadin-devloop
-description: Requires Vaadin 25.3 or newer in the target application; on an older version the dev loop does not exist and none of this applies. Applies to any edit of Vaadin application source under src/main/java, src/main/resources or the frontend folder (src/main/frontend) — a view, component, layout, theme, stylesheet or TypeScript module — and makes that edit live in the already-running app, then verifies it in the browser. The edit itself is the trigger, not any particular wording: read this BEFORE touching such a file, and follow it again once the file is saved, because a source edit that has not been applied is not done, however small the edit looks. Also covers starting or restarting the app, checking whether a change is actually live, and any request to look at the app in a browser. Phrases like "make this live", "is the change running", "start the app", "reload", "hot reload", "apply my edits" and "why doesn't the page show my change" are explicit invocations, but none of them are required. A daemon owns the app process, so this replaces running the app through Maven.
+description: Makes a saved edit live in the already-running Vaadin application in seconds and verifies it there, through a daemon that owns the app process — so it replaces `mvn spring-boot:run`, `mvn jetty:run` and IDE run configurations for running the app, and replaces `mvn compile` and `mvn test` as the way to find out whether an edit works: a Maven cycle pays for a fresh JVM and Spring context to answer what `apply` answers without one. Read this BEFORE the first edit to Vaadin application source — a view, component, layout, theme, stylesheet or TypeScript module under src/main/java, src/main/resources or the frontend folder (src/main/frontend) — and follow it again once the file is saved, because a source edit that has not been applied is not done, however small the edit looks. Also covers starting or restarting the app, checking whether a change is actually live, and any request to look at the app in a browser; phrases like "make this live", "is the change running", "start the app", "reload", "hot reload", "apply my edits" and "why doesn't the page show my change" are explicit invocations, but none of them are required — the edit itself is the trigger. Requires Vaadin 25.3 or newer in the target application (`vaadin.version` in its pom.xml); on anything older the dev loop does not exist and none of this applies.
 ---
 
 # Vaadin dev loop
@@ -69,6 +69,13 @@ use.
 configuration): the daemon owns the app, and a second process fights it for the HTTP port. The
 daemon auto-spawns on first use and survives between commands, so every command — from any
 shell, agent or IDE — answers for the same running app.
+
+**And do not reach for Maven to check an edit.** `mvn compile` and `mvn test` boot a fresh JVM
+and a fresh Spring context to answer what `apply` answers against the app already running, and
+they answer a narrower question: that the code compiles, not that the change is live in the
+page. Compile errors come out of `apply` with the same diagnostics, against the same sources.
+Run the project's own test suite once, at the end, over the change as a whole — never as the
+per-edit feedback loop.
 
 ## What is in the loop
 

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/agents-skill/vaadin-devloop/reference.md
@@ -86,9 +86,13 @@ the app turns up.
 ## Verifying in the browser
 
 First, whether to look at all: only a change with a visual surface earns a browser, as the
-shared file's step 5 says. Then use whatever browser automation this agent has — a
-Playwright/browser MCP server, a built-in browser tool, or a headless Playwright/Selenium
-script. The rules are the same whichever it is:
+shared file's step 5 says. Then use whatever browser automation this agent already has — a
+Playwright or browser MCP server, a built-in browser tool, a headless Playwright/Selenium
+script, or the browser tests the project itself already runs. Any of them is preferred over the
+others only by convenience; none of them is required, and **building a new browser harness for
+one change costs more than the change** — extend an existing `*BrowserTest`/`*IT` class instead,
+or take the no-browser answer below and say that is what you did. The rules are the same
+whichever tool it is:
 
 - **Navigate before the first `apply`, then keep the page open across applies.** CSS pushes and
   Java hot-swaps land in an already-open page; re-navigating hides what you are testing. Reload
@@ -185,12 +189,17 @@ of this.
 - The target application's `./mvnw test` for unit + UI tests. Update a test the change
   actually broke — its assertion is the behaviour you replaced — and say that you did. Leave
   the rest alone: a test suite rewritten around a one-line edit is scope nobody asked for.
-- If a **Vaadin MCP server** is available (`search_vaadin_docs`, `get_component_java_api`,
-  `get_component_styling`, `get_theme_css_properties`), use it instead of recalling API from
-  memory; otherwise check the Vaadin version in the application's `pom.xml` and read
-  vaadin.com/docs for that version. Prefer theme CSS properties (`--vaadin-*`, `--aura-*`)
-  over hard-coded values. This covers a test framework's API too: unpacking jars out of
-  `~/.m2` to find a method name spends minutes on what a docs query answers in seconds.
-- Browser verification needs a browser automation tool. Nothing installs or configures one for
-  you: register a Playwright MCP server (or the equivalent for your agent) yourself, and the
-  Vaadin docs MCP server alongside it.
+- Every MCP server named here is **preferred, never required**. The loop runs on the `vaadin-dev`
+  CLI and nothing else; a missing server changes which fallback you take, never whether the work
+  can be done. Take the fallback, and say which one you used.
+- For Vaadin API and docs, in order of preference: a **Vaadin MCP server**
+  (`search_vaadin_docs`, `get_component_java_api`, `get_component_styling`,
+  `get_theme_css_properties`); else vaadin.com/docs for the version in the application's
+  `pom.xml`; else the sources, pulled once with `./mvnw -q dependency:sources` and read like any
+  other source. Prefer theme CSS properties (`--vaadin-*`, `--aura-*`) over hard-coded values.
+  This covers a test framework's API too. Unpacking jars out of `~/.m2` and reading `javap`
+  output is the **last** resort, not the first: one method name at a time, it spends minutes on
+  what a docs query or a sources jar answers at once.
+- Browser verification wants a browser automation tool, and nothing installs one for you: a
+  Playwright MCP server (or your agent's equivalent) alongside the Vaadin docs server is the
+  smoothest setup, and *Verifying in the browser* above says what to do with neither.

--- a/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/claude-skill/vaadin-devloop/SKILL.md
+++ b/flow-plugins/flow-plugin-base/src/main/resources/vaadin-dev-cli/claude-skill/vaadin-devloop/SKILL.md
@@ -1,39 +1,43 @@
 ---
 name: vaadin-devloop
-description: Requires Vaadin 25.3 or newer in the target application; on an older version the dev loop does not exist and none of this applies. Applies to any edit of Vaadin application source under src/main/java, src/main/resources or the frontend folder (src/main/frontend) — a view, component, layout, theme, stylesheet or TypeScript module — and makes that edit live in the already-running app, then verifies it in the browser. Also covers starting or restarting the app and answering whether a change is actually live. A daemon owns the app process, so this replaces running the app through Maven.
-when_to_use: Only for applications on Vaadin 25.3 or newer — verify that first and stop here if the version is older. The edit itself is the trigger, not any particular wording. Load this BEFORE touching a Vaadin view, component, layout, theme, stylesheet or frontend file, and follow it again once the file is saved — a source edit that has not been applied is not done, however small the edit looks. Also triggers on starting or restarting the app, on checking whether a change is live, and on any request to look at the app in a browser. Phrases like "make this live", "is the change running", "start the app", "reload", "hot reload", "apply my edits" and "why doesn't the page show my change" are explicit invocations, but none of them are required.
-allowed-tools: Bash(.vaadin/vaadin-dev *), Bash(bash .vaadin/vaadin-dev *), Bash(.vaadin/vaadin-dev.cmd *), Read
+{{shared-description}}
+when_to_use: Load this BEFORE the first edit to a Vaadin view, component, layout, theme, stylesheet or frontend file, and follow it again once the file is saved — the edit is the trigger, no particular wording is required. Use it to run the app instead of `mvn spring-boot:run` or an IDE run configuration, and to find out whether an edit works instead of `mvn compile` or `mvn test`. Also triggers on starting or restarting the app, on checking whether a change is live, and on any request to look at the app in a browser. Requires Vaadin 25.3 or newer in the target application (`vaadin.version` in its pom.xml); stop here and run the app the project's normal way if it is older.
 ---
 
-# Vaadin dev loop
+{{shared-instructions}}
 
-The instructions are shared with every other agent on this repository and live in
-**[`.agents/skills/vaadin-devloop/SKILL.md`](../../../.agents/skills/vaadin-devloop/SKILL.md)**.
+## Tooling notes for Claude Code
 
-**Read that file now** — it is the cycle, the command set, what is in the loop, and how to read
-an `apply` outcome in one line each. Its
-[reference.md](../../../.agents/skills/vaadin-devloop/reference.md) carries the detail: the full
-output vocabulary, which edits need a page reload, pom/classpath semantics, the `--json` schema,
-environment variables, and what to do when the loop goes wrong.
+The instructions above are shared with every other agent on this repository and are deliberately
+tool-agnostic. These are the tools to reach for here.
 
-**Precondition — Vaadin 25.3 or newer.** The loop does not exist on older versions. Establish
-the target application's version before the first `vaadin-dev` command, as the shared file's
-*Requires Vaadin 25.3 or newer* section describes; if it is older, stop here and run the
-application the project's normal way.
+Every tool named below is a **preference with a fallback beside it, never a requirement**. The
+loop runs on the `vaadin-dev` CLI and nothing else. A missing MCP server changes which fallback
+you take — it never means the work cannot be done, and it is never a reason to stop, to skip
+verification silently, or to build tooling of your own. Take the fallback and say which one you
+took.
 
-## Bindings for this session
-
-The shared file is deliberately tool-agnostic. These are the tools to use for it here.
-
-- Verify with the **Playwright MCP** tools, for a change with a visual surface (the shared
-  file's step 5): `browser_navigate` once and before the first `apply` (a CSS push needs a page
-  already connected), then `browser_snapshot` / `browser_evaluate` for the assertions the
-  shared reference describes, and `browser_console_messages` after each change (a
-  `/favicon.ico` 404 is normal noise). The first snapshot after `browser_navigate` is usually
-  empty — Vaadin renders client-side.
-- Use the **Vaadin MCP server** (`search_vaadin_docs`, `get_component_java_api`,
-  `get_component_styling`, `get_theme_css_properties`) instead of recalling API from memory;
-  check the Vaadin version in the target application's `pom.xml`.
-- On Windows a checkout carries no executable bit, so `.vaadin/vaadin-dev` may refuse to
-  run: use `bash .vaadin/vaadin-dev` in the Bash tool, or the `.cmd` launcher beside it
-  from `cmd`/PowerShell. Same arguments, same exit codes.
+- **Editing.** This skill restricts no tools on purpose. You are expected to Edit and Write
+  application source while it is loaded — batching edits and then applying them *is* the cycle,
+  so stay in the skill rather than loading it once the work is already finished.
+- **Browser verification** — the cycle's step 5, for a change with a visual surface.
+  *Preferred:* a Playwright or browser MCP server. `browser_navigate` once, before the first
+  `apply` (a CSS push needs a page already connected), then `browser_snapshot` /
+  `browser_evaluate` for the assertions the shared reference describes, and
+  `browser_console_messages` after each change (a `/favicon.ico` 404 is normal noise). The first
+  snapshot after navigating is usually empty — Vaadin renders client-side, so wait for a known
+  element or re-snapshot before asserting. *Without one:* extend the browser tests the project
+  already has — a `*BrowserTest` or `*IT` class and the element API it already depends on — and
+  say you verified there. Do not write a new browser harness for one change: that costs more
+  than the change, and *Verifying in the browser* in
+  [reference.md](../../../.agents/skills/vaadin-devloop/reference.md) says what a run with no
+  browser at all can and cannot claim.
+- **Vaadin API and docs.** *Preferred:* the Vaadin MCP server (`search_vaadin_docs`,
+  `get_component_java_api`, `get_component_styling`, `get_theme_css_properties`), against the
+  version in the application's `pom.xml`. *Without it:* vaadin.com/docs for that version, or
+  `./mvnw -q dependency:sources` once and read the sources. Reading `javap` output out of
+  `~/.m2` is the last resort — one method name per call, it spends minutes on what either of the
+  other two answers at once.
+- **Windows.** A checkout carries no executable bit, so `.vaadin/vaadin-dev` may refuse to run:
+  use `bash .vaadin/vaadin-dev` in the Bash tool, or the `.cmd` launcher beside it from
+  `cmd`/PowerShell. Same arguments, same exit codes.

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/DevCliInstallerTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/DevCliInstallerTest.java
@@ -79,21 +79,43 @@ public class DevCliInstallerTest {
     }
 
     @Test
-    public void install_theClaudeAdapterLinkResolvesToTheSharedInstructions()
+    public void install_theClaudeAdapterCarriesTheSharedInstructions()
             throws IOException {
         Path root = temporaryFolder.getRoot().toPath();
         DevCliInstaller.install(root);
         Path adapter = root.resolve(".claude/skills/vaadin-devloop/SKILL.md");
+        String shared = Files.readString(
+                root.resolve(".agents/skills/vaadin-devloop/SKILL.md"));
 
         String content = Files.readString(adapter);
 
+        // Inlined, not linked: reaching the cycle used to cost a tool call.
+        Assert.assertFalse("no placeholder should survive composition",
+                content.contains("{{"));
+        Assert.assertTrue("the adapter should carry the cycle itself",
+                content.contains("## The cycle"));
+        Assert.assertTrue("the adapter should carry the command set",
+                content.contains(".vaadin/vaadin-dev apply"));
+        // The description drives skill selection, so the two copies of it must
+        // not drift: the adapter's is the shared one, verbatim.
+        String description = shared.lines()
+                .filter(line -> line.startsWith("description: ")).findFirst()
+                .orElseThrow();
+        Assert.assertTrue("the adapter should reuse the shared description",
+                content.contains(description));
+        // A skill that restricts tools cannot be loaded before editing, which
+        // is exactly when this one has to be.
+        Assert.assertFalse("the adapter must not restrict the tool set",
+                content.contains("allowed-tools"));
         // The whole reason both trees install under one directory: the adapter
         // carries no reference.md of its own and links to the .agents copy.
-        String link = "../../../.agents/skills/vaadin-devloop/SKILL.md";
-        Assert.assertTrue("the adapter should link to the shared instructions",
+        String link = "../../../.agents/skills/vaadin-devloop/reference.md";
+        Assert.assertTrue("the adapter should link to the shared reference",
                 content.contains(link));
         Assert.assertTrue("the relative link should resolve", Files
                 .isRegularFile(adapter.getParent().resolve(link).normalize()));
+        Assert.assertFalse("no link should point at a missing reference.md",
+                content.contains("](reference.md)"));
     }
 
     @Test


### PR DESCRIPTION
The Claude adapter allowed only `Bash(.vaadin/vaadin-dev *)` and `Read`, so a skill meant to be loaded before editing could only be loaded once the editing was finished. Drop the tool restriction, lead the description with what the loop replaces — `mvn spring-boot:run`, and `mvn compile`/`mvn test` as the per-edit check — rather than with its precondition, and give every MCP server a fallback beside it so a missing one is no longer a dead end. The adapter now carries the shared instructions inline, composed at install time, so reaching the cycle costs no extra read and the description cannot drift.