### PR TITLE
fix: detect the project folder of a Gradle module from the classpath (#25632) (CP: 25.2)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
@@ -461,5 +461,89 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 "vaadin-dev-server-settings.json leaked under the web source dir: $leaked") { leaked }
     }
 
+    /**
+     * In development mode `vaadinPrepareFrontend` does not run, so there is no
+     * `flow-build-info.json` telling the runtime where the project is and it
+     * has to determine that from the classpath. The working directory of the
+     * process must not be what decides it: an application started with the root
+     * of the build as its working directory - what a run configuration in an
+     * IDE typically does - has to prepare its frontend in the module being run
+     * and not in the root project.
+     *
+     * https://github.com/vaadin/flow/issues/25630
+     */
+    @Test
+    fun `dev mode project folder is the module folder, not the working directory`() {
+        // The :web module is configured from the root project, so it has
+        // no build script of its own
+        testProject.settingsFile.writeText("include 'web'")
+        testProject.buildFile.writeText("""
+            plugins {
+                id 'java'
+                id 'com.vaadin.flow' apply false
+            }
+            allprojects {
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+                }
+            }
+            project(':web') {
+                apply plugin: 'java'
+                apply plugin: 'com.vaadin.flow'
+
+                dependencies {
+                    implementation("com.vaadin:flow:$flowVersion")
+                }
+
+                tasks.register('printProjectFolder', JavaExec) {
+                    classpath = sourceSets.main.runtimeClasspath
+                    mainClass = 'example.PrintProjectFolder'
+                    // Run from the root of the build instead of from the module
+                    workingDir = rootProject.projectDir
+                }
+            }
+        """.trimIndent())
+        testProject.newFile("web/src/main/java/example/PrintProjectFolder.java", """
+            package example;
+
+            import com.vaadin.flow.server.AbstractConfiguration;
+
+            public class PrintProjectFolder {
+                public static void main(String[] args) throws Exception {
+                    AbstractConfiguration configuration = new AbstractConfiguration() {
+                        @Override
+                        public boolean isProductionMode() {
+                            return false;
+                        }
+
+                        @Override
+                        public String getStringProperty(String name,
+                                String defaultValue) {
+                            return defaultValue;
+                        }
+
+                        @Override
+                        public boolean getBooleanProperty(String name,
+                                boolean defaultValue) {
+                            return defaultValue;
+                        }
+                    };
+                    System.out.println("PROJECT_FOLDER="
+                            + configuration.getProjectFolder().getCanonicalPath());
+                    System.out.println("FRONTEND_FOLDER="
+                            + configuration.getFrontendFolder().getCanonicalPath());
+                }
+            }
+        """.trimIndent())
+
+        val result: BuildResult = testProject.build("web:printProjectFolder")
+
+        val webFolder = File(testProject.dir, "web").canonicalFile
+        assertContains(result.output, "PROJECT_FOLDER=$webFolder")
+        assertContains(result.output,
+                "FRONTEND_FOLDER=${File(webFolder, "src/main/frontend")}")
+    }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/FileIOUtils.java
@@ -446,7 +446,80 @@ public class FileIOUtils {
             return path.getParent().getParent().toFile();
         }
 
+        return getGradleProjectFolder(path);
+    }
+
+    /**
+     * Determines the project folder from a Gradle source set output folder,
+     * which is either
+     * {@code <project>/<buildDir>/classes/<language>/<sourceSet>} or
+     * {@code <project>/<buildDir>/resources/<sourceSet>}.
+     * <p>
+     * The name of the build directory is configurable, so the candidate is
+     * accepted only when it belongs to a Gradle build instead of matching the
+     * directory by name. Without that check a path such as
+     * {@code /srv/classes/foo/bar} would be taken for a project folder.
+     * <p>
+     * The resources layout is matched first because a build directory named
+     * {@code classes} makes the two overlap: in
+     * {@code <project>/classes/resources/main} the classes layout would match
+     * too, and it would climb one level too far.
+     *
+     * @param outputFolder
+     *            a folder on the classpath
+     * @return the project folder, or {@code null} if the folder is not the
+     *         output folder of a Gradle source set
+     */
+    private static File getGradleProjectFolder(Path outputFolder) {
+        int names = outputFolder.getNameCount();
+        Path candidate = null;
+        if (names > 2 && "resources"
+                .equals(outputFolder.getName(names - 2).toString())) {
+            candidate = ancestor(outputFolder, 3);
+        } else if (names > 3 && "classes"
+                .equals(outputFolder.getName(names - 3).toString())) {
+            candidate = ancestor(outputFolder, 4);
+        }
+        if (candidate != null && belongsToGradleBuild(candidate)) {
+            return candidate.toFile();
+        }
         return null;
+    }
+
+    /**
+     * Whether the given folder is a project of a Gradle build, that is it has a
+     * build script of its own or it lies inside a build whose root has a
+     * settings script. A subproject that the root project configures entirely
+     * has no build script of its own.
+     *
+     * @param projectFolder
+     *            the candidate project folder
+     * @return {@code true} if the folder belongs to a Gradle build
+     */
+    private static boolean belongsToGradleBuild(Path projectFolder) {
+        if (hasAnyFile(projectFolder, "build.gradle", "build.gradle.kts")) {
+            return true;
+        }
+        for (Path folder = projectFolder; folder != null; folder = folder
+                .getParent()) {
+            if (hasAnyFile(folder, "settings.gradle", "settings.gradle.kts")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAnyFile(Path folder, String... fileNames) {
+        return Arrays.stream(fileNames)
+                .anyMatch(name -> Files.isRegularFile(folder.resolve(name)));
+    }
+
+    private static Path ancestor(Path path, int levels) {
+        Path ancestor = path;
+        for (int i = 0; i < levels && ancestor != null; i++) {
+            ancestor = ancestor.getParent();
+        }
+        return ancestor;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
@@ -24,6 +24,8 @@ import java.nio.file.StandardCopyOption;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -31,6 +33,7 @@ import com.vaadin.open.OSUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -58,6 +61,67 @@ class FileIOUtilsTest {
                 "file:/Users/John%20Doe/Downloads/my-app%20(21)/my-app/target/classes/");
         assertEquals(new File("/Users/John Doe/Downloads/my-app (21)/my-app"),
                 FileIOUtils.getProjectFolderFromClasspath(url));
+    }
+
+    @Test
+    void projectFolderForGradleClassesFolder(@TempDir File projectFolder)
+            throws Exception {
+        Files.createFile(new File(projectFolder, "build.gradle").toPath());
+        URL url = gradleOutputFolder(projectFolder, "build/classes/java/main/");
+
+        assertEquals(projectFolder,
+                FileIOUtils.getProjectFolderFromClasspath(url));
+    }
+
+    @Test
+    void projectFolderForGradleResourcesFolderInCustomBuildFolder(
+            @TempDir File projectFolder) throws Exception {
+        Files.createFile(new File(projectFolder, "build.gradle.kts").toPath());
+        URL url = gradleOutputFolder(projectFolder, "out/resources/main/");
+
+        assertEquals(projectFolder,
+                FileIOUtils.getProjectFolderFromClasspath(url));
+    }
+
+    @Test
+    void projectFolderForGradleResourcesFolderInBuildFolderNamedClasses(
+            @TempDir File projectFolder) throws Exception {
+        Files.createFile(new File(projectFolder, "build.gradle").toPath());
+        // Both layouts match this one, and the classes layout would climb one
+        // level too far
+        URL url = gradleOutputFolder(projectFolder, "classes/resources/main/");
+
+        assertEquals(projectFolder,
+                FileIOUtils.getProjectFolderFromClasspath(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "settings.gradle", "settings.gradle.kts" })
+    void projectFolderForGradleModuleWithoutBuildScript(String settingsScript,
+            @TempDir File rootFolder) throws Exception {
+        // A subproject that the root project configures has no build script of
+        // its own, only the root has a settings script
+        Files.createFile(new File(rootFolder, settingsScript).toPath());
+        File moduleFolder = new File(rootFolder, "web");
+        URL url = gradleOutputFolder(moduleFolder, "build/classes/java/main/");
+
+        assertEquals(moduleFolder,
+                FileIOUtils.getProjectFolderFromClasspath(url));
+    }
+
+    @Test
+    void noProjectFolderForClassesFolderOutsideGradleBuild(@TempDir File folder)
+            throws Exception {
+        URL url = gradleOutputFolder(folder, "build/classes/java/main/");
+
+        assertNull(FileIOUtils.getProjectFolderFromClasspath(url));
+    }
+
+    private static URL gradleOutputFolder(File projectFolder,
+            String relativePath) throws Exception {
+        File outputFolder = new File(projectFolder, relativePath);
+        Files.createDirectories(outputFolder.toPath());
+        return outputFolder.toURI().toURL();
     }
 
     @Test


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #25632 to branch 25.2.
---
#### Original PR description
> ## Summary
> In development mode Vaadin finds the project folder from the classpath, but it only knew Maven's `target/classes`. A Gradle project fell back to the working directory, so an app started from the root of a multi-project build prepared its frontend in the root project instead of in the module being run. This change teaches the detection about Gradle's output folders.
> 
> Fixes #25630
> 
> ## What changed
> - `FileIOUtils.getProjectFolderFromClasspath` now also recognizes the two Gradle source set output layouts: `<buildDir>/classes/<language>/<sourceSet>` and `<buildDir>/resources/<sourceSet>`.
> - The build directory name is configurable in Gradle, so a candidate folder is accepted only when it really belongs to a Gradle build: it has a `build.gradle`/`build.gradle.kts` of its own, or it lies inside a build whose root has a `settings.gradle`/`settings.gradle.kts`. The settings check is needed because a subproject that the root project configures has no build script of its own.
> - The resources layout is checked before the classes one. A build directory named `classes` makes the two overlap (`<project>/classes/resources/main`), and the classes layout would climb one level too far.
> 
> Background: since the Gradle plugin no longer runs `vaadinPrepareFrontend` in development mode, there is no `flow-build-info.json` carrying `project.basedir`. With an IDE run configuration the working directory is the root project, which has a build script, so the old fallback accepted it and generated `package.json`, `node_modules` and `src/main/frontend` in the wrong place.
> 
> ## Test summary
> 
> | # | Status | What the test verifies | Why it matters |
> |---|--------|------------------------|----------------|
> | 1 | ✅ | `build/classes/java/main` resolves to the project folder | The main fix: Gradle classes output must be recognized |
> | 2 | ✅ | `out/resources/main` (custom build dir name) resolves to the project folder | Resources-only output and non-default build dir names must work |
> | 3 | ✅ | With a build dir named `classes`, `classes/resources/main` still resolves to the project folder, not its parent | Overlapping layouts must not climb one level too far |
> | 4 | ✅ | A module with no build script resolves when the root has `settings.gradle` or `settings.gradle.kts` | Subprojects configured from the root are common and were previously missed |
> | 5 | ✅ | A matching folder outside any Gradle build returns `null` | The build dir name is configurable, so name matching alone would claim unrelated paths |
> | 6 | ✅ | An app run with the build root as working directory reports the module folder as project folder and `<module>/src/main/frontend` as frontend folder | End-to-end proof of the reported bug: frontend files must not land in the root project |
> 
> - `FileIOUtilsTest.projectFolderForGradleClassesFolder` → 1
> - `FileIOUtilsTest.projectFolderForGradleResourcesFolderInCustomBuildFolder` → 2
> - `FileIOUtilsTest.projectFolderForGradleResourcesFolderInBuildFolderNamedClasses` → 3
> - `FileIOUtilsTest.projectFolderForGradleModuleWithoutBuildScript` (parameterized over both settings script DSLs) → 4
> - `FileIOUtilsTest.noProjectFolderForClassesFolderOutsideGradleBuild` → 5
> - `MiscMultiModuleTest.dev mode project folder is the module folder, not the working directory` → 6
> 
> Left untested on purpose: the Maven `target/classes` path and the Windows/Unix path handling, which existing tests in `FileIOUtilsTest` already cover and this change does not touch.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
