### PR TITLE
fix: rebuild the frontend bundle when PWA offline settings change (#25512) (CP: 25.2)

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -52,6 +52,7 @@ import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.Mode;
+import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.server.webcomponent.WebComponentExporterTagExtractor;
@@ -69,6 +70,19 @@ import static com.vaadin.flow.server.Constants.DEV_BUNDLE_JAR_PATH;
 public final class BundleValidationUtil {
 
     private static final String FRONTEND_HASHES_STATS_KEY = "frontendHashes";
+
+    private static final String PWA_OFFLINE_PATH_STATS_KEY = "pwaOfflinePath";
+
+    private static final String PWA_OFFLINE_ENABLED_STATS_KEY = "pwaOfflineEnabled";
+
+    /**
+     * The offline path assumed for a bundle whose stats.json predates
+     * {@code pwaOfflinePath}. It is the value the platform default bundle is
+     * built with, so applications that leave
+     * {@link com.vaadin.flow.server.PWA#offlinePath()} at its default keep
+     * reusing that bundle instead of building their own.
+     */
+    private static final String DEFAULT_PWA_OFFLINE_PATH = "'.'";
 
     /**
      * Checks if an application needs a new frontend bundle.
@@ -282,6 +296,12 @@ public final class BundleValidationUtil {
             UsageStatistics.markAsUsed(
                     "flow/rebundle-reason-changed-shadow-DOM-stylesheets",
                     null);
+            return true;
+        }
+
+        if (pwaConfigurationChanged(options, statsJson, frontendDependencies)) {
+            UsageStatistics.markAsUsed(
+                    "flow/rebundle-reason-changed-pwa-config", null);
             return true;
         }
 
@@ -804,6 +824,56 @@ public final class BundleValidationUtil {
                 getLogger().info("Detected deleted {} file", indexFile);
                 return true;
             }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether the bundle's service worker still matches the PWA
+     * configuration of the application.
+     * <p>
+     * Two parts of {@code @PWA} are compiled into the bundle and can only be
+     * changed by building a new one:
+     * {@link com.vaadin.flow.server.PWA#offline()} decides whether a service
+     * worker is built at all, and
+     * {@link com.vaadin.flow.server.PWA#offlinePath()} is baked into it as the
+     * {@code OFFLINE_PATH} constant.
+     */
+    private static boolean pwaConfigurationChanged(Options options,
+            JsonNode statsJson,
+            FrontendDependenciesScanner frontendDependencies) {
+        PwaConfiguration pwaConfiguration = frontendDependencies
+                .getPwaConfiguration();
+        if (pwaConfiguration == null || !pwaConfiguration.isOfflineEnabled()) {
+            // Without offline support the application unregisters the service
+            // worker instead of loading it, so a bundle that carries one is
+            // merely unused, never stale.
+            return false;
+        }
+        // A bundle whose stats.json predates this key does not say whether it
+        // was built with offline support, so it is assumed to have been: the
+        // platform default bundle, which is what most applications validate
+        // against, ships a service worker, and rebuilding every PWA
+        // application against it would cost more than the rare stale local
+        // bundle the assumption lets through.
+        boolean bundleHasServiceWorker = statsJson
+                .path(PWA_OFFLINE_ENABLED_STATS_KEY).booleanValue(true);
+        if (!bundleHasServiceWorker) {
+            getLogger().info(
+                    "The bundle was built without offline support, so it has no service worker to serve.");
+            return true;
+        }
+        String offlinePath = TaskUpdateSettingsFile
+                .getOfflinePath(pwaConfiguration, options.getNpmFolder());
+        JsonNode statsOfflinePath = statsJson.get(PWA_OFFLINE_PATH_STATS_KEY);
+        String bundleOfflinePath = statsOfflinePath == null
+                ? DEFAULT_PWA_OFFLINE_PATH
+                : statsOfflinePath.asString();
+        if (!offlinePath.equals(bundleOfflinePath)) {
+            getLogger().info(
+                    "The bundle's service worker uses offline path {}, but the application asks for {}.",
+                    bundleOfflinePath, offlinePath);
+            return true;
         }
         return false;
     }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
@@ -136,7 +136,8 @@ public class TaskUpdateSettingsFile implements FallibleCommand, Serializable {
 
         settings.put("offlineEnabled", pwaConfiguration.isOfflineEnabled());
 
-        settings.put("offlinePath", getOfflinePath());
+        settings.put("offlinePath",
+                getOfflinePath(pwaConfiguration, npmFolder));
 
         File settingsFile = new File(npmFolder,
                 buildDirectory + "/" + DEV_SETTINGS_FILE);
@@ -179,15 +180,33 @@ public class TaskUpdateSettingsFile implements FallibleCommand, Serializable {
         }
     }
 
-    private String getOfflinePath() {
+    /**
+     * Computes the value for the {@code OFFLINE_PATH} constant that Vite
+     * compiles into the service worker.
+     * <p>
+     * Vite substitutes the value verbatim, so the path is wrapped in single
+     * quotes to make it a JavaScript expression. Bundle validation compares
+     * this value against the one recorded in the bundle's {@code stats.json},
+     * so both sides must derive it from this method.
+     * <p>
+     * For internal use only. May be renamed or removed in a future release.
+     *
+     * @param pwaConfiguration
+     *            the PWA configuration of the application, not {@code null}
+     * @param npmFolder
+     *            the project root, used to relativize an absolute offline path
+     * @return the offline path wrapped in single quotes
+     */
+    public static String getOfflinePath(PwaConfiguration pwaConfiguration,
+            File npmFolder) {
         if (pwaConfiguration.isOfflinePathEnabled()) {
-            return "'" + getEscapedRelativePath(
+            return "'" + getEscapedRelativePath(npmFolder,
                     Paths.get(pwaConfiguration.getOfflinePath())) + "'";
         }
         return "'.'";
     }
 
-    private String getEscapedRelativePath(Path path) {
+    private static String getEscapedRelativePath(File npmFolder, Path path) {
         if (path.isAbsolute()) {
             return FrontendUtils.getUnixRelativePath(npmFolder.toPath(), path);
         } else {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.Mode;
+import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.scanner.ChunkInfo;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.CssData;
@@ -71,6 +72,8 @@ class BundleValidationTest {
     public static final String FRONTEND_HASHES = "frontendHashes";
     public static final String THEME_JSON_CONTENTS = "themeJsonContents";
     public static final String PACKAGE_JSON_HASH = "packageJsonHash";
+    public static final String PWA_OFFLINE_PATH = "pwaOfflinePath";
+    public static final String PWA_OFFLINE_ENABLED = "pwaOfflineEnabled";
 
     private static final String THEME_UTIL_JS;
     static {
@@ -2640,6 +2643,130 @@ class BundleValidationTest {
                 depScanner, mode);
         assertTrue(needsBuild,
                 "In development mode, presence of 'commercial-banner.js' should require bundling");
+    }
+
+    @ParameterizedTest
+    @MethodSource("modes")
+    void offlinePathAdded_statsWithoutOfflinePath_compilationRequired(Mode mode)
+            throws IOException {
+        setupMode(mode);
+        Mockito.when(depScanner.getPwaConfiguration())
+                .thenReturn(pwaWithOfflinePath("offline.html"));
+
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+        ObjectNode stats = getBasicStats();
+        setupFrontendUtilsMock(stats);
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        assertTrue(needsBuild,
+                "A custom offline path not recorded in the bundle should require bundling");
+    }
+
+    @ParameterizedTest
+    @MethodSource("modes")
+    void defaultOfflinePath_statsWithoutOfflinePath_noCompilationRequired(
+            Mode mode) throws IOException {
+        setupMode(mode);
+        Mockito.when(depScanner.getPwaConfiguration())
+                .thenReturn(pwaWithOfflinePath(""));
+
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+        ObjectNode stats = getBasicStats();
+        setupFrontendUtilsMock(stats);
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        assertFalse(needsBuild,
+                "The default offline path matches bundles built before it was recorded");
+    }
+
+    @ParameterizedTest
+    @MethodSource("modes")
+    void offlinePathChanged_compilationRequired(Mode mode) throws IOException {
+        setupMode(mode);
+        Mockito.when(depScanner.getPwaConfiguration())
+                .thenReturn(pwaWithOfflinePath("offline.html"));
+
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+        ObjectNode stats = getBasicStats();
+        stats.put(PWA_OFFLINE_PATH, "'other-offline.html'");
+        setupFrontendUtilsMock(stats);
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        assertTrue(needsBuild,
+                "A changed offline path should require bundling");
+    }
+
+    @ParameterizedTest
+    @MethodSource("modes")
+    void offlinePathUnchanged_noCompilationRequired(Mode mode)
+            throws IOException {
+        setupMode(mode);
+        Mockito.when(depScanner.getPwaConfiguration())
+                .thenReturn(pwaWithOfflinePath("offline.html"));
+
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+        ObjectNode stats = getBasicStats();
+        stats.put(PWA_OFFLINE_PATH, "'offline.html'");
+        setupFrontendUtilsMock(stats);
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        assertFalse(needsBuild,
+                "An unchanged offline path should not require bundling");
+    }
+
+    @ParameterizedTest
+    @MethodSource("modes")
+    void offlineEnabled_statsBuiltWithoutOfflineSupport_compilationRequired(
+            Mode mode) throws IOException {
+        setupMode(mode);
+        Mockito.when(depScanner.getPwaConfiguration())
+                .thenReturn(pwaConfiguration("", true));
+
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+        ObjectNode stats = getBasicStats();
+        stats.put(PWA_OFFLINE_PATH, "'.'");
+        stats.put(PWA_OFFLINE_ENABLED, false);
+        setupFrontendUtilsMock(stats);
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        assertTrue(needsBuild,
+                "A bundle built without a service worker should require bundling once offline is enabled");
+    }
+
+    @ParameterizedTest
+    @MethodSource("modes")
+    void offlineDisabled_offlinePathDiffers_noCompilationRequired(Mode mode)
+            throws IOException {
+        setupMode(mode);
+        Mockito.when(depScanner.getPwaConfiguration())
+                .thenReturn(pwaConfiguration("offline.html", false));
+
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+        ObjectNode stats = getBasicStats();
+        stats.put(PWA_OFFLINE_PATH, "'.'");
+        stats.put(PWA_OFFLINE_ENABLED, true);
+        setupFrontendUtilsMock(stats);
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        assertFalse(needsBuild,
+                "Without offline support the bundle's service worker is unused, so it cannot be stale");
+    }
+
+    private static PwaConfiguration pwaWithOfflinePath(String offlinePath) {
+        return pwaConfiguration(offlinePath, true);
+    }
+
+    private static PwaConfiguration pwaConfiguration(String offlinePath,
+            boolean offlineEnabled) {
+        return new PwaConfiguration(true, "App", "App", "", "#fff", "#000",
+                "icons/icon.png", "manifest.webmanifest", offlinePath,
+                "standalone", ".", new String[] {}, offlineEnabled);
     }
 
     private void createPackageJsonStub(String content) throws IOException {

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -296,6 +296,8 @@ function statsExtracterPlugin(): PluginOption {
         bundleImports: generatedImports,
         frontendHashes: frontendFiles,
         themeJsonContents: themeJsonContents,
+        pwaOfflinePath: settings.offlinePath,
+        pwaOfflineEnabled: settings.offlineEnabled,
         entryScripts,
         webComponents,
         cvdlModules: cvdls,


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #25512 to branch 25.2.
---
#### Original PR description
> Bundle validation had no PWA input, so a `@PWA` change could leave a stale bundle in place. Vite compiles two of the attributes in: `offline` decides whether a service worker is built at all, and `offlinePath` becomes its OFFLINE_PATH constant.
>
> The Vite stats extracter now records both, and validation compares them against the scanned PWA configuration.
>
> Fixes #25491
>
