### PR TITLE
docs: note refreshAll after TreeData mutations #19327

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.function.ValueProvider;
  * Represents hierarchical data.
  * <p>
  * Typically used as a backing data source for {@link TreeDataProvider}.
- * After making changes to this structure,
+ * After making changes to the tree data,
  * {@link TreeDataProvider#refreshAll()} should be called.
  *
  * @author Vaadin Ltd

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
@@ -32,9 +32,9 @@ import com.vaadin.flow.function.ValueProvider;
 /**
  * Represents hierarchical data.
  * <p>
- * Typically used as a backing data source for {@link TreeDataProvider}.
- * After making changes to the tree data,
- * {@link TreeDataProvider#refreshAll()} should be called.
+ * Typically used as a backing data source for {@link TreeDataProvider}. After
+ * making changes to the tree data, {@link TreeDataProvider#refreshAll()} should
+ * be called.
  *
  * @author Vaadin Ltd
  * @since 1.1

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeData.java
@@ -33,6 +33,8 @@ import com.vaadin.flow.function.ValueProvider;
  * Represents hierarchical data.
  * <p>
  * Typically used as a backing data source for {@link TreeDataProvider}.
+ * After making changes to this structure,
+ * {@link TreeDataProvider#refreshAll()} should be called.
  *
  * @author Vaadin Ltd
  * @since 1.1
@@ -86,6 +88,9 @@ public class TreeData<T> implements HierarchicalData<T> {
     /**
      * Adds the items as root items to this structure.
      *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
+     *
      * @param items
      *            the items to add
      * @return this
@@ -104,6 +109,9 @@ public class TreeData<T> implements HierarchicalData<T> {
     /**
      * Adds the items of the given collection as root items to this structure.
      *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
+     *
      * @param items
      *            the collection of items to add
      * @return this
@@ -121,6 +129,9 @@ public class TreeData<T> implements HierarchicalData<T> {
 
     /**
      * Adds the items of the given stream as root items to this structure.
+     *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
      *
      * @param items
      *            the stream of root items to add
@@ -141,6 +152,9 @@ public class TreeData<T> implements HierarchicalData<T> {
      * Adds a data item as a child of {@code parent}. Call with {@code null} as
      * parent to add a root level item. The given parent item must already exist
      * in this structure, and an item can only be added to this structure once.
+     *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
      *
      * @param parent
      *            the parent item for which the items are added as children
@@ -176,6 +190,9 @@ public class TreeData<T> implements HierarchicalData<T> {
      * must already exist in this structure, and an item can only be added to
      * this structure once.
      *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
+     *
      * @param parent
      *            the parent item for which the items are added as children
      * @param items
@@ -202,6 +219,9 @@ public class TreeData<T> implements HierarchicalData<T> {
      * must already exist in this structure, and an item can only be added to
      * this structure once.
      *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
+     *
      * @param parent
      *            the parent item for which the items are added as children
      * @param items
@@ -227,6 +247,9 @@ public class TreeData<T> implements HierarchicalData<T> {
      * item must already exist in this structure, and an item can only be added
      * to this structure once.
      *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
+     *
      * @param parent
      *            the parent item for which the items are added as children
      * @param items
@@ -250,6 +273,9 @@ public class TreeData<T> implements HierarchicalData<T> {
      * Adds the given items as root items and uses the given value provider to
      * recursively populate children of the root items.
      *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
+     *
      * @param rootItems
      *            the root items to add
      * @param childItemProvider
@@ -272,6 +298,9 @@ public class TreeData<T> implements HierarchicalData<T> {
      * Adds the given items as root items and uses the given value provider to
      * recursively populate children of the root items.
      *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
+     *
      * @param rootItems
      *            the root items to add
      * @param childItemProvider
@@ -290,6 +319,9 @@ public class TreeData<T> implements HierarchicalData<T> {
     /**
      * Remove a given item from this structure. Additionally, this will
      * recursively remove any descendants of the item.
+     *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
      *
      * @param item
      *            the item to remove, or null to clear all data
@@ -316,6 +348,9 @@ public class TreeData<T> implements HierarchicalData<T> {
     /**
      * Clear all items from this structure. Shorthand for calling
      * {@link #removeItem(Object)} with null.
+     *
+     * After making changes to the tree data,
+     * {@link TreeDataProvider#refreshAll()} should be called.
      *
      * @return this
      */


### PR DESCRIPTION
Fixes #19327

**DX/docs** · flow-data · apps that mutate TreeData under TreeGrid

setParent and moveAfterSibling already say to call
TreeDataProvider.refreshAll(). addItem, removeItem and the other
mutating methods did not, so drag-and-drop samples that only update
TreeData look like a no-op.

I added the same refreshAll note on the class and on every mutating
method.

**Risks:**
- javadoc only

- Note refreshAll on TreeData and on add/remove/clear/addItems
